### PR TITLE
refactor(react-grid): Split TableRowDetail into the UI & state management plugins

### DIFF
--- a/packages/dx-react-demos/src/bootstrap3/detail-row/detail-row-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/detail-row/detail-row-controlled.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Grid,
+  RowDetailState,
 } from '@devexpress/dx-react-grid';
 import {
   TableView,
@@ -38,11 +39,13 @@ export class DetailRowControlledDemo extends React.PureComponent {
         rows={rows}
         columns={columns}
       >
+        <RowDetailState
+          expandedRows={expandedRows}
+          onExpandedRowsChange={this.changeExpandedDetails}
+        />
         <TableView />
         <TableHeaderRow />
         <TableRowDetail
-          expandedRows={expandedRows}
-          onExpandedRowsChange={this.changeExpandedDetails}
           template={this.rowTemplate}
         />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/detail-row/simple-detail-row.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/detail-row/simple-detail-row.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Grid,
+  RowDetailState,
 } from '@devexpress/dx-react-grid';
 import {
   TableView,
@@ -37,10 +38,12 @@ export class SimpleDetailRowDemo extends React.PureComponent {
         rows={rows}
         columns={columns}
       >
+        <RowDetailState
+          defaultExpandedRows={[2, 5]}
+        />
         <TableView />
         <TableHeaderRow />
         <TableRowDetail
-          defaultExpandedRows={[2, 5]}
           template={this.rowTemplate}
         />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/featured/redux-integration.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured/redux-integration.jsx
@@ -6,7 +6,7 @@ import { createStore } from 'redux';
 import { connect, Provider } from 'react-redux';
 import {
     Grid,
-    SortingState, SelectionState, FilteringState, PagingState, GroupingState,
+    SortingState, SelectionState, FilteringState, PagingState, GroupingState, RowDetailState,
     LocalFiltering, LocalGrouping, LocalPaging, LocalSorting,
 } from '@devexpress/dx-react-grid';
 import {
@@ -87,6 +87,10 @@ const GridContainer = ({
       currentPage={currentPage}
       onCurrentPageChange={onCurrentPageChange}
       pageSize={8}
+    />
+    <RowDetailState
+      expandedRows={expandedRows}
+      onExpandedRowsChange={onExpandedRowsChange}
     />
 
     <LocalFiltering />

--- a/packages/dx-react-demos/src/bootstrap3/redux/grid-container.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/redux/grid-container.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
     Grid,
-    SortingState, SelectionState, FilteringState, PagingState,
+    SortingState, SelectionState, FilteringState, PagingState, RowDetailState,
     LocalFiltering, LocalPaging, LocalSorting,
 } from '@devexpress/dx-react-grid';
 import {
@@ -62,6 +62,10 @@ const GridContainer = (props) => {
           selection={selection}
           onSelectionChange={onSelectionChange}
         />
+        <RowDetailState
+          expandedRows={expandedRows}
+          onExpandedRowsChange={onExpandedRowsChange}
+        />
 
         <LocalFiltering />
         <LocalSorting />
@@ -76,8 +80,6 @@ const GridContainer = (props) => {
         <TableSelection />
 
         <TableRowDetail
-          expandedRows={expandedRows}
-          onExpandedRowsChange={onExpandedRowsChange}
           template={DetailRow}
         />
 

--- a/packages/dx-react-demos/src/bootstrap3/virtual-scrolling/integration-with-other-plugins.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/virtual-scrolling/integration-with-other-plugins.jsx
@@ -3,6 +3,7 @@ import {
     Grid,
     FilteringState,
     SortingState,
+    RowDetailState,
     LocalFiltering,
     LocalSorting,
 } from '@devexpress/dx-react-grid';
@@ -55,6 +56,7 @@ export class IntegrationWithOtherPluginsDemo extends React.PureComponent {
       >
         <FilteringState defaultFilters={[]} />
         <SortingState defaultSorting={[{ columnName: 'city', direction: 'asc' }]} />
+        <RowDetailState />
 
         <LocalFiltering />
         <LocalSorting />

--- a/packages/dx-react-grid/docs/guides/detail-row.md
+++ b/packages/dx-react-grid/docs/guides/detail-row.md
@@ -6,14 +6,15 @@ The 'Detail Row' feature allows you to display extended representation of a data
 
 ## Plugin List
 
-Only one plugin is required to enable this feature:
+There are two plugins that enable this feature:
+- [RowDetailState](../reference/row-detail-state.md)
 - [TableRowDetail](../reference/table-row-detail.md)
 
 Note that the [plugin order](../README.md#plugin-order) is very important.
 
 ## Detail Row Setup
 
-To set up a simple Grid with detail rows, you need to use the `TableRowDetail` plugin. Specify the detail row template via the `template` property of the plugin. In uncontrolled state mode, you can also pass IDs of rows that should be initially expanded into the `defaultExpandedRows` property of the same plugin, and the expanded state will be managed by the plugin internally.
+To set up a simple Grid with detail rows, you need to use the `RowDetailState` and `TableRowDetail` plugins. Specify the detail row template via the `template` property of the `TableRowDetail` plugin. In uncontrolled state mode, you can also pass IDs of rows that should be initially expanded into the `defaultExpandedRows` property of the `RowDetailState` plugin, and the expanded state will be managed by the plugin internally.
 
 [DEMO](http://devexpress.github.io/devextreme-reactive/react/grid/demos/#/detail-row/simple-detail-row)
 
@@ -21,7 +22,7 @@ To set up a simple Grid with detail rows, you need to use the `TableRowDetail` p
 
 ## Controlled Expanded State Mode
 
-To control the expanded state of the detail rows from the outside, pass an array of the expanded row IDs to the `expandedRows` property of the `TableRowDetail` plugin and handle the `onExpandedRowsChange` event of the same plugin.
+To control the expanded state of the detail rows from the outside, pass an array of the expanded row IDs to the `expandedRows` property of the `RowDetailState` plugin and handle the `onExpandedRowsChange` event of the same plugin.
 
 [DEMO](http://devexpress.github.io/devextreme-reactive/react/grid/demos/#/detail-row/detail-row-controlled)
 

--- a/packages/dx-react-grid/docs/guides/detail-row.md
+++ b/packages/dx-react-grid/docs/guides/detail-row.md
@@ -6,7 +6,7 @@ The 'Detail Row' feature allows you to display extended representation of a data
 
 ## Plugin List
 
-There are two plugins that enable this feature:
+Two plugins are required to enable this feature:
 - [RowDetailState](../reference/row-detail-state.md)
 - [TableRowDetail](../reference/table-row-detail.md)
 

--- a/packages/dx-react-grid/docs/reference/README.md
+++ b/packages/dx-react-grid/docs/reference/README.md
@@ -12,6 +12,7 @@ State Management Plugins:
 - [PagingState](paging-state.md)
 - [SelectionState](selection-state.md)
 - [EditingState](editing-state.md)
+- [RowDetailState](row-detail-state.md)
 
 Data Processing Plugins:
 

--- a/packages/dx-react-grid/docs/reference/row-detail-state.md
+++ b/packages/dx-react-grid/docs/reference/row-detail-state.md
@@ -1,0 +1,21 @@
+# RowDetailState Plugin Reference
+
+A plugin that manages the expanded state for table row details.
+
+## User Reference
+
+### Dependencies
+
+none
+
+### Properties
+
+Name | Type | Default | Description
+-----|------|---------|------------
+expandedRows | Array&lt;number&#124;string&gt; | | Specifies expanded rows
+defaultExpandedRows | Array&lt;number&#124;string&gt; | | Specifies initially expanded rows for the uncontrolled mode
+onExpandedRowsChange | (expandedRows: Array&lt;number&#124;string&gt;) => void | | Handles expanded row changes
+
+## Plugin Developer Reference
+
+To be described...

--- a/packages/dx-react-grid/docs/reference/table-row-detail.md
+++ b/packages/dx-react-grid/docs/reference/table-row-detail.md
@@ -1,6 +1,6 @@
 # TableRowDetail Plugin Reference
 
-A plugin that manages the expanded state for table row details and renders a detail row.
+A plugin that renders a table detail row.
 
 ## User Reference
 
@@ -12,9 +12,6 @@ A plugin that manages the expanded state for table row details and renders a det
 
 Name | Type | Default | Description
 -----|------|---------|------------
-expandedRows | Array&lt;number&#124;string&gt; | | Specifies expanded rows
-defaultExpandedRows | Array&lt;number&#124;string&gt; | | Specifies initially expanded rows for the uncontrolled mode
-onExpandedRowsChange | (expandedRows: Array&lt;number&#124;string&gt;) => void | | Handles expanded row changes
 template | Component&lt;[DetailContentProps](#detail-content-props)&gt; | | A component that renders details for a row
 detailCellTemplate | Component&lt;[DetailCellProps](#detail-cell-props)&gt; | | A component that renders the detail cell
 detailToggleTemplate | Component&lt;[DetailToggleProps](#detail-toggle-props)&gt; | | A component that renders the detail toggle control

--- a/packages/dx-react-grid/docs/reference/table-row-detail.md
+++ b/packages/dx-react-grid/docs/reference/table-row-detail.md
@@ -13,14 +13,14 @@ A plugin that renders a table detail row.
 Name | Type | Default | Description
 -----|------|---------|------------
 template | Component&lt;[DetailContentProps](#detail-content-props)&gt; | | A component that renders details for a row
-detailCellTemplate | Component&lt;[DetailCellProps](#detail-cell-props)&gt; | | A component that renders the detail cell
+detailCellTemplate | Component&lt;[DetailCellProps](#detail-cell-props)&gt; | | A component that renders a detail cell
 detailToggleTemplate | Component&lt;[DetailToggleProps](#detail-toggle-props)&gt; | | A component that renders the detail toggle control
 
 ## Interfaces
 
 ### <a name="detail-content-props"></a>DetailContentProps
 
-Describes properties passed to the template that renders details for a row
+Describes properties passed to the template that renders row details
 
 A value with the following shape:
 
@@ -30,14 +30,14 @@ row | [TableRow](table-view.md#table-row) | A row object for showing row details
 
 ### <a name="detail-cell-props"></a>DetailCellProps
 
-Describes properties passed to the template that renders the details cell for a row
+Describes properties passed to the template that renders a detail cell for a row
 
 A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
 row | [TableRow](table-view.md#table-row) | A row object
-template | Component&lt;void&gt; | A component that renders details for a row
+template | Component&lt;void&gt; | A component that renders row details
 
 ### <a name="detail-toggle-props"></a>DetailToggleProps
 

--- a/packages/dx-react-grid/docs/reference/table-row-detail.md
+++ b/packages/dx-react-grid/docs/reference/table-row-detail.md
@@ -12,7 +12,7 @@ A plugin that renders a table detail row.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-template | Component&lt;[DetailContentProps](#detail-content-props)&gt; | | A component that renders details for a row
+template | Component&lt;[DetailContentProps](#detail-content-props)&gt; | | A component that renders row details
 detailCellTemplate | Component&lt;[DetailCellProps](#detail-cell-props)&gt; | | A component that renders a detail cell
 detailToggleTemplate | Component&lt;[DetailToggleProps](#detail-toggle-props)&gt; | | A component that renders the detail toggle control
 

--- a/packages/dx-react-grid/src/index.js
+++ b/packages/dx-react-grid/src/index.js
@@ -18,7 +18,10 @@ export { LocalSorting } from './plugins/sorting-local';
 
 export { TableView } from './plugins/table-view';
 export { TableSelection } from './plugins/table-selection';
+
+export { RowDetailState } from './plugins/row-detail-state';
 export { TableRowDetail } from './plugins/table-row-detail';
+
 export { TableGroupRow } from './plugins/table-group-row';
 export { TableHeaderRow } from './plugins/table-header-row';
 export { TableFilterRow } from './plugins/table-filter-row';

--- a/packages/dx-react-grid/src/plugins/row-detail-state.jsx
+++ b/packages/dx-react-grid/src/plugins/row-detail-state.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Getter, Action, PluginContainer } from '@devexpress/dx-react-core';
+import { setDetailRowExpanded } from '@devexpress/dx-grid-core';
+
+export class RowDetailState extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      expandedRows: props.defaultExpandedRows || [],
+    };
+
+    this._setDetailRowExpanded = ({ rowId }) => {
+      const prevExpandedDetails = this.props.expandedRows || this.state.expandedRows;
+      const expandedRows = setDetailRowExpanded(prevExpandedDetails, { rowId });
+      const { onExpandedRowsChange } = this.props;
+      this.setState({ expandedRows });
+      if (onExpandedRowsChange) {
+        onExpandedRowsChange(expandedRows);
+      }
+    };
+  }
+
+  render() {
+    const expandedRows = this.props.expandedRows || this.state.expandedRows;
+    return (
+      <PluginContainer>
+        <Action
+          name="setDetailRowExpanded"
+          action={({ rowId }) => this._setDetailRowExpanded({ rowId })}
+        />
+
+        <Getter name="expandedRows" value={expandedRows} />
+      </PluginContainer>
+    );
+  }
+}
+
+RowDetailState.propTypes = {
+  expandedRows: PropTypes.array,
+  defaultExpandedRows: PropTypes.array,
+  onExpandedRowsChange: PropTypes.func,
+};
+
+RowDetailState.defaultProps = {
+  expandedRows: undefined,
+  defaultExpandedRows: undefined,
+  onExpandedRowsChange: undefined,
+};

--- a/packages/dx-react-grid/src/plugins/table-row-detail.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.jsx
@@ -1,30 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
-import { setDetailRowExpanded, expandedDetailRows, isDetailRowExpanded } from '@devexpress/dx-grid-core';
+import { expandedDetailRows, isDetailRowExpanded } from '@devexpress/dx-grid-core';
 
 export class TableRowDetail extends React.PureComponent {
   constructor(props) {
     super(props);
 
-    this.state = {
-      expandedRows: props.defaultExpandedRows || [],
-    };
-
-    this._setDetailRowExpanded = ({ rowId }) => {
-      const prevExpandedDetails = this.props.expandedRows || this.state.expandedRows;
-      const expandedRows = setDetailRowExpanded(prevExpandedDetails, { rowId });
-      const { onExpandedRowsChange } = this.props;
-      this.setState({ expandedRows });
-      if (onExpandedRowsChange) {
-        onExpandedRowsChange(expandedRows);
-      }
-    };
-
     this._tableColumns = tableColumns => [{ type: 'detail', width: 25 }, ...tableColumns];
   }
   render() {
-    const expandedRows = this.props.expandedRows || this.state.expandedRows;
     const { rowHeight, template, detailToggleTemplate, detailCellTemplate } = this.props;
 
     return (
@@ -41,13 +26,23 @@ export class TableRowDetail extends React.PureComponent {
           predicate={({ column, row }) => column.type === 'detail' && !row.type}
           connectGetters={getter => ({
             getRowId: getter('getRowId'),
+            expandedRows: getter('expandedRows'),
+          })}
+          connectActions={action => ({
+            setDetailRowExpanded: action('setDetailRowExpanded'),
           })}
         >
-          {({ row, getRowId, ...restParams }) => detailToggleTemplate({
-            ...restParams,
-            expanded: isDetailRowExpanded(expandedRows, getRowId(row)),
-            toggleExpanded: () => this._setDetailRowExpanded({ rowId: getRowId(row) }),
-          })}
+          {({
+              row,
+              getRowId,
+              expandedRows,
+              setDetailRowExpanded,
+              ...restParams
+            }) => detailToggleTemplate({
+              ...restParams,
+              expanded: isDetailRowExpanded(expandedRows, getRowId(row)),
+              toggleExpanded: () => setDetailRowExpanded({ rowId: getRowId(row) }),
+            })}
         </Template>
 
         <Getter
@@ -55,7 +50,7 @@ export class TableRowDetail extends React.PureComponent {
           pureComputed={expandedDetailRows}
           connectArgs={getter => [
             getter('tableBodyRows'),
-            expandedRows,
+            getter('expandedRows'),
             getter('getRowId'),
             rowHeight,
           ]}
@@ -73,9 +68,6 @@ export class TableRowDetail extends React.PureComponent {
 }
 
 TableRowDetail.propTypes = {
-  expandedRows: PropTypes.array,
-  defaultExpandedRows: PropTypes.array,
-  onExpandedRowsChange: PropTypes.func,
   template: PropTypes.func,
   detailToggleTemplate: PropTypes.func.isRequired,
   detailCellTemplate: PropTypes.func.isRequired,
@@ -86,9 +78,6 @@ TableRowDetail.propTypes = {
 };
 
 TableRowDetail.defaultProps = {
-  expandedRows: undefined,
-  defaultExpandedRows: undefined,
-  onExpandedRowsChange: undefined,
   rowHeight: 'auto',
   template: undefined,
 };

--- a/site/_data/docs/navigation.yml
+++ b/site/_data/docs/navigation.yml
@@ -36,6 +36,8 @@ react:
           path: /react/grid/docs/reference/selection-state
         - title: EditingState
           path: /react/grid/docs/reference/editing-state
+        - title: RowDetailState
+          path: /react/grid/docs/reference/row-detail-state
         - title: LocalFiltering
           path: /react/grid/docs/reference/local-filtering
         - title: LocalSorting


### PR DESCRIPTION
BREAKING CHANGE:

Previously, to enable the 'Detail row' feature a user had to use only the 'TableRowDetail' plugin. But, this plugin mixed up the rendering and state managing functionality. Now, there are two particular plugins. The first one is the 'RowDetailState' plugin. It's responsible for a state managing. The second one is the 'TableRowDetail' plugin. It only renders a detail row. 

The following code:

    <TableRowDetail
        expandedRows={expandedRows}
        onExpandedRowsChange={onExpandedRowsChange}
        template={({ row }) =>
        <GridDetailContainer
            data={row}
            columns={detailColumns}
        />
        }
    />

should be replaced with:

    <RowDetailState 
        expandedRows={expandedRows}
        onExpandedRowsChange={onExpandedRowsChange}
    />
    <TableRowDetail
        template={({ row }) =>
        <GridDetailContainer
            data={row}
            columns={detailColumns}
        />
        }
    />

