### PR TITLE
refactor(react-grid): Rename detailToggleTemplate to detailToggleCellTemplate

### DIFF
--- a/packages/dx-react-grid-bootstrap3/src/plugins/table-row-detail.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/plugins/table-row-detail.jsx
@@ -3,12 +3,12 @@ import { TableRowDetail as TableRowDetailBase } from '@devexpress/dx-react-grid'
 import { TableDetailToggleCell } from '../templates/table-detail-toggle-cell';
 import { TableDetailCell } from '../templates/table-detail-cell';
 
-const detailToggleTemplate = props => <TableDetailToggleCell {...props} />;
+const detailToggleCellTemplate = props => <TableDetailToggleCell {...props} />;
 const detailCellTemplate = props => <TableDetailCell {...props} />;
 
 export const TableRowDetail = props => (
   <TableRowDetailBase
-    detailToggleTemplate={detailToggleTemplate}
+    detailToggleCellTemplate={detailToggleCellTemplate}
     detailCellTemplate={detailCellTemplate}
     detailToggleCellWidth={25}
     {...props}

--- a/packages/dx-react-grid-material-ui/src/plugins/table-row-detail.jsx
+++ b/packages/dx-react-grid-material-ui/src/plugins/table-row-detail.jsx
@@ -3,12 +3,12 @@ import { TableRowDetail as TableRowDetailBase } from '@devexpress/dx-react-grid'
 import { TableDetailToggleCell } from '../templates/table-detail-toggle-cell';
 import { TableDetailCell } from '../templates/table-detail-cell';
 
-const detailToggleTemplate = props => <TableDetailToggleCell {...props} />;
+const detailToggleCellTemplate = props => <TableDetailToggleCell {...props} />;
 const detailCellTemplate = props => <TableDetailCell {...props} />;
 
 export const TableRowDetail = props => (
   <TableRowDetailBase
-    detailToggleTemplate={detailToggleTemplate}
+    detailToggleCellTemplate={detailToggleCellTemplate}
     detailCellTemplate={detailCellTemplate}
     detailToggleCellWidth={42}
     {...props}

--- a/packages/dx-react-grid/docs/reference/table-row-detail.md
+++ b/packages/dx-react-grid/docs/reference/table-row-detail.md
@@ -14,7 +14,7 @@ Name | Type | Default | Description
 -----|------|---------|------------
 template | (args: [DetailContentArgs](#detail-content-args)) => ReactElement | | A component that renders row details
 detailCellTemplate | (args: [DetailCellArgs](#detail-cell-args)) => ReactElement | | A component that renders a detail cell
-detailToggleTemplate | (args: [DetailToggleArgs](#detail-toggle-args)) => ReactElement | | A component that renders the detail toggle control
+detailToggleCellTemplate | (args: [DetailToggleArgs](#detail-toggle-args)) => ReactElement | | A component that renders the detail toggle control
 detailToggleCellWidth | number | | Specifies the detail toggle cell width
 rowHeight | number &#124; string | 'auto' | Specifies the detail row height
 

--- a/packages/dx-react-grid/src/plugins/table-row-detail.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.jsx
@@ -8,7 +8,7 @@ export class TableRowDetail extends React.PureComponent {
     const {
       rowHeight,
       template,
-      detailToggleTemplate,
+      detailToggleCellTemplate,
       detailCellTemplate,
       detailToggleCellWidth,
     } = this.props;
@@ -40,7 +40,7 @@ export class TableRowDetail extends React.PureComponent {
               expandedRows,
               setDetailRowExpanded,
               ...restParams
-            }) => detailToggleTemplate({
+            }) => detailToggleCellTemplate({
               ...restParams,
               expanded: isDetailRowExpanded(expandedRows, getRowId(row)),
               toggleExpanded: () => setDetailRowExpanded({ rowId: getRowId(row) }),
@@ -71,7 +71,7 @@ export class TableRowDetail extends React.PureComponent {
 
 TableRowDetail.propTypes = {
   template: PropTypes.func,
-  detailToggleTemplate: PropTypes.func.isRequired,
+  detailToggleCellTemplate: PropTypes.func.isRequired,
   detailCellTemplate: PropTypes.func.isRequired,
   detailToggleCellWidth: PropTypes.number.isRequired,
   rowHeight: PropTypes.oneOfType([


### PR DESCRIPTION
BREAKING CHANGE:

We renamed the `detailToggleTemplate` property of the TableRowDetail plugin to `detailToggleCellTemplate` to make it consistent with the `detailToggleCellWidth` property.
