### PR TITLE
refactor(react-core): Remove the onChange handler from the Getter component

### DIFF
--- a/packages/dx-react-core/src/plugged/getter.jsx
+++ b/packages/dx-react-core/src/plugged/getter.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { argumentsShallowEqual } from '../utils/shallowEqual';
 import { getAction } from '../utils/pluginHelpers';
 
-function getterMemoize(func, onChange) {
+function getterMemoize(func) {
   let lastArg = null;
   let lastResult = null;
   return (...args) => {
@@ -12,7 +12,6 @@ function getterMemoize(func, onChange) {
       !argumentsShallowEqual(lastArg, args)
     ) {
       lastResult = func(...args);
-      onChange(lastResult);
     }
     lastArg = args;
     return lastResult;
@@ -21,13 +20,11 @@ function getterMemoize(func, onChange) {
 
 export const UPDATE_CONNECTION = 'updateConnection';
 
-const noop = () => {};
-
 export class Getter extends React.PureComponent {
   componentWillMount() {
     const { pluginHost } = this.context;
-    const { name, pureComputed, onChange } = this.props;
-    const pureComputedMemoized = getterMemoize(pureComputed, result => onChange(result));
+    const { name, pureComputed } = this.props;
+    const pureComputedMemoized = getterMemoize(pureComputed);
 
     this.plugin = {
       position: () => this.props.position(),
@@ -65,7 +62,6 @@ export class Getter extends React.PureComponent {
   }
 }
 Getter.defaultProps = {
-  onChange: noop,
   value: null,
   pureComputed: null,
   connectArgs: null,
@@ -74,7 +70,6 @@ Getter.defaultProps = {
 Getter.propTypes = {
   position: PropTypes.func,
   name: PropTypes.string.isRequired,
-  onChange: PropTypes.func,
   value: PropTypes.any, // eslint-disable-line react/forbid-prop-types
   pureComputed: PropTypes.func,
   connectArgs: PropTypes.func,

--- a/packages/dx-react-core/src/plugged/getter.test.jsx
+++ b/packages/dx-react-core/src/plugged/getter.test.jsx
@@ -163,46 +163,6 @@ describe('Getter', () => {
     expect(tree.find('h1').text()).toBe('new');
   });
 
-  test('notifies when updated', () => {
-    const Test = ({ text, onChange }) => (
-      <PluginHost>
-        <Getter name="test" value={text} />
-        <Getter
-          name="test"
-          pureComputed={original => `${original}_extended`}
-          connectArgs={getter => [
-            getter('test'),
-          ]}
-          onChange={onChange}
-        />
-
-        <Template
-          name="root"
-          connectGetters={getter => ({
-            prop: getter('test'),
-          })}
-        >
-          {({ prop }) => <h1>{prop}</h1>}
-        </Template>
-      </PluginHost>
-    );
-    Test.propTypes = {
-      text: PropTypes.string.isRequired,
-      onChange: PropTypes.func.isRequired,
-    };
-
-    const onChange = jest.fn();
-    const tree = mount(
-      <Test text="text" onChange={onChange} />,
-    );
-    tree.setProps({ text: 'text' });
-    tree.setProps({ text: 'new' });
-
-    expect(onChange.mock.calls).toHaveLength(2);
-    expect(onChange.mock.calls[0][0]).toBe('text_extended');
-    expect(onChange.mock.calls[1][0]).toBe('new_extended');
-  });
-
   // This test is not correct enough. Rewrite it in future
   test('memoization based on args', () => {
     const staticValue = {};


### PR DESCRIPTION
The Watcher component is already implemented for such tasks