### PR TITLE
Decrease bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "run-sequence": "^1.2.2"
   },
   "scripts": {
-    "postinstall": "lerna bootstrap --concurrency=1",
+    "postinstall": "lerna bootstrap --concurrency=1 --hoist --nohoist=jest*",
     "build": "lerna run build",
     "build:site": "npm run -s build:site:demos && npm run -s build:site:docs",
     "build:site:demos": "lerna run build --ignore @devexpress/dx-react-demos && lerna run build:prod --scope @devexpress/dx-react-demos",

--- a/packages/dx-react-demos/webpack.config.js
+++ b/packages/dx-react-demos/webpack.config.js
@@ -32,13 +32,6 @@ module.exports = ({ production }) => ({
     ]
   },
   resolve: {
-    alias: {
-      // Strange hack for lerna
-      'react': path.resolve('./node_modules/react'),
-      'prop-types': path.resolve('./node_modules/prop-types'),
-      'react-dom': path.resolve('./node_modules/react-dom'),
-      'react-bootstrap': path.resolve('./node_modules/react-bootstrap'),
-    },
     extensions: [".webpack.js", ".web.js", ".js", ".jsx"]
   },
   plugins: [


### PR DESCRIPTION
In one of the previous PR I removed `react-bootstrap` alias and found that bundle size increased from 0.75MB to 1.05MB.

The following changes decreases bundle size to 0.63MB.