### PR TITLE
refactor(react-grid): Rename groupColumnWidth to groupIndentColumnWidth

### DIFF
--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.js
@@ -1,5 +1,5 @@
-export const tableColumnsWithGroups = (columns, grouping, groupColumnWidth) => [
-  ...grouping.map(group => ({ type: 'groupColumn', group, width: groupColumnWidth })),
+export const tableColumnsWithGroups = (columns, grouping, groupIndentColumnWidth) => [
+  ...grouping.map(group => ({ type: 'groupColumn', group, width: groupIndentColumnWidth })),
   ...columns,
 ];
 

--- a/packages/dx-react-grid-bootstrap3/src/plugins/table-group-row.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/plugins/table-group-row.jsx
@@ -10,7 +10,7 @@ export const TableGroupRow = props => (
   <TableGroupRowBase
     groupRowCellTemplate={groupRowCellTemplate}
     groupIndentCellTemplate={groupIndentCellTemplate}
-    groupColumnWidth={20}
+    groupIndentColumnWidth={20}
     {...props}
   />
 );

--- a/packages/dx-react-grid-material-ui/src/plugins/table-group-row.jsx
+++ b/packages/dx-react-grid-material-ui/src/plugins/table-group-row.jsx
@@ -10,7 +10,7 @@ export const TableGroupRow = props => (
   <TableGroupRowBase
     groupRowCellTemplate={groupRowCellTemplate}
     groupIndentCellTemplate={groupIndentCellTemplate}
-    groupColumnWidth={24}
+    groupIndentColumnWidth={24}
     {...props}
   />
 );

--- a/packages/dx-react-grid/docs/reference/table-group-row.md
+++ b/packages/dx-react-grid/docs/reference/table-group-row.md
@@ -15,7 +15,7 @@ Name | Type | Default | Description
 -----|------|---------|------------
 groupRowCellTemplate | (args: [GroupRowCellArgs](#group-row-cell-args)) => ReactElement | | A component that renders a group row
 groupIndentCellTemplate | (args: [GroupIndentCellArgs](#group-indent-cell-args)) => ReactElement | | A component that renders a group indent cell
-groupColumnWidth | number | | Width of the group indent columns
+groupIndentColumnWidth | number | | Width of the group indent columns
 
 ## Interfaces
 

--- a/packages/dx-react-grid/src/plugins/table-group-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-group-row.jsx
@@ -6,7 +6,7 @@ import { tableColumnsWithGroups } from '@devexpress/dx-grid-core';
 export class TableGroupRow extends React.PureComponent {
   render() {
     const {
-      groupColumnWidth,
+      groupIndentColumnWidth,
       groupRowCellTemplate,
       groupIndentCellTemplate,
     } = this.props;
@@ -19,7 +19,7 @@ export class TableGroupRow extends React.PureComponent {
           connectArgs={getter => [
             getter('tableColumns'),
             getter('grouping'),
-            groupColumnWidth,
+            groupIndentColumnWidth,
           ]}
         />
 
@@ -57,5 +57,5 @@ export class TableGroupRow extends React.PureComponent {
 TableGroupRow.propTypes = {
   groupRowCellTemplate: PropTypes.func.isRequired,
   groupIndentCellTemplate: PropTypes.func.isRequired,
-  groupColumnWidth: PropTypes.number.isRequired,
+  groupIndentColumnWidth: PropTypes.number.isRequired,
 };


### PR DESCRIPTION
BREAKING CHANGE:

The `groupColumnWidth` property of the TableGroupRow plugin has been renamed to `groupIndentColumnWidth` to avoid possible confusion of what it is responsible for.