### PR TITLE
fix(react-grid): cancel column grouping in FireFox

### DIFF
--- a/packages/dx-react-grid-bootstrap3/src/templates/group-panel-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/group-panel-cell.jsx
@@ -8,8 +8,7 @@ export const GroupPanelCell = ({
   groupByColumn,
   allowSorting, sortingDirection, changeSortingDirection,
 }) => (
-  <button
-    type="button"
+  <div
     className="btn btn-default"
     style={{
       marginRight: '5px',
@@ -42,7 +41,7 @@ export const GroupPanelCell = ({
       }}
       onClick={() => groupByColumn({ columnName: column.name })}
     />
-  </button>
+  </div>
 );
 
 GroupPanelCell.defaultProps = {


### PR DESCRIPTION
Fixes cancel column grouping in FireFox