### PR TITLE
refactor(react-grid): Rename groupRowCellTemplate to groupCellTemplate

### DIFF
--- a/packages/dx-react-grid-bootstrap3/src/plugins/table-group-row.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/plugins/table-group-row.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
 import { TableGroupRow as TableGroupRowBase } from '@devexpress/dx-react-grid';
-import { TableGroupRowCell, TableGroupIndentCell } from '../templates/table-group-row-cell';
+import { TableGroupCell, TableGroupIndentCell } from '../templates/table-group-row-cell';
 
-const groupRowCellTemplate = props => <TableGroupRowCell {...props} />;
+const groupCellTemplate = props => <TableGroupCell {...props} />;
 const groupIndentCellTemplate = props => <TableGroupIndentCell {...props} />;
 
 export const TableGroupRow = props => (
   <TableGroupRowBase
-    groupRowCellTemplate={groupRowCellTemplate}
+    groupCellTemplate={groupCellTemplate}
     groupIndentCellTemplate={groupIndentCellTemplate}
     groupIndentColumnWidth={20}
     {...props}

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-group-row-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-group-row-cell.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const TableGroupRowCell = ({ style, colspan, row, isExpanded, toggleGroupExpanded }) => (
+export const TableGroupCell = ({ style, colspan, row, isExpanded, toggleGroupExpanded }) => (
   <td
     colSpan={colspan}
     style={{
@@ -22,7 +22,7 @@ export const TableGroupRowCell = ({ style, colspan, row, isExpanded, toggleGroup
   </td>
 );
 
-TableGroupRowCell.propTypes = {
+TableGroupCell.propTypes = {
   style: PropTypes.shape(),
   colspan: PropTypes.number,
   row: PropTypes.shape(),
@@ -30,7 +30,7 @@ TableGroupRowCell.propTypes = {
   toggleGroupExpanded: PropTypes.func,
 };
 
-TableGroupRowCell.defaultProps = {
+TableGroupCell.defaultProps = {
   style: null,
   colspan: 1,
   row: {},

--- a/packages/dx-react-grid-material-ui/src/plugins/table-group-row.jsx
+++ b/packages/dx-react-grid-material-ui/src/plugins/table-group-row.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
 import { TableGroupRow as TableGroupRowBase } from '@devexpress/dx-react-grid';
-import { TableGroupRowCell, TableGroupIndentCell } from '../templates/table-group-row-cell';
+import { TableGroupCell, TableGroupIndentCell } from '../templates/table-group-row-cell';
 
-const groupRowCellTemplate = props => <TableGroupRowCell {...props} />;
+const groupCellTemplate = props => <TableGroupCell {...props} />;
 const groupIndentCellTemplate = props => <TableGroupIndentCell {...props} />;
 
 export const TableGroupRow = props => (
   <TableGroupRowBase
-    groupRowCellTemplate={groupRowCellTemplate}
+    groupCellTemplate={groupCellTemplate}
     groupIndentCellTemplate={groupIndentCellTemplate}
     groupIndentColumnWidth={24}
     {...props}

--- a/packages/dx-react-grid-material-ui/src/templates/table-group-row-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-group-row-cell.jsx
@@ -5,12 +5,12 @@ import ChevronRight from 'material-ui-icons/ChevronRight';
 import ExpandMore from 'material-ui-icons/ExpandMore';
 
 import {
-    TableCell,
+  TableCell,
 } from 'material-ui';
 
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 
-const styleSheet = createStyleSheet('TableGroupRowCell', theme => ({
+const styleSheet = createStyleSheet('TableGroupCell', theme => ({
   cell: {
     cursor: 'pointer',
     paddingLeft: theme.spacing.unit,
@@ -21,7 +21,7 @@ const styleSheet = createStyleSheet('TableGroupRowCell', theme => ({
   },
 }));
 
-const TableGroupRowCellBase = ({
+const TableGroupCellBase = ({
   style,
   colspan,
   row,
@@ -56,7 +56,7 @@ const TableGroupRowCellBase = ({
   </TableCell>
 );
 
-TableGroupRowCellBase.propTypes = {
+TableGroupCellBase.propTypes = {
   style: PropTypes.shape(),
   colspan: PropTypes.number,
   row: PropTypes.shape(),
@@ -65,7 +65,7 @@ TableGroupRowCellBase.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-TableGroupRowCellBase.defaultProps = {
+TableGroupCellBase.defaultProps = {
   style: null,
   colspan: 1,
   row: {},
@@ -73,7 +73,7 @@ TableGroupRowCellBase.defaultProps = {
   toggleGroupExpanded: () => {},
 };
 
-export const TableGroupRowCell = withStyles(styleSheet)(TableGroupRowCellBase);
+export const TableGroupCell = withStyles(styleSheet)(TableGroupCellBase);
 
 const TableGroupIndentCellBase = ({ column, style, classes }) => (
   <TableCell

--- a/packages/dx-react-grid/docs/reference/table-group-row.md
+++ b/packages/dx-react-grid/docs/reference/table-group-row.md
@@ -13,13 +13,13 @@ A plugin that renders group rows with the capability to expand and collapse them
 
 Name | Type | Default | Description
 -----|------|---------|------------
-groupRowCellTemplate | (args: [GroupRowCellArgs](#group-row-cell-args)) => ReactElement | | A component that renders a group row
+groupCellTemplate | (args: [GroupCellArgs](#group-cell-args)) => ReactElement | | A component that renders a group row
 groupIndentCellTemplate | (args: [GroupIndentCellArgs](#group-indent-cell-args)) => ReactElement | | A component that renders a group indent cell
 groupIndentColumnWidth | number | | Width of the group indent columns
 
 ## Interfaces
 
-### <a name="group-row-cell-args"></a>GroupRowCellArgs
+### <a name="group-cell-args"></a>GroupCellArgs
 
 Describes properties passed to the template that renders a group row.
 

--- a/packages/dx-react-grid/src/plugins/table-group-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-group-row.jsx
@@ -6,9 +6,9 @@ import { tableColumnsWithGroups } from '@devexpress/dx-grid-core';
 export class TableGroupRow extends React.PureComponent {
   render() {
     const {
-      groupIndentColumnWidth,
-      groupRowCellTemplate,
+      groupCellTemplate,
       groupIndentCellTemplate,
+      groupIndentColumnWidth,
     } = this.props;
 
     return (
@@ -31,7 +31,7 @@ export class TableGroupRow extends React.PureComponent {
           connectGetters={getter => ({ expandedGroups: getter('expandedGroups') })}
           connectActions={action => ({ toggleGroupExpanded: action('toggleGroupExpanded') })}
         >
-          {({ expandedGroups, toggleGroupExpanded, ...params }) => groupRowCellTemplate({
+          {({ expandedGroups, toggleGroupExpanded, ...params }) => groupCellTemplate({
             ...params,
             isExpanded: expandedGroups.has(params.row.key),
             toggleGroupExpanded: () => toggleGroupExpanded({ groupKey: params.row.key }),
@@ -55,7 +55,7 @@ export class TableGroupRow extends React.PureComponent {
 }
 
 TableGroupRow.propTypes = {
-  groupRowCellTemplate: PropTypes.func.isRequired,
+  groupCellTemplate: PropTypes.func.isRequired,
   groupIndentCellTemplate: PropTypes.func.isRequired,
   groupIndentColumnWidth: PropTypes.number.isRequired,
 };


### PR DESCRIPTION
BREAKING CHANGE:
The 'groupRowCellTemplate' property of the TableGroupRow plugin has been renamed to 'groupCellTemplate'