### PR TITLE
refactor(react-grid): change TableRow and TableColumn interfaces structure

### DIFF
--- a/packages/dx-grid-core/src/index.js
+++ b/packages/dx-grid-core/src/index.js
@@ -23,27 +23,34 @@ export * from './plugins/editing-state/helpers';
 export * from './plugins/column-order-state/reducers';
 export * from './plugins/column-order-state/computeds';
 
+export * from './plugins/table-edit-column/constants';
 export * from './plugins/table-edit-column/helpers';
 export * from './plugins/table-edit-column/computeds';
 
+export * from './plugins/table-edit-row/constants';
 export * from './plugins/table-edit-row/helpers';
 export * from './plugins/table-edit-row/computeds';
 
+export * from './plugins/table-filter-row/constants';
 export * from './plugins/table-filter-row/helpers';
 export * from './plugins/table-filter-row/computeds';
 
 export * from './plugins/table-group-row/computeds';
 
+export * from './plugins/table-header-row/constants';
 export * from './plugins/table-header-row/helpers';
 export * from './plugins/table-header-row/computeds';
 
+export * from './plugins/table-row-detail/constants';
+export * from './plugins/table-row-detail/helpers';
 export * from './plugins/table-row-detail/reducers';
 export * from './plugins/table-row-detail/computeds';
-export * from './plugins/table-row-detail/helpers';
 
+export * from './plugins/table-selection/constants';
 export * from './plugins/table-selection/helpers';
 export * from './plugins/table-selection/computeds';
 
+export * from './plugins/table-view/constants';
 export * from './plugins/table-view/helpers';
 export * from './plugins/table-view/computeds';
 

--- a/packages/dx-grid-core/src/index.js
+++ b/packages/dx-grid-core/src/index.js
@@ -16,10 +16,6 @@ export * from './plugins/paging-state/computeds';
 export * from './plugins/selection-state/reducers';
 export * from './plugins/selection-state/computeds';
 
-export * from './plugins/table-row-detail/reducers';
-export * from './plugins/table-row-detail/computeds';
-export * from './plugins/table-row-detail/helpers';
-
 export * from './plugins/editing-state/reducers';
 export * from './plugins/editing-state/computeds';
 export * from './plugins/editing-state/helpers';
@@ -29,10 +25,23 @@ export * from './plugins/table-edit-row/computeds';
 export * from './plugins/column-order-state/reducers';
 export * from './plugins/column-order-state/computeds';
 
+export * from './plugins/table-filter-row/helpers';
 export * from './plugins/table-filter-row/computeds';
+
 export * from './plugins/table-group-row/computeds';
+
+export * from './plugins/table-header-row/helpers';
 export * from './plugins/table-header-row/computeds';
+
+export * from './plugins/table-row-detail/reducers';
+export * from './plugins/table-row-detail/computeds';
+export * from './plugins/table-row-detail/helpers';
+
+export * from './plugins/table-selection/helpers';
 export * from './plugins/table-selection/computeds';
+
+export * from './plugins/table-view/helpers';
+export * from './plugins/table-view/computeds';
 
 export {
   tableRowKeyGetter,

--- a/packages/dx-grid-core/src/index.js
+++ b/packages/dx-grid-core/src/index.js
@@ -44,8 +44,7 @@ export * from './plugins/table-view/helpers';
 export * from './plugins/table-view/computeds';
 
 export {
-  tableRowKeyGetter,
-  tableColumnKeyGetter,
+  tableKeyGetter,
   getTableCellInfo,
   findTableCellTarget,
   getTableColumnGeometries,

--- a/packages/dx-grid-core/src/index.js
+++ b/packages/dx-grid-core/src/index.js
@@ -20,10 +20,11 @@ export * from './plugins/editing-state/reducers';
 export * from './plugins/editing-state/computeds';
 export * from './plugins/editing-state/helpers';
 
-export * from './plugins/table-edit-row/computeds';
-
 export * from './plugins/column-order-state/reducers';
 export * from './plugins/column-order-state/computeds';
+
+export * from './plugins/table-edit-row/helpers';
+export * from './plugins/table-edit-row/computeds';
 
 export * from './plugins/table-filter-row/helpers';
 export * from './plugins/table-filter-row/computeds';

--- a/packages/dx-grid-core/src/index.js
+++ b/packages/dx-grid-core/src/index.js
@@ -35,6 +35,8 @@ export * from './plugins/table-filter-row/constants';
 export * from './plugins/table-filter-row/helpers';
 export * from './plugins/table-filter-row/computeds';
 
+export * from './plugins/table-group-row/constants';
+export * from './plugins/table-group-row/helpers';
 export * from './plugins/table-group-row/computeds';
 
 export * from './plugins/table-header-row/constants';

--- a/packages/dx-grid-core/src/index.js
+++ b/packages/dx-grid-core/src/index.js
@@ -57,7 +57,6 @@ export * from './plugins/table-view/helpers';
 export * from './plugins/table-view/computeds';
 
 export {
-  tableKeyGetter,
   getTableRowColumnsWithColSpan,
   findTableCellTarget,
   getTableColumnGeometries,

--- a/packages/dx-grid-core/src/index.js
+++ b/packages/dx-grid-core/src/index.js
@@ -23,6 +23,9 @@ export * from './plugins/editing-state/helpers';
 export * from './plugins/column-order-state/reducers';
 export * from './plugins/column-order-state/computeds';
 
+export * from './plugins/table-edit-column/helpers';
+export * from './plugins/table-edit-column/computeds';
+
 export * from './plugins/table-edit-row/helpers';
 export * from './plugins/table-edit-row/computeds';
 

--- a/packages/dx-grid-core/src/plugins/_blueprint/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/_blueprint/computeds.test.js
@@ -1,5 +1,5 @@
 import {
-    pureComputed,
+  pureComputed,
 } from './computeds';
 
 describe('Plugin computeds', () => {

--- a/packages/dx-grid-core/src/plugins/_blueprint/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/_blueprint/helpers.test.js
@@ -1,5 +1,5 @@
 import {
-    pureHelper,
+  pureHelper,
 } from './helpers';
 
 describe('Plugin helpers', () => {

--- a/packages/dx-grid-core/src/plugins/_blueprint/reducers.test.js
+++ b/packages/dx-grid-core/src/plugins/_blueprint/reducers.test.js
@@ -1,5 +1,5 @@
 import {
-    pureReducer,
+  pureReducer,
 } from './reducers';
 
 describe('Plugin reducers', () => {

--- a/packages/dx-grid-core/src/plugins/editing-state/helpers.js
+++ b/packages/dx-grid-core/src/plugins/editing-state/helpers.js
@@ -1,1 +1,1 @@
-export const getRowChange = (changedRows, rowId) => changedRows[rowId];
+export const getRowChange = (changedRows, rowId) => changedRows[rowId] || {};

--- a/packages/dx-grid-core/src/plugins/table-edit-column/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/computeds.js
@@ -1,4 +1,4 @@
-import { EDIT_COMMANDS_TYPE } from './constants';
+import { TABLE_EDIT_COMMAND_TYPE } from './constants';
 
 export const tableColumnsWithEditing = (tableColumns, width) =>
-  [{ type: EDIT_COMMANDS_TYPE, id: 0, width }, ...tableColumns];
+  [{ type: TABLE_EDIT_COMMAND_TYPE, id: 0, width }, ...tableColumns];

--- a/packages/dx-grid-core/src/plugins/table-edit-column/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/computeds.js
@@ -1,4 +1,4 @@
 import { TABLE_EDIT_COMMAND_TYPE } from './constants';
 
 export const tableColumnsWithEditing = (tableColumns, width) =>
-  [{ type: TABLE_EDIT_COMMAND_TYPE, id: 0, width }, ...tableColumns];
+  [{ key: TABLE_EDIT_COMMAND_TYPE, type: TABLE_EDIT_COMMAND_TYPE, width }, ...tableColumns];

--- a/packages/dx-grid-core/src/plugins/table-edit-column/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/computeds.js
@@ -1,0 +1,4 @@
+import { EDIT_COMMANDS_TYPE } from './constants';
+
+export const tableColumnsWithEditing = (tableColumns, width) =>
+  [{ type: EDIT_COMMANDS_TYPE, id: 0, width }, ...tableColumns];

--- a/packages/dx-grid-core/src/plugins/table-edit-column/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/computeds.test.js
@@ -11,8 +11,8 @@ describe('TableEditColumn Plugin computeds', () => {
       expect(tableColumnsWithEditing(columns, 100))
         .toEqual([
           {
+            key: TABLE_EDIT_COMMAND_TYPE,
             type: TABLE_EDIT_COMMAND_TYPE,
-            id: 0,
             width: 100,
           },
           { original: { id: 1 } },

--- a/packages/dx-grid-core/src/plugins/table-edit-column/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/computeds.test.js
@@ -1,4 +1,4 @@
-import { EDIT_COMMANDS_TYPE } from './constants';
+import { TABLE_EDIT_COMMAND_TYPE } from './constants';
 import {
   tableColumnsWithEditing,
 } from './computeds';
@@ -11,7 +11,7 @@ describe('TableEditColumn Plugin computeds', () => {
       expect(tableColumnsWithEditing(columns, 100))
         .toEqual([
           {
-            type: EDIT_COMMANDS_TYPE,
+            type: TABLE_EDIT_COMMAND_TYPE,
             id: 0,
             width: 100,
           },

--- a/packages/dx-grid-core/src/plugins/table-edit-column/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/computeds.test.js
@@ -1,0 +1,23 @@
+import { EDIT_COMMANDS_TYPE } from './constants';
+import {
+  tableColumnsWithEditing,
+} from './computeds';
+
+describe('TableEditColumn Plugin computeds', () => {
+  describe('#tableColumnsWithEditing', () => {
+    it('should work', () => {
+      const columns = [{ original: { id: 1 } }, { original: { id: 2 } }];
+
+      expect(tableColumnsWithEditing(columns, 100))
+        .toEqual([
+          {
+            type: EDIT_COMMANDS_TYPE,
+            id: 0,
+            width: 100,
+          },
+          { original: { id: 1 } },
+          { original: { id: 2 } },
+        ]);
+    });
+  });
+});

--- a/packages/dx-grid-core/src/plugins/table-edit-column/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/constants.js
@@ -1,0 +1,1 @@
+export const EDIT_COMMAND_TYPE = 'editCommand';

--- a/packages/dx-grid-core/src/plugins/table-edit-column/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/constants.js
@@ -1,1 +1,1 @@
-export const EDIT_COMMAND_TYPE = 'editCommand';
+export const TABLE_EDIT_COMMAND_TYPE = 'editCommand';

--- a/packages/dx-grid-core/src/plugins/table-edit-column/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/helpers.js
@@ -3,11 +3,11 @@ import { TABLE_DATA_TYPE } from '../table-view/constants';
 import { TABLE_HEADING_TYPE } from '../table-header-row/constants';
 import { TABLE_EDIT_COMMAND_TYPE } from './constants';
 
-export const isHeaderEditCommandsTableCell = (row, column) =>
-  row.type === TABLE_HEADING_TYPE && column.type === TABLE_EDIT_COMMAND_TYPE;
-export const isEditNewRowCommandsTableCell = (row, column) =>
-  row.type === TABLE_ADDING_TYPE && column.type === TABLE_EDIT_COMMAND_TYPE;
-export const isDataEditCommandsTableCell = (row, column) =>
-  row.type === TABLE_DATA_TYPE && column.type === TABLE_EDIT_COMMAND_TYPE;
-export const isEditExistingRowCommandsTableCell = (row, column) =>
-  row.type === TABLE_EDITING_TYPE && column.type === TABLE_EDIT_COMMAND_TYPE;
+export const isHeaderEditCommandsTableCell = (tableRow, tableColumn) =>
+  tableRow.type === TABLE_HEADING_TYPE && tableColumn.type === TABLE_EDIT_COMMAND_TYPE;
+export const isEditNewRowCommandsTableCell = (tableRow, tableColumn) =>
+  tableRow.type === TABLE_ADDING_TYPE && tableColumn.type === TABLE_EDIT_COMMAND_TYPE;
+export const isDataEditCommandsTableCell = (tableRow, tableColumn) =>
+  tableRow.type === TABLE_DATA_TYPE && tableColumn.type === TABLE_EDIT_COMMAND_TYPE;
+export const isEditExistingRowCommandsTableCell = (tableRow, tableColumn) =>
+  tableRow.type === TABLE_EDITING_TYPE && tableColumn.type === TABLE_EDIT_COMMAND_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-edit-column/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/helpers.js
@@ -1,0 +1,13 @@
+import { ADD_TYPE, EDIT_TYPE } from '../table-edit-row/constants';
+import { DATA_TYPE } from '../table-view/constants';
+import { HEADING_TYPE } from '../table-header-row/constants';
+import { EDIT_COMMANDS_TYPE } from './constants';
+
+export const isHeaderEditCommandsTableCell = (row, column) =>
+  row.type === HEADING_TYPE && column.type === EDIT_COMMANDS_TYPE;
+export const isEditNewRowCommandsTableCell = (row, column) =>
+  row.type === ADD_TYPE && column.type === EDIT_COMMANDS_TYPE;
+export const isDataEditCommandsTableCell = (row, column) =>
+  row.type === DATA_TYPE && column.type === EDIT_COMMANDS_TYPE;
+export const isEditExistingRowCommandsTableCell = (row, column) =>
+  row.type === EDIT_TYPE && column.type === EDIT_COMMANDS_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-edit-column/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/helpers.js
@@ -1,13 +1,13 @@
-import { ADD_TYPE, EDIT_TYPE } from '../table-edit-row/constants';
-import { DATA_TYPE } from '../table-view/constants';
-import { HEADING_TYPE } from '../table-header-row/constants';
-import { EDIT_COMMANDS_TYPE } from './constants';
+import { TABLE_ADDING_TYPE, TABLE_EDITING_TYPE } from '../table-edit-row/constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
+import { TABLE_HEADING_TYPE } from '../table-header-row/constants';
+import { TABLE_EDIT_COMMAND_TYPE } from './constants';
 
 export const isHeaderEditCommandsTableCell = (row, column) =>
-  row.type === HEADING_TYPE && column.type === EDIT_COMMANDS_TYPE;
+  row.type === TABLE_HEADING_TYPE && column.type === TABLE_EDIT_COMMAND_TYPE;
 export const isEditNewRowCommandsTableCell = (row, column) =>
-  row.type === ADD_TYPE && column.type === EDIT_COMMANDS_TYPE;
+  row.type === TABLE_ADDING_TYPE && column.type === TABLE_EDIT_COMMAND_TYPE;
 export const isDataEditCommandsTableCell = (row, column) =>
-  row.type === DATA_TYPE && column.type === EDIT_COMMANDS_TYPE;
+  row.type === TABLE_DATA_TYPE && column.type === TABLE_EDIT_COMMAND_TYPE;
 export const isEditExistingRowCommandsTableCell = (row, column) =>
-  row.type === EDIT_TYPE && column.type === EDIT_COMMANDS_TYPE;
+  row.type === TABLE_EDITING_TYPE && column.type === TABLE_EDIT_COMMAND_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-edit-column/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/helpers.js
@@ -3,7 +3,7 @@ import { TABLE_DATA_TYPE } from '../table-view/constants';
 import { TABLE_HEADING_TYPE } from '../table-header-row/constants';
 import { TABLE_EDIT_COMMAND_TYPE } from './constants';
 
-export const isHeaderEditCommandsTableCell = (tableRow, tableColumn) =>
+export const isHeadingEditCommandsTableCell = (tableRow, tableColumn) =>
   tableRow.type === TABLE_HEADING_TYPE && tableColumn.type === TABLE_EDIT_COMMAND_TYPE;
 export const isEditNewRowCommandsTableCell = (tableRow, tableColumn) =>
   tableRow.type === TABLE_ADDING_TYPE && tableColumn.type === TABLE_EDIT_COMMAND_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-edit-column/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/helpers.test.js
@@ -12,7 +12,10 @@ import {
 describe('TableEditColumn Plugin helpers', () => {
   describe('#isHeaderEditCommandsTableCell', () => {
     it('should work', () => {
-      expect(isHeaderEditCommandsTableCell({ type: TABLE_HEADING_TYPE }, { type: TABLE_EDIT_COMMAND_TYPE }))
+      expect(isHeaderEditCommandsTableCell(
+        { type: TABLE_HEADING_TYPE },
+        { type: TABLE_EDIT_COMMAND_TYPE },
+      ))
         .toBeTruthy();
       expect(isHeaderEditCommandsTableCell({ type: TABLE_HEADING_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
@@ -22,7 +25,10 @@ describe('TableEditColumn Plugin helpers', () => {
   });
   describe('#isDataEditCommandsTableCell', () => {
     it('should work', () => {
-      expect(isDataEditCommandsTableCell({ type: TABLE_DATA_TYPE }, { type: TABLE_EDIT_COMMAND_TYPE }))
+      expect(isDataEditCommandsTableCell(
+        { type: TABLE_DATA_TYPE },
+        { type: TABLE_EDIT_COMMAND_TYPE },
+      ))
         .toBeTruthy();
       expect(isDataEditCommandsTableCell({ type: TABLE_DATA_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
@@ -32,7 +38,10 @@ describe('TableEditColumn Plugin helpers', () => {
   });
   describe('#isEditNewRowCommandsTableCell', () => {
     it('should work', () => {
-      expect(isEditNewRowCommandsTableCell({ type: TABLE_ADDING_TYPE }, { type: TABLE_EDIT_COMMAND_TYPE }))
+      expect(isEditNewRowCommandsTableCell(
+        { type: TABLE_ADDING_TYPE },
+        { type: TABLE_EDIT_COMMAND_TYPE },
+      ))
         .toBeTruthy();
       expect(isEditNewRowCommandsTableCell({ type: TABLE_ADDING_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
@@ -42,7 +51,10 @@ describe('TableEditColumn Plugin helpers', () => {
   });
   describe('#isEditExistingRowCommandsTableCell', () => {
     it('should work', () => {
-      expect(isEditExistingRowCommandsTableCell({ type: TABLE_EDITING_TYPE }, { type: TABLE_EDIT_COMMAND_TYPE }))
+      expect(isEditExistingRowCommandsTableCell(
+        { type: TABLE_EDITING_TYPE },
+        { type: TABLE_EDIT_COMMAND_TYPE },
+      ))
         .toBeTruthy();
       expect(isEditExistingRowCommandsTableCell({ type: TABLE_EDITING_TYPE }, { type: 'undefined' }))
         .toBeFalsy();

--- a/packages/dx-grid-core/src/plugins/table-edit-column/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/helpers.test.js
@@ -1,7 +1,7 @@
-import { ADD_TYPE, EDIT_TYPE } from '../table-edit-row/constants';
-import { DATA_TYPE } from '../table-view/constants';
-import { HEADING_TYPE } from '../table-header-row/constants';
-import { EDIT_COMMANDS_TYPE } from './constants';
+import { TABLE_ADDING_TYPE, TABLE_EDITING_TYPE } from '../table-edit-row/constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
+import { TABLE_HEADING_TYPE } from '../table-header-row/constants';
+import { TABLE_EDIT_COMMAND_TYPE } from './constants';
 import {
   isHeaderEditCommandsTableCell,
   isDataEditCommandsTableCell,
@@ -12,41 +12,41 @@ import {
 describe('TableEditColumn Plugin helpers', () => {
   describe('#isHeaderEditCommandsTableCell', () => {
     it('should work', () => {
-      expect(isHeaderEditCommandsTableCell({ type: HEADING_TYPE }, { type: EDIT_COMMANDS_TYPE }))
+      expect(isHeaderEditCommandsTableCell({ type: TABLE_HEADING_TYPE }, { type: TABLE_EDIT_COMMAND_TYPE }))
         .toBeTruthy();
-      expect(isHeaderEditCommandsTableCell({ type: HEADING_TYPE }, { type: 'undefined' }))
+      expect(isHeaderEditCommandsTableCell({ type: TABLE_HEADING_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
-      expect(isHeaderEditCommandsTableCell({ type: 'undefined' }, { type: EDIT_COMMANDS_TYPE }))
+      expect(isHeaderEditCommandsTableCell({ type: 'undefined' }, { type: TABLE_EDIT_COMMAND_TYPE }))
         .toBeFalsy();
     });
   });
   describe('#isDataEditCommandsTableCell', () => {
     it('should work', () => {
-      expect(isDataEditCommandsTableCell({ type: DATA_TYPE }, { type: EDIT_COMMANDS_TYPE }))
+      expect(isDataEditCommandsTableCell({ type: TABLE_DATA_TYPE }, { type: TABLE_EDIT_COMMAND_TYPE }))
         .toBeTruthy();
-      expect(isDataEditCommandsTableCell({ type: DATA_TYPE }, { type: 'undefined' }))
+      expect(isDataEditCommandsTableCell({ type: TABLE_DATA_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
-      expect(isDataEditCommandsTableCell({ type: 'undefined' }, { type: EDIT_COMMANDS_TYPE }))
+      expect(isDataEditCommandsTableCell({ type: 'undefined' }, { type: TABLE_EDIT_COMMAND_TYPE }))
         .toBeFalsy();
     });
   });
   describe('#isEditNewRowCommandsTableCell', () => {
     it('should work', () => {
-      expect(isEditNewRowCommandsTableCell({ type: ADD_TYPE }, { type: EDIT_COMMANDS_TYPE }))
+      expect(isEditNewRowCommandsTableCell({ type: TABLE_ADDING_TYPE }, { type: TABLE_EDIT_COMMAND_TYPE }))
         .toBeTruthy();
-      expect(isEditNewRowCommandsTableCell({ type: ADD_TYPE }, { type: 'undefined' }))
+      expect(isEditNewRowCommandsTableCell({ type: TABLE_ADDING_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
-      expect(isEditNewRowCommandsTableCell({ type: 'undefined' }, { type: EDIT_COMMANDS_TYPE }))
+      expect(isEditNewRowCommandsTableCell({ type: 'undefined' }, { type: TABLE_EDIT_COMMAND_TYPE }))
         .toBeFalsy();
     });
   });
   describe('#isEditExistingRowCommandsTableCell', () => {
     it('should work', () => {
-      expect(isEditExistingRowCommandsTableCell({ type: EDIT_TYPE }, { type: EDIT_COMMANDS_TYPE }))
+      expect(isEditExistingRowCommandsTableCell({ type: TABLE_EDITING_TYPE }, { type: TABLE_EDIT_COMMAND_TYPE }))
         .toBeTruthy();
-      expect(isEditExistingRowCommandsTableCell({ type: EDIT_TYPE }, { type: 'undefined' }))
+      expect(isEditExistingRowCommandsTableCell({ type: TABLE_EDITING_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
-      expect(isEditExistingRowCommandsTableCell({ type: 'undefined' }, { type: EDIT_COMMANDS_TYPE }))
+      expect(isEditExistingRowCommandsTableCell({ type: 'undefined' }, { type: TABLE_EDIT_COMMAND_TYPE }))
         .toBeFalsy();
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-edit-column/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/helpers.test.js
@@ -3,23 +3,23 @@ import { TABLE_DATA_TYPE } from '../table-view/constants';
 import { TABLE_HEADING_TYPE } from '../table-header-row/constants';
 import { TABLE_EDIT_COMMAND_TYPE } from './constants';
 import {
-  isHeaderEditCommandsTableCell,
+  isHeadingEditCommandsTableCell,
   isDataEditCommandsTableCell,
   isEditNewRowCommandsTableCell,
   isEditExistingRowCommandsTableCell,
 } from './helpers';
 
 describe('TableEditColumn Plugin helpers', () => {
-  describe('#isHeaderEditCommandsTableCell', () => {
+  describe('#isHeadingEditCommandsTableCell', () => {
     it('should work', () => {
-      expect(isHeaderEditCommandsTableCell(
+      expect(isHeadingEditCommandsTableCell(
         { type: TABLE_HEADING_TYPE },
         { type: TABLE_EDIT_COMMAND_TYPE },
       ))
         .toBeTruthy();
-      expect(isHeaderEditCommandsTableCell({ type: TABLE_HEADING_TYPE }, { type: 'undefined' }))
+      expect(isHeadingEditCommandsTableCell({ type: TABLE_HEADING_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
-      expect(isHeaderEditCommandsTableCell({ type: 'undefined' }, { type: TABLE_EDIT_COMMAND_TYPE }))
+      expect(isHeadingEditCommandsTableCell({ type: 'undefined' }, { type: TABLE_EDIT_COMMAND_TYPE }))
         .toBeFalsy();
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-edit-column/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-column/helpers.test.js
@@ -1,0 +1,53 @@
+import { ADD_TYPE, EDIT_TYPE } from '../table-edit-row/constants';
+import { DATA_TYPE } from '../table-view/constants';
+import { HEADING_TYPE } from '../table-header-row/constants';
+import { EDIT_COMMANDS_TYPE } from './constants';
+import {
+  isHeaderEditCommandsTableCell,
+  isDataEditCommandsTableCell,
+  isEditNewRowCommandsTableCell,
+  isEditExistingRowCommandsTableCell,
+} from './helpers';
+
+describe('TableEditColumn Plugin helpers', () => {
+  describe('#isHeaderEditCommandsTableCell', () => {
+    it('should work', () => {
+      expect(isHeaderEditCommandsTableCell({ type: HEADING_TYPE }, { type: EDIT_COMMANDS_TYPE }))
+        .toBeTruthy();
+      expect(isHeaderEditCommandsTableCell({ type: HEADING_TYPE }, { type: 'undefined' }))
+        .toBeFalsy();
+      expect(isHeaderEditCommandsTableCell({ type: 'undefined' }, { type: EDIT_COMMANDS_TYPE }))
+        .toBeFalsy();
+    });
+  });
+  describe('#isDataEditCommandsTableCell', () => {
+    it('should work', () => {
+      expect(isDataEditCommandsTableCell({ type: DATA_TYPE }, { type: EDIT_COMMANDS_TYPE }))
+        .toBeTruthy();
+      expect(isDataEditCommandsTableCell({ type: DATA_TYPE }, { type: 'undefined' }))
+        .toBeFalsy();
+      expect(isDataEditCommandsTableCell({ type: 'undefined' }, { type: EDIT_COMMANDS_TYPE }))
+        .toBeFalsy();
+    });
+  });
+  describe('#isEditNewRowCommandsTableCell', () => {
+    it('should work', () => {
+      expect(isEditNewRowCommandsTableCell({ type: ADD_TYPE }, { type: EDIT_COMMANDS_TYPE }))
+        .toBeTruthy();
+      expect(isEditNewRowCommandsTableCell({ type: ADD_TYPE }, { type: 'undefined' }))
+        .toBeFalsy();
+      expect(isEditNewRowCommandsTableCell({ type: 'undefined' }, { type: EDIT_COMMANDS_TYPE }))
+        .toBeFalsy();
+    });
+  });
+  describe('#isEditExistingRowCommandsTableCell', () => {
+    it('should work', () => {
+      expect(isEditExistingRowCommandsTableCell({ type: EDIT_TYPE }, { type: EDIT_COMMANDS_TYPE }))
+        .toBeTruthy();
+      expect(isEditExistingRowCommandsTableCell({ type: EDIT_TYPE }, { type: 'undefined' }))
+        .toBeFalsy();
+      expect(isEditExistingRowCommandsTableCell({ type: 'undefined' }, { type: EDIT_COMMANDS_TYPE }))
+        .toBeFalsy();
+    });
+  });
+});

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
@@ -1,4 +1,4 @@
-import { ADD_TYPE, EDIT_TYPE } from './constants';
+import { TABLE_ADDING_TYPE, TABLE_EDITING_TYPE } from './constants';
 
 // TODO: remove getRowId
 export const tableRowsWithEditing = (rows, editingRows, addedRows, getRowId, rowHeight) => {
@@ -8,7 +8,7 @@ export const tableRowsWithEditing = (rows, editingRows, addedRows, getRowId, row
       rowIds.has(getRowId(row.original))
       ? {
         ...row,
-        type: EDIT_TYPE,
+        type: TABLE_EDITING_TYPE,
         height: rowHeight,
       }
       : row
@@ -16,7 +16,7 @@ export const tableRowsWithEditing = (rows, editingRows, addedRows, getRowId, row
 
   const addedTableRows = addedRows
     .map((row, rowIndex) => ({
-      type: ADD_TYPE,
+      type: TABLE_ADDING_TYPE,
       id: rowIndex,
       height: rowHeight,
       original: row,

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
@@ -1,11 +1,11 @@
 import { TABLE_ADDING_TYPE, TABLE_EDITING_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 
-// TODO: remove getRowId
-export const tableRowsWithEditing = (tableRows, editingRows, addedRows, getRowId, rowHeight) => {
+export const tableRowsWithEditing = (tableRows, editingRows, addedRows, rowHeight) => {
   const rowIds = new Set(editingRows);
   const editedTableRows = tableRows
     .map(tableRow => (
-      rowIds.has(getRowId(tableRow.row))
+      tableRow.type === TABLE_DATA_TYPE && rowIds.has(tableRow.id)
       ? {
         ...tableRow,
         type: TABLE_EDITING_TYPE,

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
@@ -5,9 +5,10 @@ export const tableRowsWithEditing = (tableRows, editingRows, addedRows, rowHeigh
   const rowIds = new Set(editingRows);
   const editedTableRows = tableRows
     .map(tableRow => (
-      tableRow.type === TABLE_DATA_TYPE && rowIds.has(tableRow.id)
+      tableRow.type === TABLE_DATA_TYPE && rowIds.has(tableRow.rowId)
       ? {
         ...tableRow,
+        key: `${TABLE_EDITING_TYPE}_${tableRow.rowId}`,
         type: TABLE_EDITING_TYPE,
         height: rowHeight,
       }
@@ -16,8 +17,9 @@ export const tableRowsWithEditing = (tableRows, editingRows, addedRows, rowHeigh
 
   const addedTableRows = addedRows
     .map((row, rowIndex) => ({
+      key: `${TABLE_ADDING_TYPE}_${rowIndex}`,
       type: TABLE_ADDING_TYPE,
-      id: rowIndex,
+      rowId: rowIndex,
       height: rowHeight,
       row,
     }));

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
@@ -1,17 +1,17 @@
 import { TABLE_ADDING_TYPE, TABLE_EDITING_TYPE } from './constants';
 
 // TODO: remove getRowId
-export const tableRowsWithEditing = (rows, editingRows, addedRows, getRowId, rowHeight) => {
+export const tableRowsWithEditing = (tableRows, editingRows, addedRows, getRowId, rowHeight) => {
   const rowIds = new Set(editingRows);
-  const tableRows = rows
-    .map(row => (
-      rowIds.has(getRowId(row.original))
+  const editedTableRows = tableRows
+    .map(tableRow => (
+      rowIds.has(getRowId(tableRow.row))
       ? {
-        ...row,
+        ...tableRow,
         type: TABLE_EDITING_TYPE,
         height: rowHeight,
       }
-      : row
+      : tableRow
     ));
 
   const addedTableRows = addedRows
@@ -19,11 +19,11 @@ export const tableRowsWithEditing = (rows, editingRows, addedRows, getRowId, row
       type: TABLE_ADDING_TYPE,
       id: rowIndex,
       height: rowHeight,
-      original: row,
+      row,
     }));
 
   return [
     ...addedTableRows,
-    ...tableRows,
+    ...editedTableRows,
   ];
 };

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
@@ -1,23 +1,27 @@
-export const rowsWithEditing = (rows, editingRows, addedRows, getRowId, rowHeight) => {
+import { ADD_TYPE, EDIT_TYPE } from './constants';
+
+// TODO: remove getRowId
+export const tableRowsWithEditing = (rows, editingRows, addedRows, getRowId, rowHeight) => {
   const rowIds = new Set(editingRows);
-  const tableRows = rows.map(
-    row => (
-      rowIds.has(getRowId(row))
+  const tableRows = rows
+    .map(row => (
+      rowIds.has(getRowId(row.original))
       ? {
-        type: 'edit',
-        _originalRow: row,
+        ...row,
+        type: EDIT_TYPE,
         height: rowHeight,
       }
       : row
-    ),
-  );
-  const addedTableRows = addedRows.map((row, index) => ({
-    type: 'edit',
-    isNew: true,
-    index,
-    _originalRow: row,
-    height: rowHeight,
-  }));
+    ));
+
+  const addedTableRows = addedRows
+    .map((row, rowIndex) => ({
+      type: ADD_TYPE,
+      id: rowIndex,
+      height: rowHeight,
+      original: row,
+    }));
+
   return [
     ...addedTableRows,
     ...tableRows,

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
@@ -3,7 +3,7 @@ import {
   tableRowsWithEditing,
 } from './computeds';
 
-describe('EditRow computeds', () => {
+describe('TableEditRow Plugin computeds', () => {
   describe('#tableRowsWithEditing', () => {
     it('should work', () => {
       const rows = [{ original: { id: 1 } }, { original: { id: 2 } }];

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
@@ -8,9 +8,9 @@ describe('TableEditRow Plugin computeds', () => {
   describe('#tableRowsWithEditing', () => {
     it('should work', () => {
       const tableRows = [
-        { type: TABLE_DATA_TYPE, id: 1, row: 'row1' },
-        { type: TABLE_DATA_TYPE, id: 2, row: 'row2' },
-        { type: 'undefined', id: 2, row: 'row2' },
+        { type: TABLE_DATA_TYPE, rowId: 1, row: 'row1' },
+        { type: TABLE_DATA_TYPE, rowId: 2, row: 'row2' },
+        { type: 'undefined', rowId: 2, row: 'row2' },
       ];
       const editingRows = [2];
       const addedRows = [{ id: 3 }];
@@ -18,19 +18,21 @@ describe('TableEditRow Plugin computeds', () => {
       expect(tableRowsWithEditing(tableRows, editingRows, addedRows, 100))
         .toEqual([
           {
+            key: `${TABLE_ADDING_TYPE}_0`,
             type: TABLE_ADDING_TYPE,
-            id: 0,
+            rowId: 0,
             row: { id: 3 },
             height: 100,
           },
-          { type: TABLE_DATA_TYPE, id: 1, row: 'row1' },
+          { type: TABLE_DATA_TYPE, rowId: 1, row: 'row1' },
           {
+            key: `${TABLE_EDITING_TYPE}_2`,
             type: TABLE_EDITING_TYPE,
-            id: 2,
+            rowId: 2,
             row: 'row2',
             height: 100,
           },
-          { type: 'undefined', id: 2, row: 'row2' },
+          { type: 'undefined', rowId: 2, row: 'row2' },
         ]);
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
@@ -1,28 +1,28 @@
+import { ADD_TYPE, EDIT_TYPE } from './constants';
 import {
-    rowsWithEditing,
+  tableRowsWithEditing,
 } from './computeds';
 
 describe('EditRow computeds', () => {
-  describe('#rowsWithEditing', () => {
+  describe('#tableRowsWithEditing', () => {
     it('should work', () => {
-      const rows = [{ id: 1 }, { id: 2 }];
+      const rows = [{ original: { id: 1 } }, { original: { id: 2 } }];
       const editingRows = [2];
       const addedRows = [{ id: 3 }];
 
-      const computed = rowsWithEditing(rows, editingRows, addedRows, row => row.id);
-      expect(computed).toEqual([
-        {
-          index: 0,
-          type: 'edit',
-          _originalRow: { id: 3 },
-          isNew: true,
-        },
-        { id: 1 },
-        {
-          type: 'edit',
-          _originalRow: { id: 2 },
-        },
-      ]);
+      expect(tableRowsWithEditing(rows, editingRows, addedRows, row => row.id))
+        .toEqual([
+          {
+            type: ADD_TYPE,
+            id: 0,
+            original: { id: 3 },
+          },
+          { original: { id: 1 } },
+          {
+            type: EDIT_TYPE,
+            original: { id: 2 },
+          },
+        ]);
     });
   });
 });

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
@@ -1,4 +1,4 @@
-import { ADD_TYPE, EDIT_TYPE } from './constants';
+import { TABLE_ADDING_TYPE, TABLE_EDITING_TYPE } from './constants';
 import {
   tableRowsWithEditing,
 } from './computeds';
@@ -13,13 +13,13 @@ describe('TableEditRow Plugin computeds', () => {
       expect(tableRowsWithEditing(rows, editingRows, addedRows, row => row.id))
         .toEqual([
           {
-            type: ADD_TYPE,
+            type: TABLE_ADDING_TYPE,
             id: 0,
             original: { id: 3 },
           },
           { original: { id: 1 } },
           {
-            type: EDIT_TYPE,
+            type: TABLE_EDITING_TYPE,
             original: { id: 2 },
           },
         ]);

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
@@ -1,4 +1,5 @@
 import { TABLE_ADDING_TYPE, TABLE_EDITING_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 import {
   tableRowsWithEditing,
 } from './computeds';
@@ -6,22 +7,30 @@ import {
 describe('TableEditRow Plugin computeds', () => {
   describe('#tableRowsWithEditing', () => {
     it('should work', () => {
-      const rows = [{ original: { id: 1 } }, { original: { id: 2 } }];
+      const tableRows = [
+        { type: TABLE_DATA_TYPE, id: 1, row: 'row1' },
+        { type: TABLE_DATA_TYPE, id: 2, row: 'row2' },
+        { type: 'undefined', id: 2, row: 'row2' },
+      ];
       const editingRows = [2];
       const addedRows = [{ id: 3 }];
 
-      expect(tableRowsWithEditing(rows, editingRows, addedRows, row => row.id))
+      expect(tableRowsWithEditing(tableRows, editingRows, addedRows, 100))
         .toEqual([
           {
             type: TABLE_ADDING_TYPE,
             id: 0,
-            original: { id: 3 },
+            row: { id: 3 },
+            height: 100,
           },
-          { original: { id: 1 } },
+          { type: TABLE_DATA_TYPE, id: 1, row: 'row1' },
           {
             type: TABLE_EDITING_TYPE,
-            original: { id: 2 },
+            id: 2,
+            row: 'row2',
+            height: 100,
           },
+          { type: 'undefined', id: 2, row: 'row2' },
         ]);
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-edit-row/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/constants.js
@@ -1,0 +1,2 @@
+export const ADD_TYPE = 'add';
+export const EDIT_TYPE = 'edit';

--- a/packages/dx-grid-core/src/plugins/table-edit-row/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/constants.js
@@ -1,2 +1,2 @@
-export const ADD_TYPE = 'add';
-export const EDIT_TYPE = 'edit';
+export const TABLE_ADDING_TYPE = 'adding';
+export const TABLE_EDITING_TYPE = 'editing';

--- a/packages/dx-grid-core/src/plugins/table-edit-row/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/helpers.js
@@ -1,7 +1,7 @@
 import { TABLE_ADDING_TYPE, TABLE_EDITING_TYPE } from './constants';
 import { TABLE_DATA_TYPE } from '../table-view/constants';
 
-export const isEditNewTableCell = (row, column) =>
-  row.type === TABLE_ADDING_TYPE && column.type === TABLE_DATA_TYPE;
-export const isEditExistingTableCell = (row, column) =>
-  row.type === TABLE_EDITING_TYPE && column.type === TABLE_DATA_TYPE;
+export const isEditNewTableCell = (tableRow, tableColumn) =>
+  tableRow.type === TABLE_ADDING_TYPE && tableColumn.type === TABLE_DATA_TYPE;
+export const isEditExistingTableCell = (tableRow, tableColumn) =>
+  tableRow.type === TABLE_EDITING_TYPE && tableColumn.type === TABLE_DATA_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-edit-row/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/helpers.js
@@ -1,7 +1,7 @@
-import { ADD_TYPE, EDIT_TYPE } from './constants';
-import { DATA_TYPE } from '../table-view/constants';
+import { TABLE_ADDING_TYPE, TABLE_EDITING_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 
 export const isEditNewTableCell = (row, column) =>
-  row.type === ADD_TYPE && column.type === DATA_TYPE;
+  row.type === TABLE_ADDING_TYPE && column.type === TABLE_DATA_TYPE;
 export const isEditExistingTableCell = (row, column) =>
-  row.type === EDIT_TYPE && column.type === DATA_TYPE;
+  row.type === TABLE_EDITING_TYPE && column.type === TABLE_DATA_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-edit-row/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/helpers.js
@@ -1,0 +1,7 @@
+import { ADD_TYPE, EDIT_TYPE } from './constants';
+import { DATA_TYPE } from '../table-view/constants';
+
+export const isEditNewTableCell = (row, column) =>
+  row.type === ADD_TYPE && column.type === DATA_TYPE;
+export const isEditExistingTableCell = (row, column) =>
+  row.type === EDIT_TYPE && column.type === DATA_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-edit-row/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/helpers.test.js
@@ -5,7 +5,7 @@ import {
   isEditExistingTableCell,
 } from './helpers';
 
-describe('TableFilterRow Plugin helpers', () => {
+describe('TableEditRow Plugin helpers', () => {
   describe('#isEditNewTableCell', () => {
     it('should work', () => {
       expect(isEditNewTableCell({ type: ADD_TYPE }, { type: DATA_TYPE }))

--- a/packages/dx-grid-core/src/plugins/table-edit-row/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/helpers.test.js
@@ -1,5 +1,5 @@
-import { ADD_TYPE, EDIT_TYPE } from './constants';
-import { DATA_TYPE } from '../table-view/constants';
+import { TABLE_ADDING_TYPE, TABLE_EDITING_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 import {
   isEditNewTableCell,
   isEditExistingTableCell,
@@ -8,9 +8,9 @@ import {
 describe('TableEditRow Plugin helpers', () => {
   describe('#isEditNewTableCell', () => {
     it('should work', () => {
-      expect(isEditNewTableCell({ type: ADD_TYPE }, { type: DATA_TYPE }))
+      expect(isEditNewTableCell({ type: TABLE_ADDING_TYPE }, { type: TABLE_DATA_TYPE }))
         .toBeTruthy();
-      expect(isEditNewTableCell({ type: ADD_TYPE }, { type: 'undefined' }))
+      expect(isEditNewTableCell({ type: TABLE_ADDING_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
       expect(isEditNewTableCell({ type: 'undefined' }, { type: 'undefined' }))
         .toBeFalsy();
@@ -18,9 +18,9 @@ describe('TableEditRow Plugin helpers', () => {
   });
   describe('#isEditExistingTableCell', () => {
     it('should work', () => {
-      expect(isEditExistingTableCell({ type: EDIT_TYPE }, { type: DATA_TYPE }))
+      expect(isEditExistingTableCell({ type: TABLE_EDITING_TYPE }, { type: TABLE_DATA_TYPE }))
         .toBeTruthy();
-      expect(isEditExistingTableCell({ type: EDIT_TYPE }, { type: 'undefined' }))
+      expect(isEditExistingTableCell({ type: TABLE_EDITING_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
       expect(isEditExistingTableCell({ type: 'undefined' }, { type: 'undefined' }))
         .toBeFalsy();

--- a/packages/dx-grid-core/src/plugins/table-edit-row/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/helpers.test.js
@@ -1,0 +1,29 @@
+import { ADD_TYPE, EDIT_TYPE } from './constants';
+import { DATA_TYPE } from '../table-view/constants';
+import {
+  isEditNewTableCell,
+  isEditExistingTableCell,
+} from './helpers';
+
+describe('TableFilterRow Plugin helpers', () => {
+  describe('#isEditNewTableCell', () => {
+    it('should work', () => {
+      expect(isEditNewTableCell({ type: ADD_TYPE }, { type: DATA_TYPE }))
+        .toBeTruthy();
+      expect(isEditNewTableCell({ type: ADD_TYPE }, { type: 'undefined' }))
+        .toBeFalsy();
+      expect(isEditNewTableCell({ type: 'undefined' }, { type: 'undefined' }))
+        .toBeFalsy();
+    });
+  });
+  describe('#isEditExistingTableCell', () => {
+    it('should work', () => {
+      expect(isEditExistingTableCell({ type: EDIT_TYPE }, { type: DATA_TYPE }))
+        .toBeTruthy();
+      expect(isEditExistingTableCell({ type: EDIT_TYPE }, { type: 'undefined' }))
+        .toBeFalsy();
+      expect(isEditExistingTableCell({ type: 'undefined' }, { type: 'undefined' }))
+        .toBeFalsy();
+    });
+  });
+});

--- a/packages/dx-grid-core/src/plugins/table-filter-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/computeds.js
@@ -1,4 +1,4 @@
 import { TABLE_FILTER_TYPE } from './constants';
 
 export const tableHeaderRowsWithFilter = (headerRows, rowHeight) =>
-  [...headerRows, { type: TABLE_FILTER_TYPE, id: 0, height: rowHeight }];
+  [...headerRows, { key: TABLE_FILTER_TYPE, type: TABLE_FILTER_TYPE, height: rowHeight }];

--- a/packages/dx-grid-core/src/plugins/table-filter-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/computeds.js
@@ -1,1 +1,4 @@
-export const tableHeaderRowsWithFilter = (headerRows, rowHeight) => [...headerRows, { type: 'filter', height: rowHeight }];
+import { FILTER_TYPE } from './constants';
+
+export const tableHeaderRowsWithFilter = (headerRows, rowHeight) =>
+  [...headerRows, { type: FILTER_TYPE, id: 0, height: rowHeight }];

--- a/packages/dx-grid-core/src/plugins/table-filter-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/computeds.js
@@ -1,4 +1,4 @@
-import { FILTER_TYPE } from './constants';
+import { TABLE_FILTER_TYPE } from './constants';
 
 export const tableHeaderRowsWithFilter = (headerRows, rowHeight) =>
-  [...headerRows, { type: FILTER_TYPE, id: 0, height: rowHeight }];
+  [...headerRows, { type: TABLE_FILTER_TYPE, id: 0, height: rowHeight }];

--- a/packages/dx-grid-core/src/plugins/table-filter-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/computeds.test.js
@@ -7,7 +7,10 @@ describe('TableFilterRow Plugin computeds', () => {
   describe('#tableHeaderRowsWithFilter', () => {
     it('should work', () => {
       expect(tableHeaderRowsWithFilter([{}], 100))
-        .toEqual([{}, { type: TABLE_FILTER_TYPE, id: 0, height: 100 }]);
+        .toEqual([
+          {},
+          { key: TABLE_FILTER_TYPE, type: TABLE_FILTER_TYPE, height: 100 },
+        ]);
     });
   });
 });

--- a/packages/dx-grid-core/src/plugins/table-filter-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/computeds.test.js
@@ -1,4 +1,4 @@
-import { FILTER_TYPE } from './constants';
+import { TABLE_FILTER_TYPE } from './constants';
 import {
   tableHeaderRowsWithFilter,
 } from './computeds';
@@ -7,7 +7,7 @@ describe('TableFilterRow Plugin computeds', () => {
   describe('#tableHeaderRowsWithFilter', () => {
     it('should work', () => {
       expect(tableHeaderRowsWithFilter([{}], 100))
-        .toEqual([{}, { type: FILTER_TYPE, id: 0, height: 100 }]);
+        .toEqual([{}, { type: TABLE_FILTER_TYPE, id: 0, height: 100 }]);
     });
   });
 });

--- a/packages/dx-grid-core/src/plugins/table-filter-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/computeds.test.js
@@ -1,19 +1,13 @@
+import { FILTER_TYPE } from './constants';
 import {
-    tableHeaderRowsWithFilter,
+  tableHeaderRowsWithFilter,
 } from './computeds';
 
 describe('TableFilterRow Plugin computeds', () => {
   describe('#tableHeaderRowsWithFilter', () => {
-    const headerRows = [
-      { type: 'heading' },
-    ];
-
     it('should work', () => {
-      const rows = tableHeaderRowsWithFilter(headerRows, 100);
-
-      expect(rows).toHaveLength(2);
-      expect(rows[0]).toBe(headerRows[0]);
-      expect(rows[1]).toMatchObject({ type: 'filter', height: 100 });
+      expect(tableHeaderRowsWithFilter([{}], 100))
+        .toEqual([{}, { type: FILTER_TYPE, id: 0, height: 100 }]);
     });
   });
 });

--- a/packages/dx-grid-core/src/plugins/table-filter-row/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/constants.js
@@ -1,0 +1,1 @@
+export const FILTER_TYPE = 'filter';

--- a/packages/dx-grid-core/src/plugins/table-filter-row/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/constants.js
@@ -1,1 +1,1 @@
-export const FILTER_TYPE = 'filter';
+export const TABLE_FILTER_TYPE = 'filter';

--- a/packages/dx-grid-core/src/plugins/table-filter-row/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/helpers.js
@@ -1,0 +1,5 @@
+import { FILTER_TYPE } from './constants';
+import { DATA_TYPE } from '../table-view/constants';
+
+export const isFilterTableCell = (row, column) =>
+  row.type === FILTER_TYPE && column.type === DATA_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-filter-row/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/helpers.js
@@ -1,5 +1,5 @@
-import { FILTER_TYPE } from './constants';
-import { DATA_TYPE } from '../table-view/constants';
+import { TABLE_FILTER_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 
 export const isFilterTableCell = (row, column) =>
-  row.type === FILTER_TYPE && column.type === DATA_TYPE;
+  row.type === TABLE_FILTER_TYPE && column.type === TABLE_DATA_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-filter-row/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/helpers.js
@@ -1,5 +1,5 @@
 import { TABLE_FILTER_TYPE } from './constants';
 import { TABLE_DATA_TYPE } from '../table-view/constants';
 
-export const isFilterTableCell = (row, column) =>
-  row.type === TABLE_FILTER_TYPE && column.type === TABLE_DATA_TYPE;
+export const isFilterTableCell = (tableRow, tableColumn) =>
+  tableRow.type === TABLE_FILTER_TYPE && tableColumn.type === TABLE_DATA_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-filter-row/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/helpers.test.js
@@ -1,5 +1,5 @@
-import { FILTER_TYPE } from './constants';
-import { DATA_TYPE } from '../table-view/constants';
+import { TABLE_FILTER_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 import {
   isFilterTableCell,
 } from './helpers';
@@ -7,9 +7,9 @@ import {
 describe('TableFilterRow Plugin helpers', () => {
   describe('#isFilterTableCell', () => {
     it('should work', () => {
-      expect(isFilterTableCell({ type: FILTER_TYPE }, { type: DATA_TYPE }))
+      expect(isFilterTableCell({ type: TABLE_FILTER_TYPE }, { type: TABLE_DATA_TYPE }))
         .toBeTruthy();
-      expect(isFilterTableCell({ type: FILTER_TYPE }, { type: 'undefined' }))
+      expect(isFilterTableCell({ type: TABLE_FILTER_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
       expect(isFilterTableCell({ type: 'undefined' }, { type: 'undefined' }))
         .toBeFalsy();

--- a/packages/dx-grid-core/src/plugins/table-filter-row/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-filter-row/helpers.test.js
@@ -1,0 +1,18 @@
+import { FILTER_TYPE } from './constants';
+import { DATA_TYPE } from '../table-view/constants';
+import {
+  isFilterTableCell,
+} from './helpers';
+
+describe('TableFilterRow Plugin helpers', () => {
+  describe('#isFilterTableCell', () => {
+    it('should work', () => {
+      expect(isFilterTableCell({ type: FILTER_TYPE }, { type: DATA_TYPE }))
+        .toBeTruthy();
+      expect(isFilterTableCell({ type: FILTER_TYPE }, { type: 'undefined' }))
+        .toBeFalsy();
+      expect(isFilterTableCell({ type: 'undefined' }, { type: 'undefined' }))
+        .toBeFalsy();
+    });
+  });
+});

--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.js
@@ -1,13 +1,12 @@
 import { TABLE_DATA_TYPE } from '../table-view/constants';
 import { TABLE_GROUP_TYPE } from './constants';
-import { tableKeyGetter } from '../../utils/table';
 
 const tableColumnsWithDraftGrouping = (tableColumns, draftGrouping) =>
   tableColumns
     .reduce((acc, tableColumn) => {
       const columnDraftGrouping = draftGrouping
         .find(grouping => (tableColumn.type === TABLE_DATA_TYPE
-          && grouping.columnName === tableColumn.id));
+          && grouping.columnName === tableColumn.columnId));
       if (!columnDraftGrouping) {
         return [...acc, tableColumn];
       } else if (columnDraftGrouping.mode === 'remove' || columnDraftGrouping.mode === 'add') {
@@ -23,17 +22,26 @@ export const tableColumnsWithGrouping = (
   tableColumns, grouping, draftGrouping, groupIndentColumnWidth,
 ) => [
   ...grouping.map(group =>
-    ({ type: TABLE_GROUP_TYPE, id: group.columnName, width: groupIndentColumnWidth })),
+    ({
+      key: `${TABLE_GROUP_TYPE}_${group.columnName}`,
+      type: TABLE_GROUP_TYPE,
+      groupKey: group.columnName,
+      width: groupIndentColumnWidth,
+    })),
   ...tableColumnsWithDraftGrouping(tableColumns, draftGrouping),
 ];
 
 export const tableRowsWithGrouping = tableRows =>
   tableRows.map((tableRow) => {
     if (tableRow.type !== TABLE_DATA_TYPE || tableRow.row.type !== 'groupRow') return tableRow;
+    const groupKey = tableRow.row.column.name;
+    const groupValue = tableRow.row.value;
     return {
       ...tableRow,
-      id: `${tableRow.row.column.name}_${tableRow.row.key}`,
+      key: `${TABLE_GROUP_TYPE}_${groupKey}_${groupValue}`,
       type: TABLE_GROUP_TYPE,
-      colSpanStart: tableKeyGetter({ type: TABLE_GROUP_TYPE, id: tableRow.row.column.name }),
+      groupKey,
+      groupValue,
+      colSpanStart: `${TABLE_GROUP_TYPE}_${groupKey}`,
     };
   });

--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.js
@@ -1,18 +1,20 @@
-const tableColumnsWithDraftGrouping = (columns, grouping) => columns.reduce((acc, column) => {
-  const currentColumn = grouping.find(g => (g.columnName === column.name));
-  if (!currentColumn) {
-    acc.push(column);
-  } else if (currentColumn.mode === 'remove' || currentColumn.mode === 'add') {
-    acc.push({
-      ...column,
-      isDraft: true,
-    });
-  }
-  return acc;
-}, []);
+const tableColumnsWithDraftGrouping = (tableColumns, grouping) =>
+  tableColumns
+  .reduce((acc, tableColumn) => {
+    const currentColumn = grouping.find(g => (g.columnName === tableColumn.name));
+    if (!currentColumn) {
+      acc.push(tableColumn);
+    } else if (currentColumn.mode === 'remove' || currentColumn.mode === 'add') {
+      acc.push({
+        ...tableColumn,
+        isDraft: true,
+      });
+    }
+    return acc;
+  }, []);
 
-export const tableColumnsWithGrouping = (columns, grouping,
+export const tableColumnsWithGrouping = (tableColumns, grouping,
   draftGrouping, groupIndentColumnWidth) => [
     ...grouping.map(group => ({ type: 'groupColumn', group, width: groupIndentColumnWidth })),
-    ...tableColumnsWithDraftGrouping(columns, draftGrouping),
+    ...tableColumnsWithDraftGrouping(tableColumns, draftGrouping),
   ];

--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.js
@@ -1,27 +1,39 @@
-const tableColumnsWithDraftGrouping = (tableColumns, grouping) =>
-  tableColumns
-  .reduce((acc, tableColumn) => {
-    const currentColumn = grouping.find(g => (g.columnName === tableColumn.name));
-    if (!currentColumn) {
-      acc.push(tableColumn);
-    } else if (currentColumn.mode === 'remove' || currentColumn.mode === 'add') {
-      acc.push({
-        ...tableColumn,
-        isDraft: true,
-      });
-    }
-    return acc;
-  }, []);
+import { TABLE_DATA_TYPE } from '../table-view/constants';
+import { TABLE_GROUP_TYPE } from './constants';
+import { tableKeyGetter } from '../../utils/table';
 
-export const tableColumnsWithGrouping = (tableColumns, grouping,
-  draftGrouping, groupIndentColumnWidth) => [
-    ...grouping.map(group =>
-      ({ type: 'groupColumn', id: group.columnName, group, width: groupIndentColumnWidth })),
-    ...tableColumnsWithDraftGrouping(tableColumns, draftGrouping),
-  ];
+const tableColumnsWithDraftGrouping = (tableColumns, draftGrouping) =>
+  tableColumns
+    .reduce((acc, tableColumn) => {
+      const columnDraftGrouping = draftGrouping
+        .find(grouping => (tableColumn.type === TABLE_DATA_TYPE
+          && grouping.columnName === tableColumn.id));
+      if (!columnDraftGrouping) {
+        return [...acc, tableColumn];
+      } else if (columnDraftGrouping.mode === 'remove' || columnDraftGrouping.mode === 'add') {
+        return [...acc, {
+          ...tableColumn,
+          isDraft: true,
+        }];
+      }
+      return acc;
+    }, []);
+
+export const tableColumnsWithGrouping = (
+  tableColumns, grouping, draftGrouping, groupIndentColumnWidth,
+) => [
+  ...grouping.map(group =>
+    ({ type: TABLE_GROUP_TYPE, id: group.columnName, width: groupIndentColumnWidth })),
+  ...tableColumnsWithDraftGrouping(tableColumns, draftGrouping),
+];
 
 export const tableRowsWithGrouping = tableRows =>
   tableRows.map((tableRow) => {
-    if (tableRow.type !== 'groupRow') return tableRow;
-    return { ...tableRow, colSpanStart: `groupColumn_${tableRow.id}` };
+    if (tableRow.type !== TABLE_DATA_TYPE || tableRow.row.type !== 'groupRow') return tableRow;
+    return {
+      ...tableRow,
+      id: `${tableRow.row.column.name}_${tableRow.row.key}`,
+      type: TABLE_GROUP_TYPE,
+      colSpanStart: tableKeyGetter({ type: TABLE_GROUP_TYPE, id: tableRow.row.column.name }),
+    };
   });

--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.js
@@ -6,7 +6,7 @@ const tableColumnsWithDraftGrouping = (tableColumns, draftGrouping) =>
     .reduce((acc, tableColumn) => {
       const columnDraftGrouping = draftGrouping
         .find(grouping => (tableColumn.type === TABLE_DATA_TYPE
-          && grouping.columnName === tableColumn.columnId));
+          && grouping.columnName === tableColumn.column.name));
       if (!columnDraftGrouping) {
         return [...acc, tableColumn];
       } else if (columnDraftGrouping.mode === 'remove' || columnDraftGrouping.mode === 'add') {

--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.js
@@ -8,11 +8,11 @@ import {
 describe('TableGroupRow Plugin computeds', () => {
   describe('#tableColumnsWithGrouping', () => {
     const tableColumns = [
-      { type: 'undefined', columnId: 'c', column: 'column_a' },
-      { type: TABLE_DATA_TYPE, columnId: 'a', column: 'column_a' },
-      { type: TABLE_DATA_TYPE, columnId: 'b', column: 'column_b' },
-      { type: TABLE_DATA_TYPE, columnId: 'c', column: 'column_c' },
-      { type: TABLE_DATA_TYPE, columnId: 'd', column: 'column_d' },
+      { type: 'undefined', columnId: 'c', column: { name: 'a' } },
+      { type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
+      { type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+      { type: TABLE_DATA_TYPE, columnId: 'c', column: { name: 'c' } },
+      { type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
     ];
     const grouping = [
       { columnName: 'a' },
@@ -24,9 +24,9 @@ describe('TableGroupRow Plugin computeds', () => {
         .toEqual([
           { key: `${TABLE_GROUP_TYPE}_a`, type: TABLE_GROUP_TYPE, groupKey: 'a', width: 123 },
           { key: `${TABLE_GROUP_TYPE}_c`, type: TABLE_GROUP_TYPE, groupKey: 'c', width: 123 },
-          { type: 'undefined', columnId: 'c', column: 'column_a' },
-          { type: TABLE_DATA_TYPE, columnId: 'b', column: 'column_b' },
-          { type: TABLE_DATA_TYPE, columnId: 'd', column: 'column_d' },
+          { type: 'undefined', columnId: 'c', column: { name: 'a' } },
+          { type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+          { type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
         ]);
     });
 
@@ -39,10 +39,10 @@ describe('TableGroupRow Plugin computeds', () => {
         .toEqual([
           { key: `${TABLE_GROUP_TYPE}_a`, type: TABLE_GROUP_TYPE, groupKey: 'a', width: 123 },
           { key: `${TABLE_GROUP_TYPE}_c`, type: TABLE_GROUP_TYPE, groupKey: 'c', width: 123 },
-          { type: 'undefined', columnId: 'c', column: 'column_a' },
-          { type: TABLE_DATA_TYPE, columnId: 'b', column: 'column_b' },
-          { type: TABLE_DATA_TYPE, columnId: 'c', column: 'column_c', isDraft: true },
-          { type: TABLE_DATA_TYPE, columnId: 'd', column: 'column_d' },
+          { type: 'undefined', columnId: 'c', column: { name: 'a' } },
+          { type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+          { type: TABLE_DATA_TYPE, columnId: 'c', column: { name: 'c' }, isDraft: true },
+          { type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
         ]);
     });
 
@@ -55,10 +55,10 @@ describe('TableGroupRow Plugin computeds', () => {
         .toEqual([
           { key: `${TABLE_GROUP_TYPE}_a`, type: TABLE_GROUP_TYPE, groupKey: 'a', width: 123 },
           { key: `${TABLE_GROUP_TYPE}_c`, type: TABLE_GROUP_TYPE, groupKey: 'c', width: 123 },
-          { type: 'undefined', columnId: 'c', column: 'column_a' },
-          { type: TABLE_DATA_TYPE, columnId: 'b', column: 'column_b' },
-          { type: TABLE_DATA_TYPE, columnId: 'c', column: 'column_c', isDraft: true },
-          { type: TABLE_DATA_TYPE, columnId: 'd', column: 'column_d' },
+          { type: 'undefined', columnId: 'c', column: { name: 'a' } },
+          { type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+          { type: TABLE_DATA_TYPE, columnId: 'c', column: { name: 'c' }, isDraft: true },
+          { type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
         ]);
     });
 
@@ -71,9 +71,9 @@ describe('TableGroupRow Plugin computeds', () => {
         .toEqual([
           { key: `${TABLE_GROUP_TYPE}_a`, type: TABLE_GROUP_TYPE, groupKey: 'a', width: 123 },
           { key: `${TABLE_GROUP_TYPE}_c`, type: TABLE_GROUP_TYPE, groupKey: 'c', width: 123 },
-          { type: 'undefined', columnId: 'c', column: 'column_a' },
-          { type: TABLE_DATA_TYPE, columnId: 'b', column: 'column_b' },
-          { type: TABLE_DATA_TYPE, columnId: 'd', column: 'column_d' },
+          { type: 'undefined', columnId: 'c', column: { name: 'a' } },
+          { type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+          { type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
         ]);
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.js
@@ -8,11 +8,11 @@ import {
 describe('TableGroupRow Plugin computeds', () => {
   describe('#tableColumnsWithGrouping', () => {
     const tableColumns = [
-      { type: 'undefined', columnId: 'c', column: { name: 'a' } },
-      { type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
-      { type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
-      { type: TABLE_DATA_TYPE, columnId: 'c', column: { name: 'c' } },
-      { type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
+      { type: 'undefined', column: { name: 'a' } },
+      { type: TABLE_DATA_TYPE, column: { name: 'a' } },
+      { type: TABLE_DATA_TYPE, column: { name: 'b' } },
+      { type: TABLE_DATA_TYPE, column: { name: 'c' } },
+      { type: TABLE_DATA_TYPE, column: { name: 'd' } },
     ];
     const grouping = [
       { columnName: 'a' },
@@ -24,9 +24,9 @@ describe('TableGroupRow Plugin computeds', () => {
         .toEqual([
           { key: `${TABLE_GROUP_TYPE}_a`, type: TABLE_GROUP_TYPE, groupKey: 'a', width: 123 },
           { key: `${TABLE_GROUP_TYPE}_c`, type: TABLE_GROUP_TYPE, groupKey: 'c', width: 123 },
-          { type: 'undefined', columnId: 'c', column: { name: 'a' } },
-          { type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
-          { type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
+          { type: 'undefined', column: { name: 'a' } },
+          { type: TABLE_DATA_TYPE, column: { name: 'b' } },
+          { type: TABLE_DATA_TYPE, column: { name: 'd' } },
         ]);
     });
 
@@ -39,10 +39,10 @@ describe('TableGroupRow Plugin computeds', () => {
         .toEqual([
           { key: `${TABLE_GROUP_TYPE}_a`, type: TABLE_GROUP_TYPE, groupKey: 'a', width: 123 },
           { key: `${TABLE_GROUP_TYPE}_c`, type: TABLE_GROUP_TYPE, groupKey: 'c', width: 123 },
-          { type: 'undefined', columnId: 'c', column: { name: 'a' } },
-          { type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
-          { type: TABLE_DATA_TYPE, columnId: 'c', column: { name: 'c' }, isDraft: true },
-          { type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
+          { type: 'undefined', column: { name: 'a' } },
+          { type: TABLE_DATA_TYPE, column: { name: 'b' } },
+          { type: TABLE_DATA_TYPE, column: { name: 'c' }, isDraft: true },
+          { type: TABLE_DATA_TYPE, column: { name: 'd' } },
         ]);
     });
 
@@ -55,10 +55,10 @@ describe('TableGroupRow Plugin computeds', () => {
         .toEqual([
           { key: `${TABLE_GROUP_TYPE}_a`, type: TABLE_GROUP_TYPE, groupKey: 'a', width: 123 },
           { key: `${TABLE_GROUP_TYPE}_c`, type: TABLE_GROUP_TYPE, groupKey: 'c', width: 123 },
-          { type: 'undefined', columnId: 'c', column: { name: 'a' } },
-          { type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
-          { type: TABLE_DATA_TYPE, columnId: 'c', column: { name: 'c' }, isDraft: true },
-          { type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
+          { type: 'undefined', column: { name: 'a' } },
+          { type: TABLE_DATA_TYPE, column: { name: 'b' } },
+          { type: TABLE_DATA_TYPE, column: { name: 'c' }, isDraft: true },
+          { type: TABLE_DATA_TYPE, column: { name: 'd' } },
         ]);
     });
 
@@ -71,9 +71,9 @@ describe('TableGroupRow Plugin computeds', () => {
         .toEqual([
           { key: `${TABLE_GROUP_TYPE}_a`, type: TABLE_GROUP_TYPE, groupKey: 'a', width: 123 },
           { key: `${TABLE_GROUP_TYPE}_c`, type: TABLE_GROUP_TYPE, groupKey: 'c', width: 123 },
-          { type: 'undefined', columnId: 'c', column: { name: 'a' } },
-          { type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
-          { type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
+          { type: 'undefined', column: { name: 'a' } },
+          { type: TABLE_DATA_TYPE, column: { name: 'b' } },
+          { type: TABLE_DATA_TYPE, column: { name: 'd' } },
         ]);
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.js
@@ -62,7 +62,7 @@ describe('TableGroupRow Plugin computeds', () => {
         ]);
     });
 
-    xit('should add a draft column when reordering groups', () => {
+    it('should add a draft column when reordering groups', () => {
       const draftGrouping = [
         { columnName: 'a' },
         { columnName: 'c', isDraft: true, mode: 'reorder' },

--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.js
@@ -1,3 +1,5 @@
+import { TABLE_DATA_TYPE } from '../table-view/constants';
+import { TABLE_GROUP_TYPE } from './constants';
 import {
   tableColumnsWithGrouping,
   tableRowsWithGrouping,
@@ -5,11 +7,12 @@ import {
 
 describe('TableGroupRow Plugin computeds', () => {
   describe('#tableColumnsWithGrouping', () => {
-    const allColumns = [
-      { name: 'a' },
-      { name: 'b' },
-      { name: 'c' },
-      { name: 'd' },
+    const tableColumns = [
+      { type: 'undefined', id: 'c', column: 'column_a' },
+      { type: TABLE_DATA_TYPE, id: 'a', column: 'column_a' },
+      { type: TABLE_DATA_TYPE, id: 'b', column: 'column_b' },
+      { type: TABLE_DATA_TYPE, id: 'c', column: 'column_c' },
+      { type: TABLE_DATA_TYPE, id: 'd', column: 'column_d' },
     ];
     const grouping = [
       { columnName: 'a' },
@@ -17,25 +20,14 @@ describe('TableGroupRow Plugin computeds', () => {
     ];
 
     it('should work', () => {
-      const columns = tableColumnsWithGrouping(allColumns, grouping, [], 123);
-
-      expect(columns).toHaveLength(6);
-      expect(columns[0]).toMatchObject({
-        type: 'groupColumn',
-        id: 'a',
-        group: { columnName: 'a' },
-        width: 123,
-      });
-      expect(columns[1]).toMatchObject({
-        type: 'groupColumn',
-        id: 'c',
-        group: { columnName: 'c' },
-        width: 123,
-      });
-      expect(columns[2]).toBe(allColumns[0]);
-      expect(columns[3]).toBe(allColumns[1]);
-      expect(columns[4]).toBe(allColumns[2]);
-      expect(columns[5]).toBe(allColumns[3]);
+      expect(tableColumnsWithGrouping(tableColumns, grouping, grouping, 123))
+        .toEqual([
+          { type: TABLE_GROUP_TYPE, id: 'a', width: 123 },
+          { type: TABLE_GROUP_TYPE, id: 'c', width: 123 },
+          { type: 'undefined', id: 'c', column: 'column_a' },
+          { type: TABLE_DATA_TYPE, id: 'b', column: 'column_b' },
+          { type: TABLE_DATA_TYPE, id: 'd', column: 'column_d' },
+        ]);
     });
 
     it('should not remove column when grouping', () => {
@@ -43,15 +35,15 @@ describe('TableGroupRow Plugin computeds', () => {
         { columnName: 'a' },
         { columnName: 'c', isDraft: true, mode: 'add' },
       ];
-      const columns = tableColumnsWithGrouping(allColumns, [], draftGrouping, 123);
-
-      expect(columns).toHaveLength(3);
-      expect(columns[0]).toBe(allColumns[1]);
-      expect(columns[1]).toEqual({
-        ...allColumns[2],
-        isDraft: true,
-      });
-      expect(columns[2]).toBe(allColumns[3]);
+      expect(tableColumnsWithGrouping(tableColumns, grouping, draftGrouping, 123))
+        .toEqual([
+          { type: TABLE_GROUP_TYPE, id: 'a', width: 123 },
+          { type: TABLE_GROUP_TYPE, id: 'c', width: 123 },
+          { type: 'undefined', id: 'c', column: 'column_a' },
+          { type: TABLE_DATA_TYPE, id: 'b', column: 'column_b' },
+          { type: TABLE_DATA_TYPE, id: 'c', column: 'column_c', isDraft: true },
+          { type: TABLE_DATA_TYPE, id: 'd', column: 'column_d' },
+        ]);
     });
 
     it('should add a draft column when ungrouping', () => {
@@ -59,41 +51,47 @@ describe('TableGroupRow Plugin computeds', () => {
         { columnName: 'a' },
         { columnName: 'c', isDraft: true, mode: 'remove' },
       ];
-      const columns = tableColumnsWithGrouping(allColumns, [], draftGrouping, 123);
-
-      expect(columns).toHaveLength(3);
-      expect(columns[0]).toBe(allColumns[1]);
-      expect(columns[1]).toEqual({
-        ...allColumns[2],
-        isDraft: true,
-      });
-      expect(columns[2]).toBe(allColumns[3]);
+      expect(tableColumnsWithGrouping(tableColumns, grouping, draftGrouping, 123))
+        .toEqual([
+          { type: TABLE_GROUP_TYPE, id: 'a', width: 123 },
+          { type: TABLE_GROUP_TYPE, id: 'c', width: 123 },
+          { type: 'undefined', id: 'c', column: 'column_a' },
+          { type: TABLE_DATA_TYPE, id: 'b', column: 'column_b' },
+          { type: TABLE_DATA_TYPE, id: 'c', column: 'column_c', isDraft: true },
+          { type: TABLE_DATA_TYPE, id: 'd', column: 'column_d' },
+        ]);
     });
 
-    it('should add a draft column when reordering groups', () => {
+    xit('should add a draft column when reordering groups', () => {
       const draftGrouping = [
         { columnName: 'a' },
         { columnName: 'c', isDraft: true, mode: 'reorder' },
       ];
-      const columns = tableColumnsWithGrouping(allColumns, [], draftGrouping, 123);
-
-      expect(columns).toHaveLength(2);
-      expect(columns[0]).toBe(allColumns[1]);
-      expect(columns[1]).toBe(allColumns[3]);
+      expect(tableColumnsWithGrouping(tableColumns, grouping, draftGrouping, 123))
+        .toEqual([
+          { type: TABLE_GROUP_TYPE, id: 'a', width: 123 },
+          { type: TABLE_GROUP_TYPE, id: 'c', width: 123 },
+          { type: 'undefined', id: 'c', column: 'column_a' },
+          { type: TABLE_DATA_TYPE, id: 'b', column: 'column_b' },
+          { type: TABLE_DATA_TYPE, id: 'd', column: 'column_d' },
+        ]);
     });
   });
   describe('#tableRowsWithGrouping', () => {
     it('should add correct colSpanStart to group rows', () => {
-      const rows = [
-        { type: 'groupRow', column: { name: 'a' } },
-        {},
-        {},
+      const tableRows = [
+        { type: TABLE_DATA_TYPE, row: { type: 'groupRow', key: 'B', column: { name: 'a' } } },
+        { type: 'undefined', row: { column: { name: 'a' } } },
+        { type: TABLE_DATA_TYPE, row: { column: { name: 'a' } } },
+        { type: TABLE_DATA_TYPE, row: { column: { name: 'b' } } },
       ];
 
-      expect(tableRowsWithGrouping(rows))
+      expect(tableRowsWithGrouping(tableRows))
         .toEqual([
-          { type: 'groupRow', column: { name: 'a' }, colSpanStart: 'groupColumn_a' },
-          ...rows.slice(1),
+          { type: TABLE_GROUP_TYPE, id: 'a_B', row: { type: 'groupRow', key: 'B', column: { name: 'a' } }, colSpanStart: `${TABLE_GROUP_TYPE}_a` },
+          { type: 'undefined', row: { column: { name: 'a' } } },
+          { type: TABLE_DATA_TYPE, row: { column: { name: 'a' } } },
+          { type: TABLE_DATA_TYPE, row: { column: { name: 'b' } } },
         ]);
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.js
@@ -8,11 +8,11 @@ import {
 describe('TableGroupRow Plugin computeds', () => {
   describe('#tableColumnsWithGrouping', () => {
     const tableColumns = [
-      { type: 'undefined', id: 'c', column: 'column_a' },
-      { type: TABLE_DATA_TYPE, id: 'a', column: 'column_a' },
-      { type: TABLE_DATA_TYPE, id: 'b', column: 'column_b' },
-      { type: TABLE_DATA_TYPE, id: 'c', column: 'column_c' },
-      { type: TABLE_DATA_TYPE, id: 'd', column: 'column_d' },
+      { type: 'undefined', columnId: 'c', column: 'column_a' },
+      { type: TABLE_DATA_TYPE, columnId: 'a', column: 'column_a' },
+      { type: TABLE_DATA_TYPE, columnId: 'b', column: 'column_b' },
+      { type: TABLE_DATA_TYPE, columnId: 'c', column: 'column_c' },
+      { type: TABLE_DATA_TYPE, columnId: 'd', column: 'column_d' },
     ];
     const grouping = [
       { columnName: 'a' },
@@ -22,11 +22,11 @@ describe('TableGroupRow Plugin computeds', () => {
     it('should work', () => {
       expect(tableColumnsWithGrouping(tableColumns, grouping, grouping, 123))
         .toEqual([
-          { type: TABLE_GROUP_TYPE, id: 'a', width: 123 },
-          { type: TABLE_GROUP_TYPE, id: 'c', width: 123 },
-          { type: 'undefined', id: 'c', column: 'column_a' },
-          { type: TABLE_DATA_TYPE, id: 'b', column: 'column_b' },
-          { type: TABLE_DATA_TYPE, id: 'd', column: 'column_d' },
+          { key: `${TABLE_GROUP_TYPE}_a`, type: TABLE_GROUP_TYPE, groupKey: 'a', width: 123 },
+          { key: `${TABLE_GROUP_TYPE}_c`, type: TABLE_GROUP_TYPE, groupKey: 'c', width: 123 },
+          { type: 'undefined', columnId: 'c', column: 'column_a' },
+          { type: TABLE_DATA_TYPE, columnId: 'b', column: 'column_b' },
+          { type: TABLE_DATA_TYPE, columnId: 'd', column: 'column_d' },
         ]);
     });
 
@@ -37,12 +37,12 @@ describe('TableGroupRow Plugin computeds', () => {
       ];
       expect(tableColumnsWithGrouping(tableColumns, grouping, draftGrouping, 123))
         .toEqual([
-          { type: TABLE_GROUP_TYPE, id: 'a', width: 123 },
-          { type: TABLE_GROUP_TYPE, id: 'c', width: 123 },
-          { type: 'undefined', id: 'c', column: 'column_a' },
-          { type: TABLE_DATA_TYPE, id: 'b', column: 'column_b' },
-          { type: TABLE_DATA_TYPE, id: 'c', column: 'column_c', isDraft: true },
-          { type: TABLE_DATA_TYPE, id: 'd', column: 'column_d' },
+          { key: `${TABLE_GROUP_TYPE}_a`, type: TABLE_GROUP_TYPE, groupKey: 'a', width: 123 },
+          { key: `${TABLE_GROUP_TYPE}_c`, type: TABLE_GROUP_TYPE, groupKey: 'c', width: 123 },
+          { type: 'undefined', columnId: 'c', column: 'column_a' },
+          { type: TABLE_DATA_TYPE, columnId: 'b', column: 'column_b' },
+          { type: TABLE_DATA_TYPE, columnId: 'c', column: 'column_c', isDraft: true },
+          { type: TABLE_DATA_TYPE, columnId: 'd', column: 'column_d' },
         ]);
     });
 
@@ -53,12 +53,12 @@ describe('TableGroupRow Plugin computeds', () => {
       ];
       expect(tableColumnsWithGrouping(tableColumns, grouping, draftGrouping, 123))
         .toEqual([
-          { type: TABLE_GROUP_TYPE, id: 'a', width: 123 },
-          { type: TABLE_GROUP_TYPE, id: 'c', width: 123 },
-          { type: 'undefined', id: 'c', column: 'column_a' },
-          { type: TABLE_DATA_TYPE, id: 'b', column: 'column_b' },
-          { type: TABLE_DATA_TYPE, id: 'c', column: 'column_c', isDraft: true },
-          { type: TABLE_DATA_TYPE, id: 'd', column: 'column_d' },
+          { key: `${TABLE_GROUP_TYPE}_a`, type: TABLE_GROUP_TYPE, groupKey: 'a', width: 123 },
+          { key: `${TABLE_GROUP_TYPE}_c`, type: TABLE_GROUP_TYPE, groupKey: 'c', width: 123 },
+          { type: 'undefined', columnId: 'c', column: 'column_a' },
+          { type: TABLE_DATA_TYPE, columnId: 'b', column: 'column_b' },
+          { type: TABLE_DATA_TYPE, columnId: 'c', column: 'column_c', isDraft: true },
+          { type: TABLE_DATA_TYPE, columnId: 'd', column: 'column_d' },
         ]);
     });
 
@@ -69,18 +69,18 @@ describe('TableGroupRow Plugin computeds', () => {
       ];
       expect(tableColumnsWithGrouping(tableColumns, grouping, draftGrouping, 123))
         .toEqual([
-          { type: TABLE_GROUP_TYPE, id: 'a', width: 123 },
-          { type: TABLE_GROUP_TYPE, id: 'c', width: 123 },
-          { type: 'undefined', id: 'c', column: 'column_a' },
-          { type: TABLE_DATA_TYPE, id: 'b', column: 'column_b' },
-          { type: TABLE_DATA_TYPE, id: 'd', column: 'column_d' },
+          { key: `${TABLE_GROUP_TYPE}_a`, type: TABLE_GROUP_TYPE, groupKey: 'a', width: 123 },
+          { key: `${TABLE_GROUP_TYPE}_c`, type: TABLE_GROUP_TYPE, groupKey: 'c', width: 123 },
+          { type: 'undefined', columnId: 'c', column: 'column_a' },
+          { type: TABLE_DATA_TYPE, columnId: 'b', column: 'column_b' },
+          { type: TABLE_DATA_TYPE, columnId: 'd', column: 'column_d' },
         ]);
     });
   });
   describe('#tableRowsWithGrouping', () => {
     it('should add correct colSpanStart to group rows', () => {
       const tableRows = [
-        { type: TABLE_DATA_TYPE, row: { type: 'groupRow', key: 'B', column: { name: 'a' } } },
+        { type: TABLE_DATA_TYPE, row: { type: 'groupRow', value: 'B', column: { name: 'a' } } },
         { type: 'undefined', row: { column: { name: 'a' } } },
         { type: TABLE_DATA_TYPE, row: { column: { name: 'a' } } },
         { type: TABLE_DATA_TYPE, row: { column: { name: 'b' } } },
@@ -88,7 +88,14 @@ describe('TableGroupRow Plugin computeds', () => {
 
       expect(tableRowsWithGrouping(tableRows))
         .toEqual([
-          { type: TABLE_GROUP_TYPE, id: 'a_B', row: { type: 'groupRow', key: 'B', column: { name: 'a' } }, colSpanStart: `${TABLE_GROUP_TYPE}_a` },
+          {
+            key: `${TABLE_GROUP_TYPE}_a_B`,
+            type: TABLE_GROUP_TYPE,
+            groupKey: 'a',
+            groupValue: 'B',
+            row: { type: 'groupRow', value: 'B', column: { name: 'a' } },
+            colSpanStart: `${TABLE_GROUP_TYPE}_a`,
+          },
           { type: 'undefined', row: { column: { name: 'a' } } },
           { type: TABLE_DATA_TYPE, row: { column: { name: 'a' } } },
           { type: TABLE_DATA_TYPE, row: { column: { name: 'b' } } },

--- a/packages/dx-grid-core/src/plugins/table-group-row/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/constants.js
@@ -1,0 +1,1 @@
+export const TABLE_GROUP_TYPE = 'group';

--- a/packages/dx-grid-core/src/plugins/table-group-row/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/helpers.js
@@ -1,0 +1,8 @@
+import { TABLE_GROUP_TYPE } from './constants';
+
+export const isGroupTableCell = (tableRow, tableColumn) =>
+  tableRow.type === TABLE_GROUP_TYPE && tableColumn.type === TABLE_GROUP_TYPE
+  && tableRow.id.startsWith(tableColumn.id);
+export const isGroupIndentTableCell = (tableRow, tableColumn) =>
+  tableRow.type === TABLE_GROUP_TYPE && tableColumn.type === TABLE_GROUP_TYPE
+  && !tableRow.id.startsWith(tableColumn.id);

--- a/packages/dx-grid-core/src/plugins/table-group-row/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/helpers.js
@@ -2,7 +2,7 @@ import { TABLE_GROUP_TYPE } from './constants';
 
 export const isGroupTableCell = (tableRow, tableColumn) =>
   tableRow.type === TABLE_GROUP_TYPE && tableColumn.type === TABLE_GROUP_TYPE
-  && tableRow.id.startsWith(tableColumn.id);
+  && tableRow.id.startsWith(`${tableColumn.id}_`);
 export const isGroupIndentTableCell = (tableRow, tableColumn) =>
   tableRow.type === TABLE_GROUP_TYPE && tableColumn.type === TABLE_GROUP_TYPE
   && !tableRow.id.startsWith(tableColumn.id);

--- a/packages/dx-grid-core/src/plugins/table-group-row/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/helpers.js
@@ -2,7 +2,7 @@ import { TABLE_GROUP_TYPE } from './constants';
 
 export const isGroupTableCell = (tableRow, tableColumn) =>
   tableRow.type === TABLE_GROUP_TYPE && tableColumn.type === TABLE_GROUP_TYPE
-  && tableRow.id.startsWith(`${tableColumn.id}_`);
+  && tableRow.groupKey === tableColumn.groupKey;
 export const isGroupIndentTableCell = (tableRow, tableColumn) =>
   tableRow.type === TABLE_GROUP_TYPE && tableColumn.type === TABLE_GROUP_TYPE
-  && !tableRow.id.startsWith(tableColumn.id);
+  && tableRow.groupKey !== tableColumn.groupKey;

--- a/packages/dx-grid-core/src/plugins/table-group-row/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/helpers.test.js
@@ -9,6 +9,8 @@ describe('TableRowDetail Plugin helpers', () => {
     it('should work', () => {
       expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, id: 'a_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
         .toBeTruthy();
+      expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, id: 'aa_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+        .toBeFalsy();
       expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, id: 'b_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
         .toBeFalsy();
       expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, id: 'b_A' }, { type: 'undefined', id: 'a' }))

--- a/packages/dx-grid-core/src/plugins/table-group-row/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/helpers.test.js
@@ -1,0 +1,32 @@
+import { TABLE_GROUP_TYPE } from './constants';
+import {
+  isGroupTableCell,
+  isGroupIndentTableCell,
+} from './helpers';
+
+describe('TableRowDetail Plugin helpers', () => {
+  describe('#isGroupTableCell', () => {
+    it('should work', () => {
+      expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, id: 'a_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+        .toBeTruthy();
+      expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, id: 'b_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+        .toBeFalsy();
+      expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, id: 'b_A' }, { type: 'undefined', id: 'a' }))
+        .toBeFalsy();
+      expect(isGroupTableCell({ type: 'undefined', id: 'b_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+        .toBeFalsy();
+    });
+  });
+  describe('#isGroupIndentTableCell', () => {
+    it('should work', () => {
+      expect(isGroupIndentTableCell({ type: TABLE_GROUP_TYPE, id: 'b_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+        .toBeTruthy();
+      expect(isGroupIndentTableCell({ type: TABLE_GROUP_TYPE, id: 'a_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+        .toBeFalsy();
+      expect(isGroupIndentTableCell({ type: TABLE_GROUP_TYPE, id: 'b_A' }, { type: 'undefined', id: 'a' }))
+        .toBeFalsy();
+      expect(isGroupIndentTableCell({ type: 'undefined', id: 'b_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+        .toBeFalsy();
+    });
+  });
+});

--- a/packages/dx-grid-core/src/plugins/table-group-row/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-group-row/helpers.test.js
@@ -7,27 +7,25 @@ import {
 describe('TableRowDetail Plugin helpers', () => {
   describe('#isGroupTableCell', () => {
     it('should work', () => {
-      expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, id: 'a_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+      expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, groupKey: 'a' }, { type: TABLE_GROUP_TYPE, groupKey: 'a' }))
         .toBeTruthy();
-      expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, id: 'aa_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+      expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, groupKey: 'b' }, { type: TABLE_GROUP_TYPE, groupKey: 'a' }))
         .toBeFalsy();
-      expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, id: 'b_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+      expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, groupKey: 'b' }, { type: 'undefined', groupKey: 'a' }))
         .toBeFalsy();
-      expect(isGroupTableCell({ type: TABLE_GROUP_TYPE, id: 'b_A' }, { type: 'undefined', id: 'a' }))
-        .toBeFalsy();
-      expect(isGroupTableCell({ type: 'undefined', id: 'b_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+      expect(isGroupTableCell({ type: 'undefined', groupKey: 'b' }, { type: TABLE_GROUP_TYPE, groupKey: 'a' }))
         .toBeFalsy();
     });
   });
   describe('#isGroupIndentTableCell', () => {
     it('should work', () => {
-      expect(isGroupIndentTableCell({ type: TABLE_GROUP_TYPE, id: 'b_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+      expect(isGroupIndentTableCell({ type: TABLE_GROUP_TYPE, groupKey: 'b' }, { type: TABLE_GROUP_TYPE, groupKey: 'a' }))
         .toBeTruthy();
-      expect(isGroupIndentTableCell({ type: TABLE_GROUP_TYPE, id: 'a_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+      expect(isGroupIndentTableCell({ type: TABLE_GROUP_TYPE, groupKey: 'a' }, { type: TABLE_GROUP_TYPE, groupKey: 'a' }))
         .toBeFalsy();
-      expect(isGroupIndentTableCell({ type: TABLE_GROUP_TYPE, id: 'b_A' }, { type: 'undefined', id: 'a' }))
+      expect(isGroupIndentTableCell({ type: TABLE_GROUP_TYPE, groupKey: 'b' }, { type: 'undefined', groupKey: 'a' }))
         .toBeFalsy();
-      expect(isGroupIndentTableCell({ type: 'undefined', id: 'b_A' }, { type: TABLE_GROUP_TYPE, id: 'a' }))
+      expect(isGroupIndentTableCell({ type: 'undefined', groupKey: 'b' }, { type: TABLE_GROUP_TYPE, groupKey: 'a' }))
         .toBeFalsy();
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-header-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/computeds.js
@@ -1,4 +1,4 @@
 import { TABLE_HEADING_TYPE } from './constants';
 
 export const tableRowsWithHeading = headerRows =>
-  [{ type: TABLE_HEADING_TYPE, id: 0 }, ...headerRows];
+  [{ key: TABLE_HEADING_TYPE, type: TABLE_HEADING_TYPE }, ...headerRows];

--- a/packages/dx-grid-core/src/plugins/table-header-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/computeds.js
@@ -1,3 +1,3 @@
-import { HEADING_TYPE } from './constants';
+import { TABLE_HEADING_TYPE } from './constants';
 
-export const tableRowsWithHeading = headerRows => [{ type: HEADING_TYPE, id: 0 }, ...headerRows];
+export const tableRowsWithHeading = headerRows => [{ type: TABLE_HEADING_TYPE, id: 0 }, ...headerRows];

--- a/packages/dx-grid-core/src/plugins/table-header-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/computeds.js
@@ -1,1 +1,3 @@
-export const tableRowsWithHeading = headerRows => [{ type: 'heading' }, ...headerRows];
+import { HEADING_TYPE } from './constants';
+
+export const tableRowsWithHeading = headerRows => [{ type: HEADING_TYPE, id: 0 }, ...headerRows];

--- a/packages/dx-grid-core/src/plugins/table-header-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/computeds.js
@@ -1,3 +1,4 @@
 import { TABLE_HEADING_TYPE } from './constants';
 
-export const tableRowsWithHeading = headerRows => [{ type: TABLE_HEADING_TYPE, id: 0 }, ...headerRows];
+export const tableRowsWithHeading = headerRows =>
+  [{ type: TABLE_HEADING_TYPE, id: 0 }, ...headerRows];

--- a/packages/dx-grid-core/src/plugins/table-header-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/computeds.test.js
@@ -1,19 +1,15 @@
+import { HEADING_TYPE } from './constants';
 import {
-    tableRowsWithHeading,
+  tableRowsWithHeading,
 } from './computeds';
 
 describe('TableHeaderRow Plugin computeds', () => {
   describe('#tableRowsWithHeading', () => {
-    const existingRows = [
-      { type: 'filter' },
-    ];
-
     it('should work', () => {
-      const rows = tableRowsWithHeading(existingRows);
+      const rows = tableRowsWithHeading([{}]);
 
-      expect(rows).toHaveLength(2);
-      expect(rows[0]).toMatchObject({ type: 'heading' });
-      expect(rows[1]).toBe(existingRows[0]);
+      expect(rows)
+        .toEqual([{ type: HEADING_TYPE, id: 0 }, {}]);
     });
   });
 });

--- a/packages/dx-grid-core/src/plugins/table-header-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/computeds.test.js
@@ -9,7 +9,7 @@ describe('TableHeaderRow Plugin computeds', () => {
       const rows = tableRowsWithHeading([{}]);
 
       expect(rows)
-        .toEqual([{ type: TABLE_HEADING_TYPE, id: 0 }, {}]);
+        .toEqual([{ key: TABLE_HEADING_TYPE, type: TABLE_HEADING_TYPE }, {}]);
     });
   });
 });

--- a/packages/dx-grid-core/src/plugins/table-header-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/computeds.test.js
@@ -1,4 +1,4 @@
-import { HEADING_TYPE } from './constants';
+import { TABLE_HEADING_TYPE } from './constants';
 import {
   tableRowsWithHeading,
 } from './computeds';
@@ -9,7 +9,7 @@ describe('TableHeaderRow Plugin computeds', () => {
       const rows = tableRowsWithHeading([{}]);
 
       expect(rows)
-        .toEqual([{ type: HEADING_TYPE, id: 0 }, {}]);
+        .toEqual([{ type: TABLE_HEADING_TYPE, id: 0 }, {}]);
     });
   });
 });

--- a/packages/dx-grid-core/src/plugins/table-header-row/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/constants.js
@@ -1,0 +1,1 @@
+export const HEADING_TYPE = 'heading';

--- a/packages/dx-grid-core/src/plugins/table-header-row/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/constants.js
@@ -1,1 +1,1 @@
-export const HEADING_TYPE = 'heading';
+export const TABLE_HEADING_TYPE = 'heading';

--- a/packages/dx-grid-core/src/plugins/table-header-row/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/helpers.js
@@ -1,5 +1,5 @@
 import { TABLE_HEADING_TYPE } from './constants';
 import { TABLE_DATA_TYPE } from '../table-view/constants';
 
-export const isHeadingTableCell = (row, column) =>
-  row.type === TABLE_HEADING_TYPE && column.type === TABLE_DATA_TYPE;
+export const isHeadingTableCell = (tableRow, tableColumn) =>
+  tableRow.type === TABLE_HEADING_TYPE && tableColumn.type === TABLE_DATA_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-header-row/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/helpers.js
@@ -1,0 +1,5 @@
+import { HEADING_TYPE } from './constants';
+import { DATA_TYPE } from '../table-view/constants';
+
+export const isHeadingTableCell = (row, column) =>
+  row.type === HEADING_TYPE && column.type === DATA_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-header-row/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/helpers.js
@@ -1,5 +1,5 @@
-import { HEADING_TYPE } from './constants';
-import { DATA_TYPE } from '../table-view/constants';
+import { TABLE_HEADING_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 
 export const isHeadingTableCell = (row, column) =>
-  row.type === HEADING_TYPE && column.type === DATA_TYPE;
+  row.type === TABLE_HEADING_TYPE && column.type === TABLE_DATA_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-header-row/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/helpers.test.js
@@ -1,0 +1,18 @@
+import { HEADING_TYPE } from './constants';
+import { DATA_TYPE } from '../table-view/constants';
+import {
+  isHeadingTableCell,
+} from './helpers';
+
+describe('TableHeaderRow Plugin helpers', () => {
+  describe('#isHeadingTableCell', () => {
+    it('should work', () => {
+      expect(isHeadingTableCell({ type: HEADING_TYPE }, { type: DATA_TYPE }))
+        .toBeTruthy();
+      expect(isHeadingTableCell({ type: HEADING_TYPE }, { type: 'undefined' }))
+        .toBeFalsy();
+      expect(isHeadingTableCell({ type: 'undefined' }, { type: 'undefined' }))
+        .toBeFalsy();
+    });
+  });
+});

--- a/packages/dx-grid-core/src/plugins/table-header-row/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-header-row/helpers.test.js
@@ -1,5 +1,5 @@
-import { HEADING_TYPE } from './constants';
-import { DATA_TYPE } from '../table-view/constants';
+import { TABLE_HEADING_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 import {
   isHeadingTableCell,
 } from './helpers';
@@ -7,9 +7,9 @@ import {
 describe('TableHeaderRow Plugin helpers', () => {
   describe('#isHeadingTableCell', () => {
     it('should work', () => {
-      expect(isHeadingTableCell({ type: HEADING_TYPE }, { type: DATA_TYPE }))
+      expect(isHeadingTableCell({ type: TABLE_HEADING_TYPE }, { type: TABLE_DATA_TYPE }))
         .toBeTruthy();
-      expect(isHeadingTableCell({ type: HEADING_TYPE }, { type: 'undefined' }))
+      expect(isHeadingTableCell({ type: TABLE_HEADING_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
       expect(isHeadingTableCell({ type: 'undefined' }, { type: 'undefined' }))
         .toBeFalsy();

--- a/packages/dx-grid-core/src/plugins/table-row-detail/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/computeds.js
@@ -1,27 +1,26 @@
 import { TABLE_DETAIL_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 
-// TODO: remove getRowId
-export const tableRowsWithExpandedDetail = (tableRows, expandedRows, getRowId, rowHeight) => {
+export const tableRowsWithExpandedDetail = (tableRows, expandedRows, rowHeight) => {
   let result = tableRows;
   expandedRows
     .forEach((expandedRowId) => {
-      const index = result.findIndex(row => getRowId(row.row) === expandedRowId);
-      if (index !== -1) {
-        const rowIndex = result.findIndex(row => getRowId(row.row) === expandedRowId);
-        const insertIndex = rowIndex + 1;
-        const row = result[rowIndex];
-        result = [
-          ...result.slice(0, insertIndex),
-          {
-            type: TABLE_DETAIL_TYPE,
-            id: getRowId(row.row),
-            row: row.row,
-            colspan: 0,
-            height: rowHeight,
-          },
-          ...result.slice(insertIndex),
-        ];
-      }
+      const rowIndex = result.findIndex(tableRow =>
+        tableRow.type === TABLE_DATA_TYPE && tableRow.id === expandedRowId);
+      if (rowIndex === -1) return;
+      const insertIndex = rowIndex + 1;
+      const tableRow = result[rowIndex];
+      result = [
+        ...result.slice(0, insertIndex),
+        {
+          type: TABLE_DETAIL_TYPE,
+          id: tableRow.id,
+          row: tableRow.row,
+          colspan: 0,
+          height: rowHeight,
+        },
+        ...result.slice(insertIndex),
+      ];
     });
   return result;
 };

--- a/packages/dx-grid-core/src/plugins/table-row-detail/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/computeds.js
@@ -1,30 +1,30 @@
 import { TABLE_DETAIL_TYPE } from './constants';
 
 // TODO: remove getRowId
-export const tableRowsWithExpandedDetail = (sourceRows, expandedRows, getRowId, rowHeight) => {
-  let rows = sourceRows;
+export const tableRowsWithExpandedDetail = (tableRows, expandedRows, getRowId, rowHeight) => {
+  let result = tableRows;
   expandedRows
     .forEach((expandedRowId) => {
-      const index = rows.findIndex(row => getRowId(row.original) === expandedRowId);
+      const index = result.findIndex(row => getRowId(row.row) === expandedRowId);
       if (index !== -1) {
-        const rowIndex = rows.findIndex(row => getRowId(row.original) === expandedRowId);
+        const rowIndex = result.findIndex(row => getRowId(row.row) === expandedRowId);
         const insertIndex = rowIndex + 1;
-        const row = rows[rowIndex];
-        rows = [
-          ...rows.slice(0, insertIndex),
+        const row = result[rowIndex];
+        result = [
+          ...result.slice(0, insertIndex),
           {
             type: TABLE_DETAIL_TYPE,
-            id: getRowId(row.original),
-            original: row.original,
+            id: getRowId(row.row),
+            row: row.row,
             colspan: 0,
             height: rowHeight,
           },
-          ...rows.slice(insertIndex),
+          ...result.slice(insertIndex),
         ];
       }
     });
-  return rows;
+  return result;
 };
 
-export const tableColumnsWithDetail = (columns, detailToggleCellWidth) =>
-  [{ type: TABLE_DETAIL_TYPE, width: detailToggleCellWidth }, ...columns];
+export const tableColumnsWithDetail = (tableColumns, detailToggleCellWidth) =>
+  [{ type: TABLE_DETAIL_TYPE, width: detailToggleCellWidth }, ...tableColumns];

--- a/packages/dx-grid-core/src/plugins/table-row-detail/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/computeds.js
@@ -6,16 +6,17 @@ export const tableRowsWithExpandedDetail = (tableRows, expandedRows, rowHeight) 
   expandedRows
     .forEach((expandedRowId) => {
       const rowIndex = result.findIndex(tableRow =>
-        tableRow.type === TABLE_DATA_TYPE && tableRow.id === expandedRowId);
+        tableRow.type === TABLE_DATA_TYPE && tableRow.rowId === expandedRowId);
       if (rowIndex === -1) return;
       const insertIndex = rowIndex + 1;
-      const tableRow = result[rowIndex];
+      const { row, rowId } = result[rowIndex];
       result = [
         ...result.slice(0, insertIndex),
         {
+          key: `${TABLE_DETAIL_TYPE}_${rowId}`,
           type: TABLE_DETAIL_TYPE,
-          id: tableRow.id,
-          row: tableRow.row,
+          rowId,
+          row,
           colSpanStart: 0,
           height: rowHeight,
         },
@@ -25,5 +26,7 @@ export const tableRowsWithExpandedDetail = (tableRows, expandedRows, rowHeight) 
   return result;
 };
 
-export const tableColumnsWithDetail = (tableColumns, detailToggleCellWidth) =>
-  [{ type: TABLE_DETAIL_TYPE, width: detailToggleCellWidth }, ...tableColumns];
+export const tableColumnsWithDetail = (tableColumns, detailToggleCellWidth) => [
+  { key: TABLE_DETAIL_TYPE, type: TABLE_DETAIL_TYPE, width: detailToggleCellWidth },
+  ...tableColumns,
+];

--- a/packages/dx-grid-core/src/plugins/table-row-detail/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/computeds.js
@@ -1,4 +1,4 @@
-import { DETAIL_TYPE } from './constants';
+import { TABLE_DETAIL_TYPE } from './constants';
 
 // TODO: remove getRowId
 export const tableRowsWithExpandedDetail = (sourceRows, expandedRows, getRowId, rowHeight) => {
@@ -13,7 +13,7 @@ export const tableRowsWithExpandedDetail = (sourceRows, expandedRows, getRowId, 
         rows = [
           ...rows.slice(0, insertIndex),
           {
-            type: DETAIL_TYPE,
+            type: TABLE_DETAIL_TYPE,
             id: getRowId(row.original),
             original: row.original,
             colspan: 0,
@@ -27,4 +27,4 @@ export const tableRowsWithExpandedDetail = (sourceRows, expandedRows, getRowId, 
 };
 
 export const tableColumnsWithDetail = (columns, detailToggleCellWidth) =>
-  [{ type: DETAIL_TYPE, width: detailToggleCellWidth }, ...columns];
+  [{ type: TABLE_DETAIL_TYPE, width: detailToggleCellWidth }, ...columns];

--- a/packages/dx-grid-core/src/plugins/table-row-detail/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/computeds.js
@@ -1,15 +1,24 @@
-export const expandedDetailRows = (sourceRows, expandedRows, getRowId, rowHeight) => {
+import { DETAIL_TYPE } from './constants';
+
+// TODO: remove getRowId
+export const tableRowsWithExpandedDetail = (sourceRows, expandedRows, getRowId, rowHeight) => {
   let rows = sourceRows;
   expandedRows
     .forEach((expandedRowId) => {
-      const index = rows.findIndex(row => getRowId(row) === expandedRowId);
+      const index = rows.findIndex(row => getRowId(row.original) === expandedRowId);
       if (index !== -1) {
-        const rowIndex = rows.findIndex(row => getRowId(row) === expandedRowId);
+        const rowIndex = rows.findIndex(row => getRowId(row.original) === expandedRowId);
         const insertIndex = rowIndex + 1;
         const row = rows[rowIndex];
         rows = [
           ...rows.slice(0, insertIndex),
-          { type: 'detailRow', id: getRowId(row), for: row, colspan: 0, height: rowHeight },
+          {
+            type: DETAIL_TYPE,
+            id: getRowId(row.original),
+            original: row.original,
+            colspan: 0,
+            height: rowHeight,
+          },
           ...rows.slice(insertIndex),
         ];
       }
@@ -17,4 +26,5 @@ export const expandedDetailRows = (sourceRows, expandedRows, getRowId, rowHeight
   return rows;
 };
 
-export const tableColumnsWithDetail = (columns, detailToggleCellWidth) => [{ type: 'detail', width: detailToggleCellWidth }, ...columns];
+export const tableColumnsWithDetail = (columns, detailToggleCellWidth) =>
+  [{ type: DETAIL_TYPE, width: detailToggleCellWidth }, ...columns];

--- a/packages/dx-grid-core/src/plugins/table-row-detail/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/computeds.test.js
@@ -7,42 +7,53 @@ import {
 describe('TableRowDetail Plugin computeds', () => {
   describe('#tableRowsWithExpandedDetail', () => {
     it('can expand one row', () => {
-      const rows = [{ row: { id: 1 } }, { row: { id: 2 } }];
+      const tableRows = [{ type: 'data', id: 1, row: 'row1' }, { type: 'data', id: 2, row: 'row2' }];
       const expandedRows = [2];
 
-      const rowsWithDetails = tableRowsWithExpandedDetail(rows, expandedRows, row => row.id, 'auto');
+      const rowsWithDetails = tableRowsWithExpandedDetail(tableRows, expandedRows, 'auto');
       expect(rowsWithDetails).toEqual([
-        { row: { id: 1 } },
-        { row: { id: 2 } },
+        { type: 'data', id: 1, row: 'row1' },
+        { type: 'data', id: 2, row: 'row2' },
         {
           type: TABLE_DETAIL_TYPE,
           id: 2,
-          row: { id: 2 },
+          row: 'row2',
           colspan: 0,
           height: 'auto',
         },
       ]);
     });
 
+    it('can\'t expand not data', () => {
+      const tableRows = [{ type: 'data', id: 1, row: 'row1' }, { type: 'undefined', id: 2, row: 'row2' }];
+      const expandedRows = [2];
+
+      const rowsWithDetails = tableRowsWithExpandedDetail(tableRows, expandedRows, 'auto');
+      expect(rowsWithDetails).toEqual([
+        { type: 'data', id: 1, row: 'row1' },
+        { type: 'undefined', id: 2, row: 'row2' },
+      ]);
+    });
+
     it('can expand several rows', () => {
-      const rows = [{ row: { id: 1 } }, { row: { id: 2 } }];
+      const tableRows = [{ type: 'data', id: 1, row: 'row1' }, { type: 'data', id: 2, row: 'row2' }];
       const expandedRows = [1, 2];
 
-      const rowsWithDetails = tableRowsWithExpandedDetail(rows, expandedRows, row => row.id, 'auto');
+      const rowsWithDetails = tableRowsWithExpandedDetail(tableRows, expandedRows, 'auto');
       expect(rowsWithDetails).toEqual([
-        { row: { id: 1 } },
+        { type: 'data', id: 1, row: 'row1' },
         {
           type: TABLE_DETAIL_TYPE,
           id: 1,
-          row: { id: 1 },
+          row: 'row1',
           colspan: 0,
           height: 'auto',
         },
-        { row: { id: 2 } },
+        { type: 'data', id: 2, row: 'row2' },
         {
           type: TABLE_DETAIL_TYPE,
           id: 2,
-          row: { id: 2 },
+          row: 'row2',
           colspan: 0,
           height: 'auto',
         },

--- a/packages/dx-grid-core/src/plugins/table-row-detail/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/computeds.test.js
@@ -1,4 +1,4 @@
-import { DETAIL_TYPE } from './constants';
+import { TABLE_DETAIL_TYPE } from './constants';
 import {
   tableRowsWithExpandedDetail,
   tableColumnsWithDetail,
@@ -15,7 +15,7 @@ describe('TableRowDetail Plugin computeds', () => {
         { original: { id: 1 } },
         { original: { id: 2 } },
         {
-          type: DETAIL_TYPE,
+          type: TABLE_DETAIL_TYPE,
           id: 2,
           original: { id: 2 },
           colspan: 0,
@@ -32,7 +32,7 @@ describe('TableRowDetail Plugin computeds', () => {
       expect(rowsWithDetails).toEqual([
         { original: { id: 1 } },
         {
-          type: DETAIL_TYPE,
+          type: TABLE_DETAIL_TYPE,
           id: 1,
           original: { id: 1 },
           colspan: 0,
@@ -40,7 +40,7 @@ describe('TableRowDetail Plugin computeds', () => {
         },
         { original: { id: 2 } },
         {
-          type: DETAIL_TYPE,
+          type: TABLE_DETAIL_TYPE,
           id: 2,
           original: { id: 2 },
           colspan: 0,
@@ -60,7 +60,7 @@ describe('TableRowDetail Plugin computeds', () => {
       const columns = tableColumnsWithDetail(tableColumns, 50);
 
       expect(columns).toHaveLength(3);
-      expect(columns[0]).toMatchObject({ type: DETAIL_TYPE, width: 50 });
+      expect(columns[0]).toMatchObject({ type: TABLE_DETAIL_TYPE, width: 50 });
       expect(columns[1]).toBe(tableColumns[0]);
       expect(columns[2]).toBe(tableColumns[1]);
     });

--- a/packages/dx-grid-core/src/plugins/table-row-detail/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/computeds.test.js
@@ -1,22 +1,23 @@
+import { DETAIL_TYPE } from './constants';
 import {
-    expandedDetailRows,
-    tableColumnsWithDetail,
+  tableRowsWithExpandedDetail,
+  tableColumnsWithDetail,
 } from './computeds';
 
-describe('DetailRow computeds', () => {
-  describe('#expandedDetailRows', () => {
+describe('TableRowDetail Plugin computeds', () => {
+  describe('#tableRowsWithExpandedDetail', () => {
     it('can expand one row', () => {
-      const rows = [{ id: 1 }, { id: 2 }];
+      const rows = [{ original: { id: 1 } }, { original: { id: 2 } }];
       const expandedRows = [2];
 
-      const rowsWithDetails = expandedDetailRows(rows, expandedRows, row => row.id, 'auto');
+      const rowsWithDetails = tableRowsWithExpandedDetail(rows, expandedRows, row => row.id, 'auto');
       expect(rowsWithDetails).toEqual([
-        { id: 1 },
-        { id: 2 },
+        { original: { id: 1 } },
+        { original: { id: 2 } },
         {
-          type: 'detailRow',
+          type: DETAIL_TYPE,
           id: 2,
-          for: { id: 2 },
+          original: { id: 2 },
           colspan: 0,
           height: 'auto',
         },
@@ -24,24 +25,24 @@ describe('DetailRow computeds', () => {
     });
 
     it('can expand several rows', () => {
-      const rows = [{ id: 1 }, { id: 2 }];
+      const rows = [{ original: { id: 1 } }, { original: { id: 2 } }];
       const expandedRows = [1, 2];
 
-      const rowsWithDetails = expandedDetailRows(rows, expandedRows, row => row.id, 'auto');
+      const rowsWithDetails = tableRowsWithExpandedDetail(rows, expandedRows, row => row.id, 'auto');
       expect(rowsWithDetails).toEqual([
-        { id: 1 },
+        { original: { id: 1 } },
         {
-          type: 'detailRow',
+          type: DETAIL_TYPE,
           id: 1,
-          for: { id: 1 },
+          original: { id: 1 },
           colspan: 0,
           height: 'auto',
         },
-        { id: 2 },
+        { original: { id: 2 } },
         {
-          type: 'detailRow',
+          type: DETAIL_TYPE,
           id: 2,
-          for: { id: 2 },
+          original: { id: 2 },
           colspan: 0,
           height: 'auto',
         },
@@ -59,7 +60,7 @@ describe('DetailRow computeds', () => {
       const columns = tableColumnsWithDetail(tableColumns, 50);
 
       expect(columns).toHaveLength(3);
-      expect(columns[0]).toMatchObject({ type: 'detail', width: 50 });
+      expect(columns[0]).toMatchObject({ type: DETAIL_TYPE, width: 50 });
       expect(columns[1]).toBe(tableColumns[0]);
       expect(columns[2]).toBe(tableColumns[1]);
     });

--- a/packages/dx-grid-core/src/plugins/table-row-detail/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/computeds.test.js
@@ -7,17 +7,17 @@ import {
 describe('TableRowDetail Plugin computeds', () => {
   describe('#tableRowsWithExpandedDetail', () => {
     it('can expand one row', () => {
-      const rows = [{ original: { id: 1 } }, { original: { id: 2 } }];
+      const rows = [{ row: { id: 1 } }, { row: { id: 2 } }];
       const expandedRows = [2];
 
       const rowsWithDetails = tableRowsWithExpandedDetail(rows, expandedRows, row => row.id, 'auto');
       expect(rowsWithDetails).toEqual([
-        { original: { id: 1 } },
-        { original: { id: 2 } },
+        { row: { id: 1 } },
+        { row: { id: 2 } },
         {
           type: TABLE_DETAIL_TYPE,
           id: 2,
-          original: { id: 2 },
+          row: { id: 2 },
           colspan: 0,
           height: 'auto',
         },
@@ -25,24 +25,24 @@ describe('TableRowDetail Plugin computeds', () => {
     });
 
     it('can expand several rows', () => {
-      const rows = [{ original: { id: 1 } }, { original: { id: 2 } }];
+      const rows = [{ row: { id: 1 } }, { row: { id: 2 } }];
       const expandedRows = [1, 2];
 
       const rowsWithDetails = tableRowsWithExpandedDetail(rows, expandedRows, row => row.id, 'auto');
       expect(rowsWithDetails).toEqual([
-        { original: { id: 1 } },
+        { row: { id: 1 } },
         {
           type: TABLE_DETAIL_TYPE,
           id: 1,
-          original: { id: 1 },
+          row: { id: 1 },
           colspan: 0,
           height: 'auto',
         },
-        { original: { id: 2 } },
+        { row: { id: 2 } },
         {
           type: TABLE_DETAIL_TYPE,
           id: 2,
-          original: { id: 2 },
+          row: { id: 2 },
           colspan: 0,
           height: 'auto',
         },

--- a/packages/dx-grid-core/src/plugins/table-row-detail/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/computeds.test.js
@@ -7,16 +7,20 @@ import {
 describe('TableRowDetail Plugin computeds', () => {
   describe('#tableRowsWithExpandedDetail', () => {
     it('can expand one row', () => {
-      const tableRows = [{ type: 'data', id: 1, row: 'row1' }, { type: 'data', id: 2, row: 'row2' }];
+      const tableRows = [
+        { type: 'data', rowId: 1, row: 'row1' },
+        { type: 'data', rowId: 2, row: 'row2' },
+      ];
       const expandedRows = [2];
 
       const rowsWithDetails = tableRowsWithExpandedDetail(tableRows, expandedRows, 'auto');
       expect(rowsWithDetails).toEqual([
-        { type: 'data', id: 1, row: 'row1' },
-        { type: 'data', id: 2, row: 'row2' },
+        { type: 'data', rowId: 1, row: 'row1' },
+        { type: 'data', rowId: 2, row: 'row2' },
         {
+          key: `${TABLE_DETAIL_TYPE}_2`,
           type: TABLE_DETAIL_TYPE,
-          id: 2,
+          rowId: 2,
           row: 'row2',
           colSpanStart: 0,
           height: 'auto',
@@ -25,34 +29,36 @@ describe('TableRowDetail Plugin computeds', () => {
     });
 
     it('can\'t expand not data', () => {
-      const tableRows = [{ type: 'data', id: 1, row: 'row1' }, { type: 'undefined', id: 2, row: 'row2' }];
+      const tableRows = [{ type: 'data', rowId: 1, row: 'row1' }, { type: 'undefined', rowId: 2, row: 'row2' }];
       const expandedRows = [2];
 
       const rowsWithDetails = tableRowsWithExpandedDetail(tableRows, expandedRows, 'auto');
       expect(rowsWithDetails).toEqual([
-        { type: 'data', id: 1, row: 'row1' },
-        { type: 'undefined', id: 2, row: 'row2' },
+        { type: 'data', rowId: 1, row: 'row1' },
+        { type: 'undefined', rowId: 2, row: 'row2' },
       ]);
     });
 
     it('can expand several rows', () => {
-      const tableRows = [{ type: 'data', id: 1, row: 'row1' }, { type: 'data', id: 2, row: 'row2' }];
+      const tableRows = [{ type: 'data', rowId: 1, row: 'row1' }, { type: 'data', rowId: 2, row: 'row2' }];
       const expandedRows = [1, 2];
 
       const rowsWithDetails = tableRowsWithExpandedDetail(tableRows, expandedRows, 'auto');
       expect(rowsWithDetails).toEqual([
-        { type: 'data', id: 1, row: 'row1' },
+        { type: 'data', rowId: 1, row: 'row1' },
         {
+          key: `${TABLE_DETAIL_TYPE}_1`,
           type: TABLE_DETAIL_TYPE,
-          id: 1,
+          rowId: 1,
           row: 'row1',
           colSpanStart: 0,
           height: 'auto',
         },
-        { type: 'data', id: 2, row: 'row2' },
+        { type: 'data', rowId: 2, row: 'row2' },
         {
+          key: `${TABLE_DETAIL_TYPE}_2`,
           type: TABLE_DETAIL_TYPE,
-          id: 2,
+          rowId: 2,
           row: 'row2',
           colSpanStart: 0,
           height: 'auto',
@@ -62,18 +68,12 @@ describe('TableRowDetail Plugin computeds', () => {
   });
 
   describe('#tableColumnsWithDetail', () => {
-    const tableColumns = [
-      { name: 'a' },
-      { name: 'b' },
-    ];
-
     it('should work', () => {
-      const columns = tableColumnsWithDetail(tableColumns, 50);
-
-      expect(columns).toHaveLength(3);
-      expect(columns[0]).toMatchObject({ type: TABLE_DETAIL_TYPE, width: 50 });
-      expect(columns[1]).toBe(tableColumns[0]);
-      expect(columns[2]).toBe(tableColumns[1]);
+      expect(tableColumnsWithDetail([{}], 50))
+        .toEqual([
+          { key: TABLE_DETAIL_TYPE, type: TABLE_DETAIL_TYPE, width: 50 },
+          {},
+        ]);
     });
   });
 });

--- a/packages/dx-grid-core/src/plugins/table-row-detail/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/computeds.test.js
@@ -45,26 +45,16 @@ describe('TableRowDetail Plugin computeds', () => {
         {
           type: TABLE_DETAIL_TYPE,
           id: 1,
-<<<<<<< HEAD
           row: 'row1',
-          colspan: 0,
-=======
-          for: { id: 1 },
           colSpanStart: 0,
->>>>>>> upstream/master
           height: 'auto',
         },
         { type: 'data', id: 2, row: 'row2' },
         {
           type: TABLE_DETAIL_TYPE,
           id: 2,
-<<<<<<< HEAD
           row: 'row2',
-          colspan: 0,
-=======
-          for: { id: 2 },
           colSpanStart: 0,
->>>>>>> upstream/master
           height: 'auto',
         },
       ]);

--- a/packages/dx-grid-core/src/plugins/table-row-detail/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/constants.js
@@ -1,0 +1,1 @@
+export const DETAIL_TYPE = 'detail';

--- a/packages/dx-grid-core/src/plugins/table-row-detail/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/constants.js
@@ -1,1 +1,1 @@
-export const DETAIL_TYPE = 'detail';
+export const TABLE_DETAIL_TYPE = 'detail';

--- a/packages/dx-grid-core/src/plugins/table-row-detail/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/helpers.js
@@ -2,6 +2,6 @@ import { TABLE_DETAIL_TYPE } from './constants';
 import { TABLE_DATA_TYPE } from '../table-view/constants';
 
 export const isDetailRowExpanded = (expandedRows, rowId) => expandedRows.indexOf(rowId) > -1;
-export const isDetailToggleTableCell = (row, column) =>
-  column.type === TABLE_DETAIL_TYPE && row.type === TABLE_DATA_TYPE;
-export const isDetailTableRow = row => row.type === TABLE_DETAIL_TYPE;
+export const isDetailToggleTableCell = (tableRow, tableColumn) =>
+  tableColumn.type === TABLE_DETAIL_TYPE && tableRow.type === TABLE_DATA_TYPE;
+export const isDetailTableRow = tableRow => tableRow.type === TABLE_DETAIL_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-row-detail/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/helpers.js
@@ -1,7 +1,7 @@
-import { DETAIL_TYPE } from './constants';
-import { DATA_TYPE } from '../table-view/constants';
+import { TABLE_DETAIL_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 
 export const isDetailRowExpanded = (expandedRows, rowId) => expandedRows.indexOf(rowId) > -1;
 export const isDetailToggleTableCell = (row, column) =>
-  column.type === DETAIL_TYPE && row.type === DATA_TYPE;
-export const isDetailTableRow = row => row.type === DETAIL_TYPE;
+  column.type === TABLE_DETAIL_TYPE && row.type === TABLE_DATA_TYPE;
+export const isDetailTableRow = row => row.type === TABLE_DETAIL_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-row-detail/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/helpers.js
@@ -1,1 +1,7 @@
+import { DETAIL_TYPE } from './constants';
+import { DATA_TYPE } from '../table-view/constants';
+
 export const isDetailRowExpanded = (expandedRows, rowId) => expandedRows.indexOf(rowId) > -1;
+export const isDetailToggleTableCell = (row, column) =>
+  column.type === DETAIL_TYPE && row.type === DATA_TYPE;
+export const isDetailTableRow = row => row.type === DETAIL_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-row-detail/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/helpers.test.js
@@ -1,14 +1,38 @@
+import { DETAIL_TYPE } from './constants';
+import { DATA_TYPE } from '../table-view/constants';
 import {
-    isDetailRowExpanded,
+  isDetailRowExpanded,
+  isDetailToggleTableCell,
+  isDetailTableRow,
 } from './helpers';
 
-describe('DetailRow helpers', () => {
+describe('TableRowDetail Plugin helpers', () => {
   describe('#isDetailRowExpanded', () => {
     it('should work', () => {
       const expandedRows = [1];
 
       expect(isDetailRowExpanded(expandedRows, 1)).toBeTruthy();
       expect(isDetailRowExpanded(expandedRows, 2)).toBeFalsy();
+    });
+  });
+
+  describe('#isDetailToggleTableCell', () => {
+    it('should work', () => {
+      expect(isDetailToggleTableCell({ type: DATA_TYPE }, { type: DETAIL_TYPE }))
+        .toBeTruthy();
+      expect(isDetailToggleTableCell({ type: 'undefined' }, { type: DETAIL_TYPE }))
+        .toBeFalsy();
+      expect(isDetailToggleTableCell({ type: 'undefined' }, { type: 'undefined' }))
+        .toBeFalsy();
+    });
+  });
+
+  describe('#isDetailTableRow', () => {
+    it('should work', () => {
+      expect(isDetailTableRow({ type: DETAIL_TYPE }))
+        .toBeTruthy();
+      expect(isDetailTableRow({ type: 'undefined' }))
+        .toBeFalsy();
     });
   });
 });

--- a/packages/dx-grid-core/src/plugins/table-row-detail/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/helpers.test.js
@@ -1,5 +1,5 @@
-import { DETAIL_TYPE } from './constants';
-import { DATA_TYPE } from '../table-view/constants';
+import { TABLE_DETAIL_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 import {
   isDetailRowExpanded,
   isDetailToggleTableCell,
@@ -18,9 +18,9 @@ describe('TableRowDetail Plugin helpers', () => {
 
   describe('#isDetailToggleTableCell', () => {
     it('should work', () => {
-      expect(isDetailToggleTableCell({ type: DATA_TYPE }, { type: DETAIL_TYPE }))
+      expect(isDetailToggleTableCell({ type: TABLE_DATA_TYPE }, { type: TABLE_DETAIL_TYPE }))
         .toBeTruthy();
-      expect(isDetailToggleTableCell({ type: 'undefined' }, { type: DETAIL_TYPE }))
+      expect(isDetailToggleTableCell({ type: 'undefined' }, { type: TABLE_DETAIL_TYPE }))
         .toBeFalsy();
       expect(isDetailToggleTableCell({ type: 'undefined' }, { type: 'undefined' }))
         .toBeFalsy();
@@ -29,7 +29,7 @@ describe('TableRowDetail Plugin helpers', () => {
 
   describe('#isDetailTableRow', () => {
     it('should work', () => {
-      expect(isDetailTableRow({ type: DETAIL_TYPE }))
+      expect(isDetailTableRow({ type: TABLE_DETAIL_TYPE }))
         .toBeTruthy();
       expect(isDetailTableRow({ type: 'undefined' }))
         .toBeFalsy();

--- a/packages/dx-grid-core/src/plugins/table-row-detail/reducers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-row-detail/reducers.test.js
@@ -4,7 +4,7 @@ import {
     setDetailRowExpanded,
 } from './reducers';
 
-describe('DetailRow reducers', () => {
+describe('TableRowDetail Plugin reducers', () => {
   describe('#setDetailRowExpanded', () => {
     it('can expand row by toggling', () => {
       const expandedRows = [];

--- a/packages/dx-grid-core/src/plugins/table-selection/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/computeds.js
@@ -1,26 +1,21 @@
 import { TABLE_SELECT_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 import extendWithEventListener from '../../utils/extend-with-event-listener';
 
 export const tableColumnsWithSelection = (tableColumns, selectionColumnWidth) =>
   [{ type: TABLE_SELECT_TYPE, id: 0, width: selectionColumnWidth }, ...tableColumns];
 
-// TODO: remove getRowId
-export const tableRowsWithSelection = (tableRows, selection, getRowId) => {
+export const tableRowsWithSelection = (tableRows, selection) => {
   const selectionSet = new Set(selection);
   return tableRows
     .map((tableRow) => {
-      if (!selectionSet.has(getRowId(tableRow.row))) return tableRow;
+      if (tableRow.type !== TABLE_DATA_TYPE || !selectionSet.has(tableRow.id)) return tableRow;
       return { selected: true, ...tableRow };
     });
 };
 
-// TODO: remove getRowId
-export const tableExtraPropsWithSelection = (
-  extraProps,
-  setRowSelection,
-  getRowId,
-) => extendWithEventListener(extraProps, 'onClick', ({ tableRow }) => {
-  const rowId = getRowId(tableRow.row);
-  if (rowId === undefined) return;
-  setRowSelection({ rowId });
-});
+export const tableExtraPropsWithSelection = (extraProps, setRowSelection) =>
+  extendWithEventListener(extraProps, 'onClick', ({ tableRow: { type, id: rowId } }) => {
+    if (type !== TABLE_DATA_TYPE) return;
+    setRowSelection({ rowId });
+  });

--- a/packages/dx-grid-core/src/plugins/table-selection/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/computeds.js
@@ -1,16 +1,16 @@
 import { TABLE_SELECT_TYPE } from './constants';
 import extendWithEventListener from '../../utils/extend-with-event-listener';
 
-export const tableColumnsWithSelection = (columns, selectionColumnWidth) =>
-  [{ type: TABLE_SELECT_TYPE, id: 0, width: selectionColumnWidth }, ...columns];
+export const tableColumnsWithSelection = (tableColumns, selectionColumnWidth) =>
+  [{ type: TABLE_SELECT_TYPE, id: 0, width: selectionColumnWidth }, ...tableColumns];
 
 // TODO: remove getRowId
-export const tableBodyRowsWithSelection = (bodyRows, selection, getRowId) => {
+export const tableRowsWithSelection = (tableRows, selection, getRowId) => {
   const selectionSet = new Set(selection);
-  return bodyRows
-    .map((row) => {
-      if (!selectionSet.has(getRowId(row.original))) return row;
-      return { selected: true, ...row };
+  return tableRows
+    .map((tableRow) => {
+      if (!selectionSet.has(getRowId(tableRow.row))) return tableRow;
+      return { selected: true, ...tableRow };
     });
 };
 
@@ -19,8 +19,8 @@ export const tableExtraPropsWithSelection = (
   extraProps,
   setRowSelection,
   getRowId,
-) => extendWithEventListener(extraProps, 'onClick', ({ row }) => {
-  const rowId = getRowId(row.original);
+) => extendWithEventListener(extraProps, 'onClick', ({ tableRow }) => {
+  const rowId = getRowId(tableRow.row);
   if (rowId === undefined) return;
   setRowSelection({ rowId });
 });

--- a/packages/dx-grid-core/src/plugins/table-selection/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/computeds.js
@@ -1,24 +1,26 @@
+import { SELECT_TYPE } from './constants';
 import extendWithEventListener from '../../utils/extend-with-event-listener';
 
 export const tableColumnsWithSelection = (columns, selectionColumnWidth) =>
-  [{ type: 'select', name: 'select', width: selectionColumnWidth }, ...columns];
+  [{ type: SELECT_TYPE, id: 0, width: selectionColumnWidth }, ...columns];
 
+// TODO: remove getRowId
 export const tableBodyRowsWithSelection = (bodyRows, selection, getRowId) => {
   const selectionSet = new Set(selection);
   return bodyRows
     .map((row) => {
-      if (!selectionSet.has(getRowId(row))) return row;
-      return Object.assign({ selected: true, _originalRow: row }, row);
+      if (!selectionSet.has(getRowId(row.original))) return row;
+      return { selected: true, ...row };
     });
 };
 
-export const tableExtraProps = (
-    extraProps,
-    availableToSelect,
-    setRowSelection,
-    getRowId,
-  ) => extendWithEventListener(extraProps, 'onClick', ({ row }) => {
-    const rowId = getRowId(row);
-    if (availableToSelect.indexOf(rowId) === -1) return;
-    setRowSelection({ rowId });
-  });
+// TODO: remove getRowId
+export const tableExtraPropsWithSelection = (
+  extraProps,
+  setRowSelection,
+  getRowId,
+) => extendWithEventListener(extraProps, 'onClick', ({ row }) => {
+  const rowId = getRowId(row.original);
+  if (rowId === undefined) return;
+  setRowSelection({ rowId });
+});

--- a/packages/dx-grid-core/src/plugins/table-selection/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/computeds.js
@@ -1,8 +1,8 @@
-import { SELECT_TYPE } from './constants';
+import { TABLE_SELECT_TYPE } from './constants';
 import extendWithEventListener from '../../utils/extend-with-event-listener';
 
 export const tableColumnsWithSelection = (columns, selectionColumnWidth) =>
-  [{ type: SELECT_TYPE, id: 0, width: selectionColumnWidth }, ...columns];
+  [{ type: TABLE_SELECT_TYPE, id: 0, width: selectionColumnWidth }, ...columns];
 
 // TODO: remove getRowId
 export const tableBodyRowsWithSelection = (bodyRows, selection, getRowId) => {

--- a/packages/dx-grid-core/src/plugins/table-selection/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/computeds.js
@@ -2,20 +2,22 @@ import { TABLE_SELECT_TYPE } from './constants';
 import { TABLE_DATA_TYPE } from '../table-view/constants';
 import extendWithEventListener from '../../utils/extend-with-event-listener';
 
-export const tableColumnsWithSelection = (tableColumns, selectionColumnWidth) =>
-  [{ type: TABLE_SELECT_TYPE, id: 0, width: selectionColumnWidth }, ...tableColumns];
+export const tableColumnsWithSelection = (tableColumns, selectionColumnWidth) => [
+  { key: TABLE_SELECT_TYPE, type: TABLE_SELECT_TYPE, width: selectionColumnWidth },
+  ...tableColumns,
+];
 
 export const tableRowsWithSelection = (tableRows, selection) => {
   const selectionSet = new Set(selection);
   return tableRows
     .map((tableRow) => {
-      if (tableRow.type !== TABLE_DATA_TYPE || !selectionSet.has(tableRow.id)) return tableRow;
+      if (tableRow.type !== TABLE_DATA_TYPE || !selectionSet.has(tableRow.rowId)) return tableRow;
       return { selected: true, ...tableRow };
     });
 };
 
 export const tableExtraPropsWithSelection = (extraProps, setRowSelection) =>
-  extendWithEventListener(extraProps, 'onClick', ({ tableRow: { type, id: rowId } }) => {
+  extendWithEventListener(extraProps, 'onClick', ({ tableRow: { type, rowId } }) => {
     if (type !== TABLE_DATA_TYPE) return;
     setRowSelection({ rowId });
   });

--- a/packages/dx-grid-core/src/plugins/table-selection/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/computeds.test.js
@@ -1,4 +1,4 @@
-import { SELECT_TYPE } from './constants';
+import { TABLE_SELECT_TYPE } from './constants';
 import {
   tableColumnsWithSelection,
   tableBodyRowsWithSelection,
@@ -16,7 +16,7 @@ describe('TableSelection Plugin computeds', () => {
       const columns = tableColumnsWithSelection(tableColumns, 123);
 
       expect(columns).toHaveLength(3);
-      expect(columns[0]).toMatchObject({ type: SELECT_TYPE, id: 0, width: 123 });
+      expect(columns[0]).toMatchObject({ type: TABLE_SELECT_TYPE, id: 0, width: 123 });
       expect(columns[1]).toBe(tableColumns[0]);
       expect(columns[2]).toBe(tableColumns[1]);
     });

--- a/packages/dx-grid-core/src/plugins/table-selection/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/computeds.test.js
@@ -1,7 +1,7 @@
 import { TABLE_SELECT_TYPE } from './constants';
 import {
   tableColumnsWithSelection,
-  tableBodyRowsWithSelection,
+  tableRowsWithSelection,
   tableExtraPropsWithSelection,
 } from './computeds';
 
@@ -22,34 +22,34 @@ describe('TableSelection Plugin computeds', () => {
     });
   });
 
-  describe('#tableBodyRowsWithSelection', () => {
+  describe('#tableRowsWithSelection', () => {
     const bodyRows = [
-      { original: { field: 'a' } },
-      { original: { field: 'b' } },
-      { original: { field: 'c' } },
+      { row: { field: 'a' } },
+      { row: { field: 'b' } },
+      { row: { field: 'c' } },
     ];
     const selection = [0, 2];
-    const getRowId = row => bodyRows.findIndex(item => item.original.field === row.field);
+    const getRowId = row => bodyRows.findIndex(item => item.row.field === row.field);
 
     it('should work', () => {
-      const selectedRows = tableBodyRowsWithSelection(bodyRows, selection, getRowId);
+      const selectedRows = tableRowsWithSelection(bodyRows, selection, getRowId);
 
       expect(selectedRows)
         .toEqual([
-          { selected: true, original: { field: 'a' } },
-          { original: { field: 'b' } },
-          { selected: true, original: { field: 'c' } },
+          { selected: true, row: { field: 'a' } },
+          { row: { field: 'b' } },
+          { selected: true, row: { field: 'c' } },
         ]);
     });
   });
 
   describe('#tableExtraPropsWithSelection', () => {
     const rows = [
-      { original: { field: 'a' } },
-      { original: { field: 'b' } },
-      { original: { field: 'c' } },
+      { row: { field: 'a' } },
+      { row: { field: 'b' } },
+      { row: { field: 'c' } },
     ];
-    const getRowId = row => rows.findIndex(item => item.original.field === row.field);
+    const getRowId = row => rows.findIndex(item => item.row.field === row.field);
     const setRowSelectionMock = jest.fn();
     const setRowSelectionCalls = setRowSelectionMock.mock.calls;
     const existingExtraProps = { a: 1 };
@@ -62,8 +62,8 @@ describe('TableSelection Plugin computeds', () => {
       );
       const extraPropsKeys = Object.keys(extraProps);
 
-      extraProps.onClick({ row: { original: { field: 'a' } } });
-      extraProps.onClick({ row: { original: { field: 'c' } } });
+      extraProps.onClick({ tableRow: { row: { field: 'a' } } });
+      extraProps.onClick({ tableRow: { row: { field: 'c' } } });
 
       expect(extraPropsKeys).toHaveLength(2);
       expect(extraPropsKeys[0]).toBe('a');

--- a/packages/dx-grid-core/src/plugins/table-selection/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/computeds.test.js
@@ -8,27 +8,21 @@ import {
 
 describe('TableSelection Plugin computeds', () => {
   describe('#tableColumnsWithSelection', () => {
-    const tableColumns = [
-      { name: 'a' },
-      { name: 'b' },
-    ];
-
     it('should work', () => {
-      const columns = tableColumnsWithSelection(tableColumns, 123);
-
-      expect(columns).toHaveLength(3);
-      expect(columns[0]).toMatchObject({ type: TABLE_SELECT_TYPE, id: 0, width: 123 });
-      expect(columns[1]).toBe(tableColumns[0]);
-      expect(columns[2]).toBe(tableColumns[1]);
+      expect(tableColumnsWithSelection([{}], 123))
+        .toEqual([
+          { key: TABLE_SELECT_TYPE, type: TABLE_SELECT_TYPE, width: 123 },
+          {},
+        ]);
     });
   });
 
   describe('#tableRowsWithSelection', () => {
     const bodyRows = [
-      { type: TABLE_DATA_TYPE, id: 0, row: { field: 'a' } },
-      { type: TABLE_DATA_TYPE, id: 1, row: { field: 'b' } },
-      { type: TABLE_DATA_TYPE, id: 2, row: { field: 'c' } },
-      { type: 'undefined', id: 2, row: { field: 'c' } },
+      { type: TABLE_DATA_TYPE, rowId: 0, row: { field: 'a' } },
+      { type: TABLE_DATA_TYPE, rowId: 1, row: { field: 'b' } },
+      { type: TABLE_DATA_TYPE, rowId: 2, row: { field: 'c' } },
+      { type: 'undefined', rowId: 2, row: { field: 'c' } },
     ];
     const selection = [0, 2];
 
@@ -37,10 +31,10 @@ describe('TableSelection Plugin computeds', () => {
 
       expect(selectedRows)
         .toEqual([
-          { type: TABLE_DATA_TYPE, id: 0, row: { field: 'a' }, selected: true },
-          { type: TABLE_DATA_TYPE, id: 1, row: { field: 'b' } },
-          { type: TABLE_DATA_TYPE, id: 2, row: { field: 'c' }, selected: true },
-          { type: 'undefined', id: 2, row: { field: 'c' } },
+          { type: TABLE_DATA_TYPE, rowId: 0, row: { field: 'a' }, selected: true },
+          { type: TABLE_DATA_TYPE, rowId: 1, row: { field: 'b' } },
+          { type: TABLE_DATA_TYPE, rowId: 2, row: { field: 'c' }, selected: true },
+          { type: 'undefined', rowId: 2, row: { field: 'c' } },
         ]);
     });
   });
@@ -57,9 +51,9 @@ describe('TableSelection Plugin computeds', () => {
       );
       const extraPropsKeys = Object.keys(extraProps);
 
-      extraProps.onClick({ tableRow: { type: TABLE_DATA_TYPE, id: 0, row: { field: 'a' } } });
-      extraProps.onClick({ tableRow: { type: TABLE_DATA_TYPE, id: 2, row: { field: 'c' } } });
-      extraProps.onClick({ tableRow: { type: 'undefined', id: 3, row: { field: 'c' } } });
+      extraProps.onClick({ tableRow: { type: TABLE_DATA_TYPE, rowId: 0, row: { field: 'a' } } });
+      extraProps.onClick({ tableRow: { type: TABLE_DATA_TYPE, rowId: 2, row: { field: 'c' } } });
+      extraProps.onClick({ tableRow: { type: 'undefined', rowId: 3, row: { field: 'c' } } });
 
       expect(extraPropsKeys).toHaveLength(2);
       expect(extraPropsKeys[0]).toBe('a');

--- a/packages/dx-grid-core/src/plugins/table-selection/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/computeds.test.js
@@ -1,7 +1,8 @@
+import { SELECT_TYPE } from './constants';
 import {
-    tableColumnsWithSelection,
-    tableBodyRowsWithSelection,
-    tableExtraProps,
+  tableColumnsWithSelection,
+  tableBodyRowsWithSelection,
+  tableExtraPropsWithSelection,
 } from './computeds';
 
 describe('TableSelection Plugin computeds', () => {
@@ -15,7 +16,7 @@ describe('TableSelection Plugin computeds', () => {
       const columns = tableColumnsWithSelection(tableColumns, 123);
 
       expect(columns).toHaveLength(3);
-      expect(columns[0]).toMatchObject({ type: 'select', name: 'select', width: 123 });
+      expect(columns[0]).toMatchObject({ type: SELECT_TYPE, id: 0, width: 123 });
       expect(columns[1]).toBe(tableColumns[0]);
       expect(columns[2]).toBe(tableColumns[1]);
     });
@@ -23,48 +24,46 @@ describe('TableSelection Plugin computeds', () => {
 
   describe('#tableBodyRowsWithSelection', () => {
     const bodyRows = [
-      { field: 'a' },
-      { field: 'b' },
-      { field: 'c' },
+      { original: { field: 'a' } },
+      { original: { field: 'b' } },
+      { original: { field: 'c' } },
     ];
     const selection = [0, 2];
-    const getRowId = row => bodyRows.findIndex(item => item.field === row.field);
+    const getRowId = row => bodyRows.findIndex(item => item.original.field === row.field);
 
     it('should work', () => {
       const selectedRows = tableBodyRowsWithSelection(bodyRows, selection, getRowId);
 
-      expect(selectedRows).toHaveLength(3);
-      expect(selectedRows[0]).toMatchObject({ selected: true, _originalRow: bodyRows[0], field: 'a' });
-      expect(selectedRows[1]).toBe(bodyRows[1]);
-      expect(selectedRows[2]).toMatchObject({ selected: true, _originalRow: bodyRows[2], field: 'c' });
+      expect(selectedRows)
+        .toEqual([
+          { selected: true, original: { field: 'a' } },
+          { original: { field: 'b' } },
+          { selected: true, original: { field: 'c' } },
+        ]);
     });
   });
 
-  describe('#tableExtraProps', () => {
+  describe('#tableExtraPropsWithSelection', () => {
     const rows = [
-      { name: 'a' },
-      { name: 'b' },
-      { name: 'c' },
+      { original: { field: 'a' } },
+      { original: { field: 'b' } },
+      { original: { field: 'c' } },
     ];
-
-    const getRowId = row => rows.findIndex(item => row.name === item.name);
+    const getRowId = row => rows.findIndex(item => item.original.field === row.field);
     const setRowSelectionMock = jest.fn();
     const setRowSelectionCalls = setRowSelectionMock.mock.calls;
     const existingExtraProps = { a: 1 };
-    const availableToSelect = [0, 2];
 
     it('should work', () => {
-      const extraProps = tableExtraProps(
+      const extraProps = tableExtraPropsWithSelection(
         existingExtraProps,
-        availableToSelect,
         setRowSelectionMock,
         getRowId,
       );
       const extraPropsKeys = Object.keys(extraProps);
 
-      extraProps.onClick({ row: { name: 'a' } });
-      extraProps.onClick({ row: { name: 'b' } });
-      extraProps.onClick({ row: { name: 'c' } });
+      extraProps.onClick({ row: { original: { field: 'a' } } });
+      extraProps.onClick({ row: { original: { field: 'c' } } });
 
       expect(extraPropsKeys).toHaveLength(2);
       expect(extraPropsKeys[0]).toBe('a');

--- a/packages/dx-grid-core/src/plugins/table-selection/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/computeds.test.js
@@ -1,4 +1,5 @@
 import { TABLE_SELECT_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
 import {
   tableColumnsWithSelection,
   tableRowsWithSelection,
@@ -24,32 +25,27 @@ describe('TableSelection Plugin computeds', () => {
 
   describe('#tableRowsWithSelection', () => {
     const bodyRows = [
-      { row: { field: 'a' } },
-      { row: { field: 'b' } },
-      { row: { field: 'c' } },
+      { type: TABLE_DATA_TYPE, id: 0, row: { field: 'a' } },
+      { type: TABLE_DATA_TYPE, id: 1, row: { field: 'b' } },
+      { type: TABLE_DATA_TYPE, id: 2, row: { field: 'c' } },
+      { type: 'undefined', id: 2, row: { field: 'c' } },
     ];
     const selection = [0, 2];
-    const getRowId = row => bodyRows.findIndex(item => item.row.field === row.field);
 
     it('should work', () => {
-      const selectedRows = tableRowsWithSelection(bodyRows, selection, getRowId);
+      const selectedRows = tableRowsWithSelection(bodyRows, selection);
 
       expect(selectedRows)
         .toEqual([
-          { selected: true, row: { field: 'a' } },
-          { row: { field: 'b' } },
-          { selected: true, row: { field: 'c' } },
+          { type: TABLE_DATA_TYPE, id: 0, row: { field: 'a' }, selected: true },
+          { type: TABLE_DATA_TYPE, id: 1, row: { field: 'b' } },
+          { type: TABLE_DATA_TYPE, id: 2, row: { field: 'c' }, selected: true },
+          { type: 'undefined', id: 2, row: { field: 'c' } },
         ]);
     });
   });
 
   describe('#tableExtraPropsWithSelection', () => {
-    const rows = [
-      { row: { field: 'a' } },
-      { row: { field: 'b' } },
-      { row: { field: 'c' } },
-    ];
-    const getRowId = row => rows.findIndex(item => item.row.field === row.field);
     const setRowSelectionMock = jest.fn();
     const setRowSelectionCalls = setRowSelectionMock.mock.calls;
     const existingExtraProps = { a: 1 };
@@ -58,12 +54,12 @@ describe('TableSelection Plugin computeds', () => {
       const extraProps = tableExtraPropsWithSelection(
         existingExtraProps,
         setRowSelectionMock,
-        getRowId,
       );
       const extraPropsKeys = Object.keys(extraProps);
 
-      extraProps.onClick({ tableRow: { row: { field: 'a' } } });
-      extraProps.onClick({ tableRow: { row: { field: 'c' } } });
+      extraProps.onClick({ tableRow: { type: TABLE_DATA_TYPE, id: 0, row: { field: 'a' } } });
+      extraProps.onClick({ tableRow: { type: TABLE_DATA_TYPE, id: 2, row: { field: 'c' } } });
+      extraProps.onClick({ tableRow: { type: 'undefined', id: 3, row: { field: 'c' } } });
 
       expect(extraPropsKeys).toHaveLength(2);
       expect(extraPropsKeys[0]).toBe('a');

--- a/packages/dx-grid-core/src/plugins/table-selection/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/constants.js
@@ -1,0 +1,1 @@
+export const SELECT_TYPE = 'select';

--- a/packages/dx-grid-core/src/plugins/table-selection/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/constants.js
@@ -1,1 +1,1 @@
-export const SELECT_TYPE = 'select';
+export const TABLE_SELECT_TYPE = 'select';

--- a/packages/dx-grid-core/src/plugins/table-selection/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/helpers.js
@@ -1,8 +1,8 @@
-import { SELECT_TYPE } from './constants';
-import { DATA_TYPE } from '../table-view/constants';
-import { HEADING_TYPE } from '../table-header-row/constants';
+import { TABLE_SELECT_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
+import { TABLE_HEADING_TYPE } from '../table-header-row/constants';
 
 export const isSelectTableCell = (row, column) =>
-  column.type === SELECT_TYPE && row.type === DATA_TYPE;
+  column.type === TABLE_SELECT_TYPE && row.type === TABLE_DATA_TYPE;
 export const isSelectAllTableCell = (row, column) =>
-  column.type === SELECT_TYPE && row.type === HEADING_TYPE;
+  column.type === TABLE_SELECT_TYPE && row.type === TABLE_HEADING_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-selection/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/helpers.js
@@ -2,7 +2,7 @@ import { TABLE_SELECT_TYPE } from './constants';
 import { TABLE_DATA_TYPE } from '../table-view/constants';
 import { TABLE_HEADING_TYPE } from '../table-header-row/constants';
 
-export const isSelectTableCell = (row, column) =>
-  column.type === TABLE_SELECT_TYPE && row.type === TABLE_DATA_TYPE;
-export const isSelectAllTableCell = (row, column) =>
-  column.type === TABLE_SELECT_TYPE && row.type === TABLE_HEADING_TYPE;
+export const isSelectTableCell = (tableRow, tableColumn) =>
+  tableColumn.type === TABLE_SELECT_TYPE && tableRow.type === TABLE_DATA_TYPE;
+export const isSelectAllTableCell = (tableRow, tableColumn) =>
+  tableColumn.type === TABLE_SELECT_TYPE && tableRow.type === TABLE_HEADING_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-selection/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/helpers.js
@@ -1,0 +1,8 @@
+import { SELECT_TYPE } from './constants';
+import { DATA_TYPE } from '../table-view/constants';
+import { HEADING_TYPE } from '../table-header-row/constants';
+
+export const isSelectTableCell = (row, column) =>
+  column.type === SELECT_TYPE && row.type === DATA_TYPE;
+export const isSelectAllTableCell = (row, column) =>
+  column.type === SELECT_TYPE && row.type === HEADING_TYPE;

--- a/packages/dx-grid-core/src/plugins/table-selection/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/helpers.test.js
@@ -1,6 +1,6 @@
-import { SELECT_TYPE } from './constants';
-import { DATA_TYPE } from '../table-view/constants';
-import { HEADING_TYPE } from '../table-header-row/constants';
+import { TABLE_SELECT_TYPE } from './constants';
+import { TABLE_DATA_TYPE } from '../table-view/constants';
+import { TABLE_HEADING_TYPE } from '../table-header-row/constants';
 import {
   isSelectAllTableCell,
   isSelectTableCell,
@@ -9,21 +9,21 @@ import {
 describe('TableSelection Plugin helpers', () => {
   describe('#isSelectAllTableCell', () => {
     it('should work', () => {
-      expect(isSelectAllTableCell({ type: HEADING_TYPE }, { type: SELECT_TYPE }))
+      expect(isSelectAllTableCell({ type: TABLE_HEADING_TYPE }, { type: TABLE_SELECT_TYPE }))
         .toBeTruthy();
-      expect(isSelectAllTableCell({ type: DATA_TYPE }, { type: SELECT_TYPE }))
+      expect(isSelectAllTableCell({ type: TABLE_DATA_TYPE }, { type: TABLE_SELECT_TYPE }))
         .toBeFalsy();
-      expect(isSelectAllTableCell({ type: 'undefined' }, { type: SELECT_TYPE }))
+      expect(isSelectAllTableCell({ type: 'undefined' }, { type: TABLE_SELECT_TYPE }))
         .toBeFalsy();
     });
   });
   describe('#isSelectTableCell', () => {
     it('should work', () => {
-      expect(isSelectTableCell({ type: DATA_TYPE }, { type: SELECT_TYPE }))
+      expect(isSelectTableCell({ type: TABLE_DATA_TYPE }, { type: TABLE_SELECT_TYPE }))
         .toBeTruthy();
-      expect(isSelectTableCell({ type: HEADING_TYPE }, { type: SELECT_TYPE }))
+      expect(isSelectTableCell({ type: TABLE_HEADING_TYPE }, { type: TABLE_SELECT_TYPE }))
         .toBeFalsy();
-      expect(isSelectTableCell({ type: 'undefined' }, { type: SELECT_TYPE }))
+      expect(isSelectTableCell({ type: 'undefined' }, { type: TABLE_SELECT_TYPE }))
         .toBeFalsy();
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-selection/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-selection/helpers.test.js
@@ -1,0 +1,30 @@
+import { SELECT_TYPE } from './constants';
+import { DATA_TYPE } from '../table-view/constants';
+import { HEADING_TYPE } from '../table-header-row/constants';
+import {
+  isSelectAllTableCell,
+  isSelectTableCell,
+} from './helpers';
+
+describe('TableSelection Plugin helpers', () => {
+  describe('#isSelectAllTableCell', () => {
+    it('should work', () => {
+      expect(isSelectAllTableCell({ type: HEADING_TYPE }, { type: SELECT_TYPE }))
+        .toBeTruthy();
+      expect(isSelectAllTableCell({ type: DATA_TYPE }, { type: SELECT_TYPE }))
+        .toBeFalsy();
+      expect(isSelectAllTableCell({ type: 'undefined' }, { type: SELECT_TYPE }))
+        .toBeFalsy();
+    });
+  });
+  describe('#isSelectTableCell', () => {
+    it('should work', () => {
+      expect(isSelectTableCell({ type: DATA_TYPE }, { type: SELECT_TYPE }))
+        .toBeTruthy();
+      expect(isSelectTableCell({ type: HEADING_TYPE }, { type: SELECT_TYPE }))
+        .toBeFalsy();
+      expect(isSelectTableCell({ type: 'undefined' }, { type: SELECT_TYPE }))
+        .toBeFalsy();
+    });
+  });
+});

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.js
@@ -4,7 +4,6 @@ export const tableColumnsWithDataRows = columns =>
   columns.map(column => ({
     key: `${TABLE_DATA_TYPE}_${column.name}`,
     type: TABLE_DATA_TYPE,
-    columnId: column.name,
     width: column.width,
     column,
   }));

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.js
@@ -1,8 +1,8 @@
-import { DATA_TYPE, NODATA_TYPE } from './constants';
+import { TABLE_DATA_TYPE, TABLE_NODATA_TYPE } from './constants';
 
 export const tableColumnsWithDataRows = columns =>
   columns.map(column => ({
-    type: DATA_TYPE,
+    type: TABLE_DATA_TYPE,
     id: column.name,
     width: column.width, // TODO: remove it?
     original: column,
@@ -11,12 +11,12 @@ export const tableColumnsWithDataRows = columns =>
 export const tableRowsWithDataRows = (rows, getRowId) => (
   !rows.length
   ? [{
-    type: NODATA_TYPE,
+    type: TABLE_NODATA_TYPE,
     id: 0,
     colspan: 0,
   }]
   : rows.map(row => ({
-    type: DATA_TYPE,
+    type: TABLE_DATA_TYPE,
     id: getRowId(row),
     original: row,
   })));

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.js
@@ -5,7 +5,7 @@ export const tableColumnsWithDataRows = columns =>
     type: TABLE_DATA_TYPE,
     id: column.name,
     width: column.width, // TODO: remove it?
-    original: column,
+    column,
   }));
 
 export const tableRowsWithDataRows = (rows, getRowId) => (
@@ -18,5 +18,5 @@ export const tableRowsWithDataRows = (rows, getRowId) => (
   : rows.map(row => ({
     type: TABLE_DATA_TYPE,
     id: getRowId(row),
-    original: row,
+    row,
   })));

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.js
@@ -13,7 +13,7 @@ export const tableRowsWithDataRows = (rows, getRowId) => (
   ? [{
     type: TABLE_NODATA_TYPE,
     id: 0,
-    colspan: 0,
+    colSpanStart: 0,
   }]
   : rows.map(row => ({
     type: TABLE_DATA_TYPE,

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.js
@@ -2,21 +2,22 @@ import { TABLE_DATA_TYPE, TABLE_NODATA_TYPE } from './constants';
 
 export const tableColumnsWithDataRows = columns =>
   columns.map(column => ({
+    key: `${TABLE_DATA_TYPE}_${column.name}`,
     type: TABLE_DATA_TYPE,
-    id: column.name,
+    columnId: column.name,
     width: column.width,
     column,
   }));
 
 export const tableRowsWithDataRows = (rows, getRowId) => (
   !rows.length
-  ? [{
-    type: TABLE_NODATA_TYPE,
-    id: 0,
-    colSpanStart: 0,
-  }]
-  : rows.map(row => ({
-    type: TABLE_DATA_TYPE,
-    id: getRowId(row),
-    row,
-  })));
+  ? [{ key: TABLE_NODATA_TYPE, type: TABLE_NODATA_TYPE, colSpanStart: 0 }]
+  : rows.map((row) => {
+    const rowId = getRowId(row);
+    return {
+      key: `${TABLE_DATA_TYPE}_${rowId}`,
+      type: TABLE_DATA_TYPE,
+      rowId,
+      row,
+    };
+  }));

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.js
@@ -4,7 +4,7 @@ export const tableColumnsWithDataRows = columns =>
   columns.map(column => ({
     type: TABLE_DATA_TYPE,
     id: column.name,
-    width: column.width, // TODO: document it
+    width: column.width,
     column,
   }));
 

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.js
@@ -4,7 +4,7 @@ export const tableColumnsWithDataRows = columns =>
   columns.map(column => ({
     type: TABLE_DATA_TYPE,
     id: column.name,
-    width: column.width, // TODO: remove it?
+    width: column.width, // TODO: document it
     column,
   }));
 

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.js
@@ -1,0 +1,22 @@
+import { DATA_TYPE, NODATA_TYPE } from './constants';
+
+export const tableColumnsWithDataRows = columns =>
+  columns.map(column => ({
+    type: DATA_TYPE,
+    id: column.name,
+    width: column.width, // TODO: remove it?
+    original: column,
+  }));
+
+export const tableRowsWithDataRows = (rows, getRowId) => (
+  !rows.length
+  ? [{
+    type: NODATA_TYPE,
+    id: 0,
+    colspan: 0,
+  }]
+  : rows.map(row => ({
+    type: DATA_TYPE,
+    id: getRowId(row),
+    original: row,
+  })));

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.test.js
@@ -11,8 +11,8 @@ describe('TableView Plugin computeds', () => {
 
       expect(tableColumnsWithDataRows(columns))
         .toEqual([
-          { type: TABLE_DATA_TYPE, id: 'a', column: columns[0] },
-          { type: TABLE_DATA_TYPE, id: 'b', column: columns[1] },
+          { key: `${TABLE_DATA_TYPE}_a`, type: TABLE_DATA_TYPE, columnId: 'a', column: columns[0] },
+          { key: `${TABLE_DATA_TYPE}_b`, type: TABLE_DATA_TYPE, columnId: 'b', column: columns[1] },
         ]);
     });
 
@@ -31,8 +31,8 @@ describe('TableView Plugin computeds', () => {
 
       expect(tableRowsWithDataRows(rows, getRowId))
         .toEqual([
-          { type: TABLE_DATA_TYPE, id: 1, row: rows[0] },
-          { type: TABLE_DATA_TYPE, id: 2, row: rows[1] },
+          { key: `${TABLE_DATA_TYPE}_1`, type: TABLE_DATA_TYPE, rowId: 1, row: rows[0] },
+          { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2, row: rows[1] },
         ]);
     });
 
@@ -42,7 +42,7 @@ describe('TableView Plugin computeds', () => {
 
       expect(tableRowsWithDataRows(rows, getRowId))
         .toEqual([
-          { type: TABLE_NODATA_TYPE, id: 0, colSpanStart: 0 },
+          { key: TABLE_NODATA_TYPE, type: TABLE_NODATA_TYPE, colSpanStart: 0 },
         ]);
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.test.js
@@ -1,4 +1,4 @@
-import { DATA_TYPE, NODATA_TYPE } from './constants';
+import { TABLE_DATA_TYPE, TABLE_NODATA_TYPE } from './constants';
 import {
   tableRowsWithDataRows,
   tableColumnsWithDataRows,
@@ -11,8 +11,8 @@ describe('TableView Plugin computeds', () => {
 
       expect(tableColumnsWithDataRows(columns))
         .toEqual([
-          { type: DATA_TYPE, id: 'a', original: columns[0] },
-          { type: DATA_TYPE, id: 'b', original: columns[1] },
+          { type: TABLE_DATA_TYPE, id: 'a', original: columns[0] },
+          { type: TABLE_DATA_TYPE, id: 'b', original: columns[1] },
         ]);
     });
 
@@ -31,8 +31,8 @@ describe('TableView Plugin computeds', () => {
 
       expect(tableRowsWithDataRows(rows, getRowId))
         .toEqual([
-          { type: DATA_TYPE, id: 1, original: rows[0] },
-          { type: DATA_TYPE, id: 2, original: rows[1] },
+          { type: TABLE_DATA_TYPE, id: 1, original: rows[0] },
+          { type: TABLE_DATA_TYPE, id: 2, original: rows[1] },
         ]);
     });
 
@@ -42,7 +42,7 @@ describe('TableView Plugin computeds', () => {
 
       expect(tableRowsWithDataRows(rows, getRowId))
         .toEqual([
-          { type: NODATA_TYPE, id: 0, colspan: 0 },
+          { type: TABLE_NODATA_TYPE, id: 0, colspan: 0 },
         ]);
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.test.js
@@ -11,8 +11,8 @@ describe('TableView Plugin computeds', () => {
 
       expect(tableColumnsWithDataRows(columns))
         .toEqual([
-          { key: `${TABLE_DATA_TYPE}_a`, type: TABLE_DATA_TYPE, columnId: 'a', column: columns[0] },
-          { key: `${TABLE_DATA_TYPE}_b`, type: TABLE_DATA_TYPE, columnId: 'b', column: columns[1] },
+          { key: `${TABLE_DATA_TYPE}_a`, type: TABLE_DATA_TYPE, column: columns[0] },
+          { key: `${TABLE_DATA_TYPE}_b`, type: TABLE_DATA_TYPE, column: columns[1] },
         ]);
     });
 

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.test.js
@@ -1,0 +1,49 @@
+import { DATA_TYPE, NODATA_TYPE } from './constants';
+import {
+  tableRowsWithDataRows,
+  tableColumnsWithDataRows,
+} from './computeds';
+
+describe('TableView Plugin computeds', () => {
+  describe('#tableColumnsWithDataRows', () => {
+    it('should work', () => {
+      const columns = [{ name: 'a' }, { name: 'b' }];
+
+      expect(tableColumnsWithDataRows(columns))
+        .toEqual([
+          { type: DATA_TYPE, id: 'a', original: columns[0] },
+          { type: DATA_TYPE, id: 'b', original: columns[1] },
+        ]);
+    });
+
+    it('should copy width', () => {
+      const columns = [{ name: 'a', width: 100 }];
+
+      expect(tableColumnsWithDataRows(columns)[0])
+        .toMatchObject({ width: 100 });
+    });
+  });
+
+  describe('#tableRowsWithDataRows', () => {
+    it('should work', () => {
+      const rows = [{ id: 1 }, { id: 2 }];
+      const getRowId = row => row.id;
+
+      expect(tableRowsWithDataRows(rows, getRowId))
+        .toEqual([
+          { type: DATA_TYPE, id: 1, original: rows[0] },
+          { type: DATA_TYPE, id: 2, original: rows[1] },
+        ]);
+    });
+
+    it('should add nodata row if rows are empty', () => {
+      const rows = [];
+      const getRowId = row => row.id;
+
+      expect(tableRowsWithDataRows(rows, getRowId))
+        .toEqual([
+          { type: NODATA_TYPE, id: 0, colspan: 0 },
+        ]);
+    });
+  });
+});

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.test.js
@@ -42,7 +42,7 @@ describe('TableView Plugin computeds', () => {
 
       expect(tableRowsWithDataRows(rows, getRowId))
         .toEqual([
-          { type: TABLE_NODATA_TYPE, id: 0, colspan: 0 },
+          { type: TABLE_NODATA_TYPE, id: 0, colSpanStart: 0 },
         ]);
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-view/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-view/computeds.test.js
@@ -11,8 +11,8 @@ describe('TableView Plugin computeds', () => {
 
       expect(tableColumnsWithDataRows(columns))
         .toEqual([
-          { type: TABLE_DATA_TYPE, id: 'a', original: columns[0] },
-          { type: TABLE_DATA_TYPE, id: 'b', original: columns[1] },
+          { type: TABLE_DATA_TYPE, id: 'a', column: columns[0] },
+          { type: TABLE_DATA_TYPE, id: 'b', column: columns[1] },
         ]);
     });
 
@@ -31,8 +31,8 @@ describe('TableView Plugin computeds', () => {
 
       expect(tableRowsWithDataRows(rows, getRowId))
         .toEqual([
-          { type: TABLE_DATA_TYPE, id: 1, original: rows[0] },
-          { type: TABLE_DATA_TYPE, id: 2, original: rows[1] },
+          { type: TABLE_DATA_TYPE, id: 1, row: rows[0] },
+          { type: TABLE_DATA_TYPE, id: 2, row: rows[1] },
         ]);
     });
 

--- a/packages/dx-grid-core/src/plugins/table-view/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-view/constants.js
@@ -1,0 +1,2 @@
+export const DATA_TYPE = 'data';
+export const NODATA_TYPE = 'nodata';

--- a/packages/dx-grid-core/src/plugins/table-view/constants.js
+++ b/packages/dx-grid-core/src/plugins/table-view/constants.js
@@ -1,2 +1,2 @@
-export const DATA_TYPE = 'data';
-export const NODATA_TYPE = 'nodata';
+export const TABLE_DATA_TYPE = 'data';
+export const TABLE_NODATA_TYPE = 'nodata';

--- a/packages/dx-grid-core/src/plugins/table-view/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-view/helpers.js
@@ -1,5 +1,5 @@
-import { DATA_TYPE, NODATA_TYPE } from './constants';
+import { TABLE_DATA_TYPE, TABLE_NODATA_TYPE } from './constants';
 
-export const isNoDataTableRow = row => row.type === NODATA_TYPE;
-export const isDataTableCell = (row, column) => row.type === DATA_TYPE && column.type === DATA_TYPE;
+export const isNoDataTableRow = row => row.type === TABLE_NODATA_TYPE;
+export const isDataTableCell = (row, column) => row.type === TABLE_DATA_TYPE && column.type === TABLE_DATA_TYPE;
 export const isHeaderStubTableCell = (row, headerRows) => headerRows.indexOf(row) > -1;

--- a/packages/dx-grid-core/src/plugins/table-view/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-view/helpers.js
@@ -1,0 +1,5 @@
+import { DATA_TYPE, NODATA_TYPE } from './constants';
+
+export const isNoDataTableRow = row => row.type === NODATA_TYPE;
+export const isDataTableCell = (row, column) => row.type === DATA_TYPE && column.type === DATA_TYPE;
+export const isHeaderStubTableCell = (row, headerRows) => headerRows.indexOf(row) > -1;

--- a/packages/dx-grid-core/src/plugins/table-view/helpers.js
+++ b/packages/dx-grid-core/src/plugins/table-view/helpers.js
@@ -1,5 +1,6 @@
 import { TABLE_DATA_TYPE, TABLE_NODATA_TYPE } from './constants';
 
-export const isNoDataTableRow = row => row.type === TABLE_NODATA_TYPE;
-export const isDataTableCell = (row, column) => row.type === TABLE_DATA_TYPE && column.type === TABLE_DATA_TYPE;
-export const isHeaderStubTableCell = (row, headerRows) => headerRows.indexOf(row) > -1;
+export const isNoDataTableRow = tableRow => tableRow.type === TABLE_NODATA_TYPE;
+export const isDataTableCell = (tableRow, tableColumn) =>
+  tableRow.type === TABLE_DATA_TYPE && tableColumn.type === TABLE_DATA_TYPE;
+export const isHeaderStubTableCell = (tableRow, headerRows) => headerRows.indexOf(tableRow) > -1;

--- a/packages/dx-grid-core/src/plugins/table-view/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-view/helpers.test.js
@@ -1,0 +1,38 @@
+import { DATA_TYPE, NODATA_TYPE } from './constants';
+import {
+  isNoDataTableRow,
+  isDataTableCell,
+  isHeaderStubTableCell,
+} from './helpers';
+
+describe('TableView Plugin helpers', () => {
+  describe('#isNoDataTableRow', () => {
+    it('should work', () => {
+      expect(isNoDataTableRow({ type: NODATA_TYPE }))
+        .toBeTruthy();
+      expect(isNoDataTableRow({ type: 'undefined' }))
+        .toBeFalsy();
+    });
+  });
+  describe('#isDataTableCell', () => {
+    it('should work', () => {
+      expect(isDataTableCell({ type: DATA_TYPE }, { type: DATA_TYPE }))
+        .toBeTruthy();
+      expect(isDataTableCell({ type: 'undefined' }, { type: DATA_TYPE }))
+        .toBeFalsy();
+      expect(isDataTableCell({ type: DATA_TYPE }, { type: 'undefined' }))
+        .toBeFalsy();
+      expect(isDataTableCell({ type: 'undefined' }, { type: 'undefined' }))
+        .toBeFalsy();
+    });
+  });
+  describe('#isHeaderStubTableCell', () => {
+    it('should work', () => {
+      const row = { type: 'undefined' };
+      expect(isHeaderStubTableCell(row, [row]))
+        .toBeTruthy();
+      expect(isHeaderStubTableCell(row, []))
+        .toBeFalsy();
+    });
+  });
+});

--- a/packages/dx-grid-core/src/plugins/table-view/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table-view/helpers.test.js
@@ -1,4 +1,4 @@
-import { DATA_TYPE, NODATA_TYPE } from './constants';
+import { TABLE_DATA_TYPE, TABLE_NODATA_TYPE } from './constants';
 import {
   isNoDataTableRow,
   isDataTableCell,
@@ -8,7 +8,7 @@ import {
 describe('TableView Plugin helpers', () => {
   describe('#isNoDataTableRow', () => {
     it('should work', () => {
-      expect(isNoDataTableRow({ type: NODATA_TYPE }))
+      expect(isNoDataTableRow({ type: TABLE_NODATA_TYPE }))
         .toBeTruthy();
       expect(isNoDataTableRow({ type: 'undefined' }))
         .toBeFalsy();
@@ -16,11 +16,11 @@ describe('TableView Plugin helpers', () => {
   });
   describe('#isDataTableCell', () => {
     it('should work', () => {
-      expect(isDataTableCell({ type: DATA_TYPE }, { type: DATA_TYPE }))
+      expect(isDataTableCell({ type: TABLE_DATA_TYPE }, { type: TABLE_DATA_TYPE }))
         .toBeTruthy();
-      expect(isDataTableCell({ type: 'undefined' }, { type: DATA_TYPE }))
+      expect(isDataTableCell({ type: 'undefined' }, { type: TABLE_DATA_TYPE }))
         .toBeFalsy();
-      expect(isDataTableCell({ type: DATA_TYPE }, { type: 'undefined' }))
+      expect(isDataTableCell({ type: TABLE_DATA_TYPE }, { type: 'undefined' }))
         .toBeFalsy();
       expect(isDataTableCell({ type: 'undefined' }, { type: 'undefined' }))
         .toBeFalsy();

--- a/packages/dx-grid-core/src/utils/table.js
+++ b/packages/dx-grid-core/src/utils/table.js
@@ -5,19 +5,19 @@ import { getTargetColumnGeometries } from './column-geometries';
 
 export const tableKeyGetter = object => `${object.type}_${object.id}`;
 
-export const getTableRowColumnsWithColSpan = (columns, colSpanStart) => {
-  if (colSpanStart === undefined) return columns.map(column => ({ original: column }));
+export const getTableRowColumnsWithColSpan = (tableColumns, colSpanStart) => {
+  if (colSpanStart === undefined) return tableColumns;
 
   let span = false;
-  return columns
-    .reduce((acc, column, columnIndex) => {
+  return tableColumns
+    .reduce((acc, tableColumn, columnIndex) => {
       if (span) return acc;
       if (columnIndex === colSpanStart ||
-        tableKeyGetter(column, columnIndex) === colSpanStart) {
+        tableKeyGetter(tableColumn, columnIndex) === colSpanStart) {
         span = true;
-        return [...acc, { original: column, colspan: columns.length - columnIndex }];
+        return [...acc, { ...tableColumn, colspan: tableColumns.length - columnIndex }];
       }
-      return [...acc, { original: column }];
+      return [...acc, tableColumn];
     }, []);
 };
 

--- a/packages/dx-grid-core/src/utils/table.js
+++ b/packages/dx-grid-core/src/utils/table.js
@@ -3,8 +3,6 @@ import { easeOutCubic } from '@devexpress/dx-core';
 import { querySelectorAll } from './dom-utils';
 import { getTargetColumnGeometries } from './column-geometries';
 
-export const tableKeyGetter = object => `${object.type}_${object.id}`;
-
 export const getTableRowColumnsWithColSpan = (tableColumns, colSpanStart) => {
   if (colSpanStart === undefined) return tableColumns;
 
@@ -12,8 +10,7 @@ export const getTableRowColumnsWithColSpan = (tableColumns, colSpanStart) => {
   return tableColumns
     .reduce((acc, tableColumn, columnIndex) => {
       if (span) return acc;
-      if (columnIndex === colSpanStart ||
-        tableKeyGetter(tableColumn, columnIndex) === colSpanStart) {
+      if (columnIndex === colSpanStart || tableColumn.key === colSpanStart) {
         span = true;
         return [...acc, { ...tableColumn, colspan: tableColumns.length - columnIndex }];
       }
@@ -71,7 +68,7 @@ export const getAnimations = (
   prevColumns, nextColumns, tableWidth, draggingColumnKey, prevAnimations,
 ) => {
   const prevColumnGeometries = new Map(getTableColumnGeometries(prevColumns, tableWidth)
-    .map((geometry, index) => [tableKeyGetter(prevColumns[index]), geometry])
+    .map((geometry, index) => [prevColumns[index].key, geometry])
     .map(([key, geometry]) => {
       const animation = prevAnimations.get(key);
       if (!animation) return [key, geometry];
@@ -84,7 +81,7 @@ export const getAnimations = (
     }));
 
   const nextColumnGeometries = new Map(getTableColumnGeometries(nextColumns, tableWidth)
-    .map((geometry, index) => [tableKeyGetter(nextColumns[index]), geometry]));
+    .map((geometry, index) => [nextColumns[index].key, geometry]));
 
   return new Map([...nextColumnGeometries.keys()]
     .map((key) => {

--- a/packages/dx-grid-core/src/utils/table.js
+++ b/packages/dx-grid-core/src/utils/table.js
@@ -3,18 +3,7 @@ import { easeOutCubic } from '@devexpress/dx-core';
 import { querySelectorAll } from './dom-utils';
 import { getTargetColumnGeometries } from './column-geometries';
 
-const getTableKeyGetter = (getIntrinsicKey, object, index) => {
-  const type = object.type || 'data';
-  const intrinsicKey = type === 'data' ? getIntrinsicKey(object) : object.id;
-  const key = intrinsicKey === undefined ? `$${index}` : intrinsicKey;
-  return `${type}_${key}`;
-};
-
-export const tableRowKeyGetter = getTableKeyGetter;
-
-const getColumnId = column => column.name;
-export const tableColumnKeyGetter = (column, columnIndex) =>
-  getTableKeyGetter(getColumnId, column, columnIndex);
+export const tableKeyGetter = object => `${object.type}_${object.id}`;
 
 export const getTableCellInfo = ({ row, columnIndex, columns }) => {
   if (row.colspan !== undefined && columnIndex > row.colspan) return { skip: true };
@@ -72,7 +61,7 @@ export const getAnimations = (
   prevColumns, nextColumns, tableWidth, draggingColumnKey, prevAnimations,
 ) => {
   const prevColumnGeometries = new Map(getTableColumnGeometries(prevColumns, tableWidth)
-    .map((geometry, index) => [tableColumnKeyGetter(prevColumns[index], index), geometry])
+    .map((geometry, index) => [tableKeyGetter(prevColumns[index]), geometry])
     .map(([key, geometry]) => {
       const animation = prevAnimations.get(key);
       if (!animation) return [key, geometry];
@@ -85,7 +74,7 @@ export const getAnimations = (
     }));
 
   const nextColumnGeometries = new Map(getTableColumnGeometries(nextColumns, tableWidth)
-    .map((geometry, index) => [tableColumnKeyGetter(nextColumns[index], index), geometry]));
+    .map((geometry, index) => [tableKeyGetter(nextColumns[index]), geometry]));
 
   return new Map([...nextColumnGeometries.keys()]
     .map((key) => {

--- a/packages/dx-grid-core/src/utils/table.test.js
+++ b/packages/dx-grid-core/src/utils/table.test.js
@@ -1,18 +1,10 @@
 import {
-  tableKeyGetter,
   getTableColumnGeometries,
   getTableTargetColumnIndex,
   getTableRowColumnsWithColSpan,
 } from './table';
 
 describe('table utils', () => {
-  describe('#tableKeyGetter', () => {
-    it('should correctly return keys', () => {
-      expect(tableKeyGetter({ type: 'a', id: 0 }))
-        .toBe('a_0');
-    });
-  });
-
   describe('#getTableRowColumnsWithColSpan', () => {
     it('should return correct columns without colspan', () => {
       const columns = [{ type: 'a', id: 1 }, { type: 'b', id: 2 }];
@@ -32,7 +24,7 @@ describe('table utils', () => {
     });
 
     it('should return correct columns with string colspan', () => {
-      const columns = [{ type: 'a', id: 1 }, { type: 'b', id: 2 }, { type: 'c', id: 3 }];
+      const columns = [{ key: 'a_1' }, { key: 'b_2' }, { key: 'c_3' }];
 
       expect(getTableRowColumnsWithColSpan(columns, 'a_1'))
         .toEqual([{ ...columns[0], colspan: 3 }]);

--- a/packages/dx-grid-core/src/utils/table.test.js
+++ b/packages/dx-grid-core/src/utils/table.test.js
@@ -17,28 +17,28 @@ describe('table utils', () => {
     it('should return correct columns without colspan', () => {
       const columns = [{ type: 'a', id: 1 }, { type: 'b', id: 2 }];
 
-      expect(getTableRowColumnsWithColSpan(columns, {}))
-        .toEqual(columns.map(column => ({ original: column })));
+      expect(getTableRowColumnsWithColSpan(columns, null))
+        .toEqual(columns);
     });
 
     it('should return correct columns with numeric colspan', () => {
       const columns = [{ type: 'a', id: 1 }, { type: 'b', id: 2 }, { type: 'c', id: 3 }];
 
       expect(getTableRowColumnsWithColSpan(columns, 0))
-        .toEqual([{ original: columns[0], colspan: 3 }]);
+        .toEqual([{ ...columns[0], colspan: 3 }]);
 
       expect(getTableRowColumnsWithColSpan(columns, 1))
-        .toEqual([{ original: columns[0] }, { original: columns[1], colspan: 2 }]);
+        .toEqual([columns[0], { ...columns[1], colspan: 2 }]);
     });
 
     it('should return correct columns with string colspan', () => {
       const columns = [{ type: 'a', id: 1 }, { type: 'b', id: 2 }, { type: 'c', id: 3 }];
 
       expect(getTableRowColumnsWithColSpan(columns, 'a_1'))
-        .toEqual([{ original: columns[0], colspan: 3 }]);
+        .toEqual([{ ...columns[0], colspan: 3 }]);
 
       expect(getTableRowColumnsWithColSpan(columns, 'b_2'))
-        .toEqual([{ original: columns[0] }, { original: columns[1], colspan: 2 }]);
+        .toEqual([columns[0], { ...columns[1], colspan: 2 }]);
     });
   });
 

--- a/packages/dx-grid-core/src/utils/table.test.js
+++ b/packages/dx-grid-core/src/utils/table.test.js
@@ -1,37 +1,14 @@
 import {
-  tableColumnKeyGetter,
-  tableRowKeyGetter,
+  tableKeyGetter,
   getTableColumnGeometries,
   getTableTargetColumnIndex,
 } from './table';
 
 describe('table utils', () => {
-  describe('#tableColumnKeyGetter', () => {
+  describe('#tableKeyGetter', () => {
     it('should correctly return keys', () => {
-      const columns = [{ type: 'test' }, { type: 'test', id: 'a' }, { name: 'a' }, { name: 'b', id: 'bb' }];
-
-      expect(columns.map(tableColumnKeyGetter))
-        .toEqual([
-          'test_$0',
-          'test_a',
-          'data_a',
-          'data_b',
-        ]);
-    });
-  });
-
-  describe('#tableRowKeyGetter', () => {
-    it('should correctly return keys', () => {
-      const rows = [{ type: 'test' }, { type: 'test', id: 'a' }, { name: 'a' }, { name: 'b', id: 'bb' }];
-      const getRowId = row => rows.filter(r => !r.type).indexOf(row);
-
-      expect(rows.map((row, rowIndex) => tableRowKeyGetter(getRowId, row, rowIndex)))
-        .toEqual([
-          'test_$0',
-          'test_a',
-          'data_0',
-          'data_1',
-        ]);
+      expect(tableKeyGetter({ type: 'a', id: 0 }))
+        .toBe('a_0');
     });
   });
 

--- a/packages/dx-react-demos/src/bootstrap3/featured-remote-data/demo.test.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-remote-data/demo.test.jsx
@@ -4,7 +4,7 @@ import RemoteDataDemo from './demo';
 
 describe('BS3 featured: remote data demo', () => {
   beforeEach(() => {
-    window.fetch = jest.fn().mockImplementation(() => Promise.resolve());
+    window.fetch = jest.fn(() => Promise.resolve());
   });
 
   it('should work', () => {

--- a/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.test.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.test.jsx
@@ -8,7 +8,7 @@ injectTapEventPlugin();
 
 describe('BS3 featured: remote data demo', () => {
   beforeEach(() => {
-    window.fetch = jest.fn().mockImplementation(() => Promise.resolve());
+    window.fetch = jest.fn(() => Promise.resolve());
   });
 
   it('should work', () => {

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.jsx
@@ -15,7 +15,7 @@ export class TableHeaderCell extends React.PureComponent {
   }
   render() {
     const {
-      style, column,
+      style, column, tableColumn,
       allowSorting, sortingDirection, changeSortingDirection,
       allowGroupingByClick, groupByColumn,
       allowDragging, dragPayload,
@@ -84,7 +84,7 @@ export class TableHeaderCell extends React.PureComponent {
             WebkitUserSelect: 'none',
           } : {}),
           ...(allowSorting || allowDragging ? { cursor: 'pointer' } : null),
-          ...(dragging || column.isDraft ? { opacity: 0.3 } : null),
+          ...(dragging || tableColumn.isDraft ? { opacity: 0.3 } : null),
           ...style,
         }}
         onClick={(e) => {
@@ -128,6 +128,7 @@ export class TableHeaderCell extends React.PureComponent {
 }
 
 TableHeaderCell.propTypes = {
+  tableColumn: PropTypes.object,
   column: PropTypes.shape({
     title: PropTypes.string,
   }).isRequired,
@@ -142,6 +143,7 @@ TableHeaderCell.propTypes = {
 };
 
 TableHeaderCell.defaultProps = {
+  tableColumn: {},
   style: null,
   allowSorting: false,
   sortingDirection: undefined,

--- a/packages/dx-react-grid-bootstrap3/src/templates/virtual-table.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/virtual-table.jsx
@@ -74,7 +74,11 @@ export class VirtualTable extends React.Component {
             };
           }}
           itemTemplate={(columnIndex, _, style) =>
-            cellTemplate({ tableRow: row, tableColumn: columnsWithColSpan[columnIndex], style })}
+            cellTemplate({
+              tableRow: row,
+              tableColumn: columnsWithColSpan[columnIndex].original,
+              style,
+            })}
         />
       );
     };

--- a/packages/dx-react-grid-bootstrap3/src/templates/virtual-table.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/virtual-table.jsx
@@ -73,7 +73,7 @@ export class VirtualTable extends React.Component {
             };
           }}
           itemTemplate={(columnIndex, _, style) =>
-            cellTemplate({ row, column: columns[columnIndex], style })}
+            cellTemplate({ tableRow: row, tableColumn: columns[columnIndex], style })}
         />
       );
     };

--- a/packages/dx-react-grid-bootstrap3/src/templates/virtual-table.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/virtual-table.jsx
@@ -74,11 +74,7 @@ export class VirtualTable extends React.Component {
             };
           }}
           itemTemplate={(columnIndex, _, style) =>
-            cellTemplate({
-              tableRow: row,
-              tableColumn: columnsWithColSpan[columnIndex].original,
-              style,
-            })}
+            cellTemplate({ tableRow: row, tableColumn: columnsWithColSpan[columnIndex], style })}
         />
       );
     };

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell.jsx
@@ -98,7 +98,7 @@ class TableHeaderCellBase extends React.PureComponent {
   }
   render() {
     const {
-      style, column,
+      style, column, tableColumn,
       allowSorting, sortingDirection, changeSortingDirection,
       allowGroupingByClick, groupByColumn,
       allowDragging, dragPayload,
@@ -121,11 +121,10 @@ class TableHeaderCellBase extends React.PureComponent {
       {
         [classes.cell]: true,
         [classes.cellRight]: align === 'right',
-        [classes.clearPadding]: !column.name,
         [classes.cellNoUserSelect]: allowDragging || allowSorting,
         [classes.cellDraggable]: allowDragging,
         [classes.cellClickable]: allowSorting,
-        [classes.cellDimmed]: dragging || column.isDraft,
+        [classes.cellDimmed]: dragging || tableColumn.isDraft,
       },
     );
 
@@ -212,6 +211,7 @@ class TableHeaderCellBase extends React.PureComponent {
 }
 
 TableHeaderCellBase.propTypes = {
+  tableColumn: PropTypes.object,
   column: PropTypes.shape({
     title: PropTypes.string,
   }).isRequired,
@@ -227,6 +227,7 @@ TableHeaderCellBase.propTypes = {
 };
 
 TableHeaderCellBase.defaultProps = {
+  tableColumn: {},
   style: null,
   allowSorting: false,
   sortingDirection: undefined,

--- a/packages/dx-react-grid/docs/reference/grid.md
+++ b/packages/dx-react-grid/docs/reference/grid.md
@@ -25,6 +25,8 @@ A data object to be represented as a Grid row
 
 Note that any number of other fields can be specified. The fields are used as data to be displayed within the Grid.
 
+Can be extended by other plugins. See the Extensions section.
+
 ### Column
 
 Describes the column interface
@@ -34,6 +36,8 @@ A value with the following shape:
 Field | Type | Description
 ------|------|------------
 name | string | Specifies the field name in the data row to obtain a column value. A unique key can be also used to identify a particular column
+
+Can be extended by other plugins. See the Extensions section.
 
 ### <a name="root-args"></a>RootArgs
 

--- a/packages/dx-react-grid/docs/reference/grid.md
+++ b/packages/dx-react-grid/docs/reference/grid.md
@@ -25,8 +25,6 @@ A data object to be represented as a Grid row
 
 Note that multiple fields can be specified. These fields are displayed as data within the Grid.
 
-Can be extended by other plugins. See the Extensions section.
-
 ### Column
 
 Describes the column interface
@@ -36,8 +34,6 @@ A value with the following shape:
 Field | Type | Description
 ------|------|------------
 name | string | Specifies the field name in the data row to obtain a column value. A unique key can also be used to identify a column
-
-Can be extended by other plugins. See the Extensions section.
 
 ### <a name="root-args"></a>RootArgs
 

--- a/packages/dx-react-grid/docs/reference/grouping-state.md
+++ b/packages/dx-react-grid/docs/reference/grouping-state.md
@@ -46,9 +46,7 @@ isDraft? | boolean | Indicates that the column should be displayed as grouped
 
 Describes a group that can be nested in another one
 
-A primitive value with the following type: `string`
-
-This string consists of values by which rows are grouped. The `|` symbol merges values. For example, the expanded group 'Male' is described as `Male` and 'Male'/'Audi' as `Male|Audi` and so on.
+A string value that consists of values by which rows are grouped, separated by the `|` character. For example, the expanded group 'Male' is described as `Male` and 'Male'/'Audi' as `Male|Audi` and so on.
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/grouping-state.md
+++ b/packages/dx-react-grid/docs/reference/grouping-state.md
@@ -46,9 +46,7 @@ isDraft? | boolean | Indicates that the column should be displayed as grouped
 
 Describes a group that can be nested in another one
 
-A primitive value with the following type:
-
-string
+A primitive value with the following type: `string`
 
 This string consists of values by which rows are grouped. The `|` symbol merges values. For example, the expanded group 'Male' is described as `Male` and 'Male'/'Audi' as `Male|Audi` and so on.
 
@@ -64,7 +62,7 @@ columns | Getter | Array&lt;[Column](grid.md#column)&gt; | The grid columns
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-grouping | Getter | Array&lt;[Grouping](#grouping)&gt; | The current grouping state 
+grouping | Getter | Array&lt;[Grouping](#grouping)&gt; | The current grouping state
 draftGrouping | Getter | Array&lt;[DraftGrouping](#draft-grouping)&gt; | Grouping options used for preview
 expandedGroups | Getter | Set&lt;[GroupKey](#group-key)&gt; | Expanded groups
 groupedColumns | Getter | Array&lt;[Column](grid.md#column)&gt; | Columns used for grouping

--- a/packages/dx-react-grid/docs/reference/selection-state.md
+++ b/packages/dx-react-grid/docs/reference/selection-state.md
@@ -24,7 +24,6 @@ Name | Plugin | Type | Description
 -----|--------|------|------------
 rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be rendered
 getRowId | Getter | (row: [Row](grid.md#row)) => number &#124; string | A function used to get a unique row identifier
-availableToSelect | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be rendered, which are available for selection
 
 ### Exports
 
@@ -32,5 +31,5 @@ Name | Plugin | Type | Description
 -----|--------|------|------------
 setRowSelection | Action | ({ rowId }) => void | A function that selects a row
 setRowsSelection | Action | ({ rowIds }) => void | A function that selects multiple rows
-availableToSelect | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be rendered, which are available for selection
+availableToSelect | Getter | Array&lt;number &#124; string&gt; | Rows to be rendered, which are available for selection
 selection | Getter | Array&lt;number &#124; string&gt; | Selected rows

--- a/packages/dx-react-grid/docs/reference/table-edit-column.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-column.md
@@ -27,7 +27,7 @@ width | number &#124; string | 140 | Specifies the width of the edit column
 
 Describes properties passed to a data row's command cell template.
 
-Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
+A value with the [TableCellArgs](table-view.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -45,7 +45,7 @@ commandTemplate | (args: [CommandArgs](#command-args)) => ReactElement | A compo
 
 Describes properties passed to a heading row's command cell template.
 
-Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
+A value with the [TableCellArgs](table-view.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------

--- a/packages/dx-react-grid/docs/reference/table-edit-column.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-column.md
@@ -27,12 +27,12 @@ width | number &#124; string | 140 | Specifies the width of the edit column
 
 Describes properties passed to the command cell template of a data row.
 
-A value with the following shape:
+Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
 
 Field | Type | Description
 ------|------|------------
-row | [TableRow](table-view.md#table-row) | Specifies an edited table row with applied changes
-column | [TableColumn](table-view.md#table-column) | Specifies a table column
+row | [Row](grid.md#row) | Specifies an edited table row with applied changes
+column | [Column](grid.md#column) | Specifies a table column
 startEditing | () => void | Switches a row to the editing mode
 cancelEditing | () => void | Switches a row to the read-only mode
 commitChanges | () => void | Initiates committing of row changes
@@ -40,22 +40,18 @@ deleteRow | () => void | Initiates row deletion
 allowEditing | boolean | Specifies if a row can be edited
 allowDeleting | boolean | Specifies if a row can be deleted
 commandTemplate | (args: [CommandArgs](#command-args)) => ReactElement | A component that renders command controls within the command column cell
-style | Object | Styles that should be applied to the root cell element
 
 ### <a name="command-heading-cell-args"></a>CommandHeadingCellArgs
 
 Describes properties passed to the command cell template of a heading row.
 
-A value with the following shape:
+Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
 
 Field | Type | Description
 ------|------|------------
-row | [TableRow](table-view.md#table-row) | Specifies an editing table row with applied changes
-column | [TableColumn](table-view.md#table-column) | Specifies a table column
 addRow | () => void | Creates a new row
 allowAdding | boolean | Specifies if a new row can be created
 commandTemplate | (args: [CommandArgs](#command-args)) => ReactElement | A component that renders command controls within the command column cell
-style | Object | Styles that should be applied to the root cell element
 
 ### <a name="command-args"></a>CommandArgs
 

--- a/packages/dx-react-grid/docs/reference/table-edit-column.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-column.md
@@ -71,7 +71,6 @@ text | string | Specifies the text to be rendered within the command control
 Name | Plugin | Type | Description
 -----|--------|------|------------
 tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
-getRowId | Getter | (row: [Row](grid.md#row)) => number &#124; string | A function used to get a unique row identifier
 addRow | Action | () => void | Creates a row
 cancelAddedRows | Action | ({ rowIds: Array&lt;number&gt; }) => void | Removes uncommitted new rows from the `addedRows` array
 commitAddedRows | Action | ({ rowIds: Array&lt;number&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](editing-state.md#change-set) and removes the specified rows from the `addedRows` array
@@ -81,7 +80,7 @@ cancelChangedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => 
 commitChangedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](editing-state.md#change-set) and removes the specified rows from the `changedRows` array
 deleteRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Prepares rows specified by the ID for deletion, adding them to the `deletedRows` array
 commitDeletedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](editing-state.md#change-set) and removes the specified rows from the `deletedRows` array
-tableViewCell | Template | { row: [TableRow](table-view.md#table-row), column: [TableColumn](table-view.md#table-column) } | A template that renders a table cell
+tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/table-edit-row.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-row.md
@@ -22,7 +22,7 @@ editCellTemplate | (args: [EditCellArgs](#edit-cell-args)) => ReactElement | | A
 
 Describes properties passed to the edit row's cell template.
 
-Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
+A value with the [TableCellArgs](table-view.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------

--- a/packages/dx-react-grid/docs/reference/table-edit-row.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-row.md
@@ -26,8 +26,8 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-row | [TableRow](table-view.md#table-row) | Specifies the initial row
-column | [TableColumn](table-view.md#table-column) | Specifies a table column
+row | [Row](grid.md#row) | Specifies the initial row
+column | [Column](grid.md#column) | Specifies a column
 value | any | Specifies a value to be edited
 onValueChange | (newValue: any) => void | Handles value changes
 

--- a/packages/dx-react-grid/docs/reference/table-edit-row.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-row.md
@@ -40,11 +40,10 @@ Name | Plugin | Type | Description
 tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Rows to be rendered inside the table body
 editingRows | Getter | Array&lt;number &#124; string&gt; | IDs of the rows being edited
 addedRows | Getter | Array&lt;Object&gt; | The created rows
-getRowId | Getter | (row: [Row](grid.md#row)) => number &#124; string | The function used to get a unique row identifier
 changedRows | Getter | { [key: string]: Object } | Uncommitted changed rows
 changeRow | Action | ({ rowId: number &#124; string, change: Object }) => void | Applies a change to an existing row
 changeAddedRow | Action | ({ rowId: number, change: Object }) => void | Applies a change to a new row. Note: `rowId` is a row index within the `addedRows` array
-tableViewCell | Template | { row: [TableRow](table-view.md#table-row), column: [TableColumn](table-view.md#table-column) } | A template that renders a table cell
+tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/table-edit-row.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-row.md
@@ -22,7 +22,7 @@ editCellTemplate | (args: [EditCellArgs](#edit-cell-args)) => ReactElement | | A
 
 Describes properties passed to the edit row's cell template.
 
-A value with the following shape:
+Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
 
 Field | Type | Description
 ------|------|------------

--- a/packages/dx-react-grid/docs/reference/table-filter-row.md
+++ b/packages/dx-react-grid/docs/reference/table-filter-row.md
@@ -22,7 +22,7 @@ filterCellTemplate | (args: [FilterCellArgs](#filter-cell-args)) => ReactElement
 
 Describes properties passed to the filter row cell template.
 
-Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
+A value with the [TableCellArgs](table-view.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------

--- a/packages/dx-react-grid/docs/reference/table-filter-row.md
+++ b/packages/dx-react-grid/docs/reference/table-filter-row.md
@@ -22,14 +22,13 @@ filterCellTemplate | (args: [FilterCellArgs](#filter-cell-args)) => ReactElement
 
 Describes properties passed to the filter row cell template.
 
-A value with the following shape:
+Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
 
 Field | Type | Description
 ------|------|------------
 filter | [Filter](filtering-state.md#filter) | A filter applied to a column
 setFilter | (filter: [Filter](filtering-state.md#filter)) => void | Apply a new filter to a column
 column | [Column](grid.md#column) | Specifies a column
-style? | Object | Specifies filter cell styles
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/table-filter-row.md
+++ b/packages/dx-react-grid/docs/reference/table-filter-row.md
@@ -39,7 +39,7 @@ Name | Plugin | Type | Description
 tableHeaderRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Header rows to be rendered
 filters | Getter | Array&lt;[Filter](filtering-state.md#filter)&gt; | Applied column filters
 setColumnFilter | Action | ({ columnName: string, config: Object }) => void | Changes a column filter. Removes the filter if config is `null`
-tableViewCell | Template | { row: [TableRow](table-view.md#table-row), column: [TableColumn](table-view.md#table-column) } | A template that renders a table cell
+tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/table-filter-row.md
+++ b/packages/dx-react-grid/docs/reference/table-filter-row.md
@@ -28,7 +28,7 @@ Field | Type | Description
 ------|------|------------
 filter | [Filter](filtering-state.md#filter) | A filter applied to a column
 setFilter | (filter: [Filter](filtering-state.md#filter)) => void | Apply a new filter to a column
-column | [TableColumn](table-view.md#table-column) | Specifies a table column
+column | [Column](grid.md#column) | Specifies a column
 style? | Object | Specifies filter cell styles
 
 ## Plugin Developer Reference

--- a/packages/dx-react-grid/docs/reference/table-group-row.md
+++ b/packages/dx-react-grid/docs/reference/table-group-row.md
@@ -46,9 +46,7 @@ column | [Column](grid.md#column) | A group indent column
 
 Describes a group row data structure.
 
-Extends [Row](grid.md#row)
-
-A value with the following shape:
+Extends [Row](grid.md#row) with the following shape:
 
 Field | Type | Description
 ------|------|------------

--- a/packages/dx-react-grid/docs/reference/table-group-row.md
+++ b/packages/dx-react-grid/docs/reference/table-group-row.md
@@ -23,7 +23,7 @@ groupIndentColumnWidth | number | | The group indent column's width
 
 Describes the properties passed to the template that renders a group row.
 
-Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
+A value with the [TableCellArgs](table-view.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -35,7 +35,7 @@ toggleGroupExpanded | () => void | Toggles the group row's expanded state
 
 Describes properties passed to the template that renders a group indent cell.
 
-Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
+A value with the [TableCellArgs](table-view.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------

--- a/packages/dx-react-grid/docs/reference/table-group-row.md
+++ b/packages/dx-react-grid/docs/reference/table-group-row.md
@@ -39,17 +39,15 @@ Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
 
 Field | Type | Description
 ------|------|------------
-row | [GroupRow](#group-row) | A row object
+row | [GroupRow](#group-row) | A group row data object
 
 ### <a name="group-row"></a>GroupRow
 
 Describes the group row data structure.
 
-Extends [Row](grid.md#row) with the following shape:
-
 Field | Type | Description
 ------|------|------------
-row | [GroupRow](#group-row) | A row object
+column | [Column](grid.md#column) | The column associated with the group
 value | any | The current group key value
 
 ## Plugin Developer Reference

--- a/packages/dx-react-grid/docs/reference/table-group-row.md
+++ b/packages/dx-react-grid/docs/reference/table-group-row.md
@@ -64,7 +64,7 @@ grouping | Getter | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | Column
 draftGrouping | Getter | Array&lt;[DraftGrouping](grouping-state.md#draft-grouping)&gt; | Grouping options used for preview
 expandedGroups | Getter | Set&lt;[GroupKey](grouping-state.md#group-key)&gt; | Expanded groups
 toggleGroupExpanded | Action | ({ groupKey: [GroupKey](grouping-state.md#group-key) }) => void | Toggles the expanded group state
-tableViewCell | Template | { row: [TableRow](table-view.md#table-row), column: [TableColumn](table-view.md#table-column) } | A template that renders a table cell
+tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/table-group-row.md
+++ b/packages/dx-react-grid/docs/reference/table-group-row.md
@@ -23,7 +23,7 @@ groupIndentColumnWidth | number | | The group indent column's width
 
 Describes the properties passed to the template that renders a group row.
 
-A value with the following shape:
+Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
 
 Field | Type | Description
 ------|------|------------
@@ -35,12 +35,11 @@ toggleGroupExpanded | () => void | Toggles the group row's expanded state
 
 Describes properties passed to the template that renders a group indent cell.
 
-A value with the following shape:
+Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
 
 Field | Type | Description
 ------|------|------------
-row | [Row](grid.md#row) | A row object
-column | [Column](grid.md#column) | A group indent column
+row | [GroupRow](#group-row) | A row object
 
 ### <a name="group-row"></a>GroupRow
 
@@ -50,7 +49,7 @@ Extends [Row](grid.md#row) with the following shape:
 
 Field | Type | Description
 ------|------|------------
-column | [Column](grid.md#column) | The column associated with the group
+row | [GroupRow](#group-row) | A row object
 value | any | The current group key value
 
 ## Plugin Developer Reference

--- a/packages/dx-react-grid/docs/reference/table-header-row.md
+++ b/packages/dx-react-grid/docs/reference/table-header-row.md
@@ -24,11 +24,11 @@ allowGroupingByClick | boolean | false | If true, it renders a component that to
 
 ## Extensions
 
-### <a name="titled-column"></a>TitledColumn
+### Column
 
-Describes column properties used to render the table header row.
+Extends [Column](grid.md#column)
 
-Extends [Column](grid.md#column) with the following shape:
+A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
@@ -44,7 +44,7 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-column | [TitledColumn](#titled-column) | A column object
+column | [Column](#column) | A column object
 allowSorting | boolean | If true, an end-user can change sorting by a column
 sortingDirection? | 'asc' &#124; 'desc' | Specifies the column sort order
 changeSortingDirection | ({ keepOther: boolean, cancel: boolean }) | Changes column sort direction. Keeps existing sorting if `keepOther` is set to `true`. Cancels sorting by the current column if `cancel` is set to true.
@@ -61,7 +61,7 @@ Name | Plugin | Type | Description
 -----|--------|------|------------
 tableHeaderRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Header rows to be rendered
 sorting | Getter | Array&lt;[Sorting](sorting-state.md#sorting)&gt; | Column sorting
-columns | Getter | Array&lt;[TitledColumn](#titled-column)&gt; | Table columns
+columns | Getter | Array&lt;[Column](#column)&gt; | Table columns
 grouping | Getter | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | Columns used for grouping
 setColumnSorting | Action | ({ columnName: string, direction: 'asc' &#124; 'desc', keepOther: boolean, cancel: boolean }) => void | Changes column sorting
 groupByColumn | Action | ({ columnName: string, groupIndex?: number }) => void | Groups a table by the specified column or cancels grouping. If `groupIndex` is omitted, the group is added to the end of the group list.

--- a/packages/dx-react-grid/docs/reference/table-header-row.md
+++ b/packages/dx-react-grid/docs/reference/table-header-row.md
@@ -22,19 +22,19 @@ allowSorting | boolean | false | If true, it allows an end-user to change sortin
 allowDragging | boolean | false | If true, it allows an end-user to drag a column by the header cell
 allowGroupingByClick | boolean | false | If true, it renders a component that toggles a column's grouping state
 
-## Interfaces
+## Extensions
 
-### Column
+### <a name="titled-column"></a>TitledColumn
 
-Describes properties used to render the table header row.
+Describes column properties used to render the table header row.
 
-Extends [Column](grid.md#column)
-
-A value with the following shape:
+Extends [Column](grid.md#column) with the following shape:
 
 Field | Type | Description
 ------|------|------------
 title? | string | Specifies a table column title
+
+## Interfaces
 
 ### <a name="header-cell-args"></a>HeaderCellArgs
 
@@ -44,6 +44,7 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
+column | [TitledColumn](#titled-column) | A column object
 allowSorting | boolean | If true, an end-user can change sorting by a column
 sortingDirection? | 'asc' &#124; 'desc' | Specifies the column sort order
 changeSortingDirection | ({ keepOther: boolean, cancel: boolean }) | Changes column sort direction. Keeps existing sorting if `keepOther` is set to `true`. Cancels sorting by the current column if `cancel` is set to true.
@@ -60,7 +61,7 @@ Name | Plugin | Type | Description
 -----|--------|------|------------
 tableHeaderRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Header rows to be rendered
 sorting | Getter | Array&lt;[Sorting](sorting-state.md#sorting)&gt; | Column sorting
-columns | Getter | Array&lt;[Column](grid.md#column)&gt; | Table columns
+columns | Getter | Array&lt;[TitledColumn](#titled-column)&gt; | Table columns
 grouping | Getter | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | Columns used for grouping
 setColumnSorting | Action | ({ columnName: string, direction: 'asc' &#124; 'desc', keepOther: boolean, cancel: boolean }) => void | Changes column sorting
 groupByColumn | Action | ({ columnName: string, groupIndex?: number }) => void | Groups a table by the specified column or cancels grouping. If `groupIndex` is omitted, the group is added to the end of the group list.

--- a/packages/dx-react-grid/docs/reference/table-header-row.md
+++ b/packages/dx-react-grid/docs/reference/table-header-row.md
@@ -22,17 +22,15 @@ allowSorting | boolean | false | If true, it allows an end-user to change sortin
 allowDragging | boolean | false | If true, it allows an end-user to drag a column by the header cell
 allowGroupingByClick | boolean | false | If true, it renders a component that toggles a column's grouping state
 
-## Extensions
+## Interfaces
 
-### Column
+### <a name="column"></a>Column (Extension)
 
 Extends [Column](grid.md#column) with the following shape:
 
 Field | Type | Description
 ------|------|------------
 title? | string | Specifies a table column title
-
-## Interfaces
 
 ### <a name="header-cell-args"></a>HeaderCellArgs
 

--- a/packages/dx-react-grid/docs/reference/table-header-row.md
+++ b/packages/dx-react-grid/docs/reference/table-header-row.md
@@ -26,7 +26,7 @@ allowGroupingByClick | boolean | false | If true, it renders a component that to
 
 ### <a name="column"></a>Column (Extension)
 
-Extends [Column](grid.md#column) with the following shape:
+A value with the [Column](grid.md#column) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -36,7 +36,7 @@ title? | string | Specifies a table column title
 
 Describes properties used to render a table header cell.
 
-Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
+A value with the [TableCellArgs](table-view.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------

--- a/packages/dx-react-grid/docs/reference/table-header-row.md
+++ b/packages/dx-react-grid/docs/reference/table-header-row.md
@@ -63,7 +63,7 @@ columns | Getter | Array&lt;[Column](#column)&gt; | Table columns
 grouping | Getter | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | Columns used for grouping
 setColumnSorting | Action | ({ columnName: string, direction: 'asc' &#124; 'desc', keepOther: boolean, cancel: boolean }) => void | Changes column sorting
 groupByColumn | Action | ({ columnName: string, groupIndex?: number }) => void | Groups a table by the specified column or cancels grouping. If `groupIndex` is omitted, the group is added to the end of the group list.
-tableViewCell | Template | { row: [TableRow](table-view.md#table-row), column: [TableColumn](table-view.md#table-column) } | A template that renders a table cell
+tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/table-header-row.md
+++ b/packages/dx-react-grid/docs/reference/table-header-row.md
@@ -26,9 +26,7 @@ allowGroupingByClick | boolean | false | If true, it renders a component that to
 
 ### Column
 
-Extends [Column](grid.md#column)
-
-A value with the following shape:
+Extends [Column](grid.md#column) with the following shape:
 
 Field | Type | Description
 ------|------|------------
@@ -40,7 +38,7 @@ title? | string | Specifies a table column title
 
 Describes properties used to render a table header cell.
 
-A value with the following shape:
+Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
 
 Field | Type | Description
 ------|------|------------

--- a/packages/dx-react-grid/docs/reference/table-row-detail.md
+++ b/packages/dx-react-grid/docs/reference/table-row-detail.md
@@ -28,7 +28,7 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-row | [TableRow](table-view.md#table-row) | A row object for showing row details
+row | [Row](grid.md#row) | A row object for showing row details
 
 ### <a name="detail-cell-args"></a>DetailCellArgs
 
@@ -38,8 +38,10 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-row | [TableRow](table-view.md#table-row) | A row object
+row | [Row](grid.md#row) | A row object
 template | () => ReactElement | A component that renders row details
+style? | Object | Specifies cell styles
+colspan? | number | Specifies the number of columns the cell spans
 
 ### <a name="detail-toggle-args"></a>DetailToggleArgs
 
@@ -49,8 +51,10 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
+row | [Row](grid.md#row) | A row object
 expanded | boolean | Specifies whether or not row details are displayed
 toggleExpanded | () => void | Toggles the expanded state for a row
+style? | Object | Specifies cell styles
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/table-row-detail.md
+++ b/packages/dx-react-grid/docs/reference/table-row-detail.md
@@ -34,27 +34,24 @@ row | [Row](grid.md#row) | A row object for showing row details
 
 Describes properties passed to the template that renders a detail cell for a row
 
-A value with the following shape:
+Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
 
 Field | Type | Description
 ------|------|------------
 row | [Row](grid.md#row) | A row object
 template | () => ReactElement | A component that renders row details
-style? | Object | Specifies cell styles
-colspan? | number | Specifies the number of columns the cell spans
 
 ### <a name="detail-toggle-args"></a>DetailToggleArgs
 
 Describes properties passed to the template that renders the detail toggle control
 
-A value with the following shape:
+Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
 
 Field | Type | Description
 ------|------|------------
 row | [Row](grid.md#row) | A row object
 expanded | boolean | Specifies whether or not row details are displayed
 toggleExpanded | () => void | Toggles the expanded state for a row
-style? | Object | Specifies cell styles
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/table-row-detail.md
+++ b/packages/dx-react-grid/docs/reference/table-row-detail.md
@@ -35,7 +35,7 @@ row | [Row](grid.md#row) | A row object for showing row details
 
 Describes properties passed to the template that renders a detail cell for a row
 
-Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
+A value with the [TableCellArgs](table-view.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -46,12 +46,12 @@ template | () => ReactElement | A component that renders row details
 
 Describes properties passed to the template that renders the detail toggle control
 
-Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
+A value with the [TableCellArgs](table-view.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
 row | [Row](grid.md#row) | A row object
-expanded | boolean | Specifies whether or not row details are displayed
+expanded | boolean | Specifies if row details are displayed
 toggleExpanded | () => void | Toggles a row's expanded state
 
 ## Plugin Developer Reference

--- a/packages/dx-react-grid/docs/reference/table-row-detail.md
+++ b/packages/dx-react-grid/docs/reference/table-row-detail.md
@@ -62,9 +62,8 @@ Name | Plugin | Type | Description
 tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
 tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Body rows to be rendered
 expandedRows | Getter | Array&lt;number &#124; string&gt; | Expanded rows
-getRowId | Getter | (row: [Row](grid.md#row)) => number &#124; string | The function used to get a unique row identifier
 setDetailRowExpanded | Action | ({ rowId }) => void | Expands the specified row
-tableViewCell | Template | { row: [TableRow](table-view.md#table-row), column: [TableColumn](table-view.md#table-column) } | A template that renders a table cell
+tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/table-selection.md
+++ b/packages/dx-react-grid/docs/reference/table-selection.md
@@ -66,9 +66,9 @@ Name | Plugin | Type | Description
 -----|--------|------|------------
 tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
 tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Body rows to be rendered
-selection | Getter | Array&lt;number &#124; string&gt; | Selected rows
 tableExtraProps | Getter | { [key: string]: any } | Additional table properties that can be provided by other plugins
-availableToSelect | Getter | Array&lt;[Row](grid.md#row)&gt; | Body rows to be rendered available for selection
+selection | Getter | Array&lt;number &#124; string&gt; | Selected rows
+availableToSelect | Getter | Array&lt;number &#124; string&gt; | Rows to be rendered, which are available for selection
 setRowSelection | Action | ({ rowId }) => void | Selects a row
 setRowsSelection | Action | ({ rowIds }) => void | Selects multiple rows
 tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell

--- a/packages/dx-react-grid/docs/reference/table-selection.md
+++ b/packages/dx-react-grid/docs/reference/table-selection.md
@@ -21,6 +21,16 @@ selectCellTemplate | (args: [SelectCellArgs](#select-cell-args)) => ReactElement
 selectAllCellTemplate | (args: [SelectAllCellArgs](#select-all-cell-args)) => ReactElement | | A component that renders the Select All checkbox
 selectionColumnWidth | number | | The selection column's width
 
+## Extensions
+
+### <a name="table-row"></a>TableRow
+
+Extends [TableRow](table-view.md#table-row) with the following shape:
+
+Field | Type | Description
+------|------|------------
+selected? | boolean | Specifies whether a row is selected
+
 ## Interfaces
 
 ### <a name="select-all-cell-args"></a>SelectAllCellArgs
@@ -57,17 +67,16 @@ Name | Plugin | Type | Description
 tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
 tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Body rows to be rendered
 selection | Getter | Array&lt;number &#124; string&gt; | Selected rows
-getRowId | Getter | (row: [Row](grid.md#row)) => number &#124; string | The function used to get a unique row identifier
 tableExtraProps | Getter | { [key: string]: any } | Additional table properties that can be provided by other plugins
 availableToSelect | Getter | Array&lt;[Row](grid.md#row)&gt; | Body rows to be rendered available for selection
 setRowSelection | Action | ({ rowId }) => void | Selects a row
 setRowsSelection | Action | ({ rowIds }) => void | Selects multiple rows
-tableViewCell | Template | { row: [TableRow](table-view.md#table-row), column: [TableColumn](table-view.md#table-column) } | A template that renders a table cell
+tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
 tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns including the selection column
-tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Body rows to be rendered including the selected ones
+tableBodyRows | Getter | Array&lt;[TableRow](#table-row)&gt; | Body rows to be rendered including the selected ones
 tableExtraProps | Getter | { [key: string]: any } | Additional table properties extended with the row onClick event listener

--- a/packages/dx-react-grid/docs/reference/table-selection.md
+++ b/packages/dx-react-grid/docs/reference/table-selection.md
@@ -27,7 +27,7 @@ selectionColumnWidth | number | | The selection column's width
 
 Describes properties passed to the template that renders a cell with a selection control.
 
-A value with the following shape:
+Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
 
 Field | Type | Description
 ------|------|------------
@@ -40,7 +40,7 @@ toggleAll | () => void | Selects or deselects all rows
 
 Describes properties passed to a template that renders a cell with the selection control inside the heading row.
 
-A value with the following shape:
+Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
 
 Field | Type | Description
 ------|------|------------

--- a/packages/dx-react-grid/docs/reference/table-selection.md
+++ b/packages/dx-react-grid/docs/reference/table-selection.md
@@ -44,6 +44,7 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
+row | [Row](grid.md#row) | A row object
 selected | boolean | Specifies whether a row is selected
 changeSelected | () => void | Selects or deselects a row
 

--- a/packages/dx-react-grid/docs/reference/table-selection.md
+++ b/packages/dx-react-grid/docs/reference/table-selection.md
@@ -21,17 +21,15 @@ selectCellTemplate | (args: [SelectCellArgs](#select-cell-args)) => ReactElement
 selectAllCellTemplate | (args: [SelectAllCellArgs](#select-all-cell-args)) => ReactElement | | A component that renders the Select All checkbox
 selectionColumnWidth | number | | The selection column's width
 
-## Extensions
+## Interfaces 
 
-### <a name="table-row"></a>TableRow
+### <a name="table-row"></a>TableRow (Extension)
 
 Extends [TableRow](table-view.md#table-row) with the following shape:
 
 Field | Type | Description
 ------|------|------------
 selected? | boolean | Specifies whether a row is selected
-
-## Interfaces
 
 ### <a name="select-all-cell-args"></a>SelectAllCellArgs
 
@@ -65,7 +63,7 @@ changeSelected | () => void | Selects or deselects a row
 Name | Plugin | Type | Description
 -----|--------|------|------------
 tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
-tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Body rows to be rendered
+tableBodyRows | Getter | Array&lt;[TableRow](#table-row)&gt; | Body rows to be rendered
 tableExtraProps | Getter | { [key: string]: any } | Additional table properties that can be provided by other plugins
 selection | Getter | Array&lt;number &#124; string&gt; | Selected rows
 availableToSelect | Getter | Array&lt;number &#124; string&gt; | Rows to be rendered, which are available for selection

--- a/packages/dx-react-grid/docs/reference/table-selection.md
+++ b/packages/dx-react-grid/docs/reference/table-selection.md
@@ -25,17 +25,17 @@ selectionColumnWidth | number | | The selection column's width
 
 ### <a name="table-row"></a>TableRow (Extension)
 
-Extends [TableRow](table-view.md#table-row) with the following shape:
+A value with the [TableRow](table-view.md#table-row) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
-selected? | boolean | Specifies whether a row is selected
+selected? | boolean | Specifies if a row is selected
 
 ### <a name="select-all-cell-args"></a>SelectAllCellArgs
 
 Describes properties passed to the template that renders a cell with a selection control.
 
-Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
+A value with the [TableCellArgs](table-view.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -48,7 +48,7 @@ toggleAll | () => void | Selects or deselects all rows
 
 Describes properties passed to a template that renders a cell with the selection control inside the heading row.
 
-Extends [TableCellArgs](table-view.md#table-cell-args) with the following shape:
+A value with the [TableCellArgs](table-view.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -14,10 +14,10 @@ This plugin renders the Grid data as a table. It contains the Table View and Tab
 Name | Type | Default | Description
 -----|------|---------|------------
 tableTemplate | (args: [TableArgs](#table-args)) => ReactElement | | Renders a table using the specified parameters
-tableCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a table cell using the specified parameters
-tableNoDataCellTemplate | (args: [TableNoDataCellArgs](#table-no-data-cell-args)) => ReactElement | | Renders a table cell using the specified parameters when the table is empty
-tableStubCellTemplate | (args: [TableStubCellArgs](#table-stub-cell-args)) => ReactElement | | Renders a stub table cell if the cell data is not provided
-tableStubHeaderCellTemplate | (args: [TableStubHeaderCellArgs](#table-stub-header-cell-args)) => ReactElement | | Renders a stub header cell if the cell data is not provided
+tableCellTemplate | (args: [TableDataCellArgs](#table-data-cell-args)) => ReactElement | | Renders a table cell using the specified parameters
+tableNoDataCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a table cell using the specified parameters when the table is empty
+tableStubCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a stub table cell if the cell data is not provided
+tableStubHeaderCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a stub header cell if the cell data is not provided
 allowColumnReordering | boolean | false | If true, it allows end-users to change the column's order by dragging it
 
 ## Interfaces
@@ -31,56 +31,7 @@ Field | Type | Description
 headerRows | Array&lt;[TableRow](#table-row)&gt; | Specifies rows rendered in the table header
 bodyRows | Array&lt;[TableRow](#table-row)&gt; | Specifies rows rendered in the table body
 columns | Array&lt;[TableColumn](#table-column)&gt; | Specifies the rendered table columns
-cellTemplate | (args: [CellArgs](#cell-args)) => ReactElement | The template used to render table cells
-
-### <a name="cell-args"></a>CellArgs
-
-Describes properties passed to a cell template when it is being rendered.
-
-A value with the following shape:
-
-Field | Type | Description
-------|------|------------
-row | [TableRow](#table-row) | Specifies a table row
-column | [TableColumn](#table-column) | Specifies a table column
-style? | Object | Specifies cell styles
-colspan? | number | Specifies the number of columns the cell spans
-
-### <a name="table-cell-args"></a>TableCellArgs
-
-Describes properties passed to the table cell template when it is being rendered.
-
-Field | Type | Description
-------|------|------------
-row | [TableRow](#table-row) | Specifies a table row
-column | [TableColumn](#table-column) | Specifies a table column
-style? | Object | Specifies cell styles
-colspan? | number | Specifies the number of columns the cell spans
-
-### <a name="table-no-data-cell-args"></a>TableNoDataCellArgs
-
-Describes properties passed to the table cell being rendered when using an empty template.
-
-Field | Type | Description
-------|------|------------
-style? | Object | Specifies cell styles
-colspan? | number | Specifies the number of columns the cell spans
-
-### <a name="table-stub-cell-args"></a>TableStubCellArgs
-
-Describes properties passed to the stub table cell template being rendered.
-
-Field | Type | Description
-------|------|------------
-style? | Object | Specifies cell styles
-
-### <a name="table-stub-header-cell-args"></a>TableStubHeaderCellArgs
-
-Describes properties passed to the stub header cell template being rendered.
-
-Field | Type | Description
-------|------|------------
-style? | Object | Specifies cell styles
+cellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | The template used to render table cells
 
 ### <a name="table-row"></a>TableRow
 
@@ -93,7 +44,9 @@ Field | Type | Description
 type | string | Specifies the table row type. Defines a cell template used to render a row.
 id | number &#124; string | Specifies the table row id. Used to unique identify row of the given type.
 height? | number &#124; string | Specifies the table row height.
-original? | [Row](grid.md#row) | Specifies the associated row.
+row? | [Row](grid.md#row) | Specifies the associated row.
+
+Can be extended by other plugins. See the Extensions section.
 
 ### <a name="table-column"></a>TableColumn
 
@@ -106,7 +59,35 @@ Field | Type | Description
 type | string | Specifies the table column type. Defines a cell template used to render a row.
 id | number &#124; string | Specifies the table column id. Used to unique identify column of the given type.
 width? | number &#124; string | Specifies the table column width.
-original? | [Column](grid.md#column) | Specifies the associated column.
+column? | [Column](grid.md#column) | Specifies the associated column.
+
+Can be extended by other plugins. See the Extensions section.
+
+### <a name="table-cell-args"></a>TableCellArgs
+
+Describes properties passed to a cell template when it is being rendered.
+
+A value with the following shape:
+
+Field | Type | Description
+------|------|------------
+tableRow | [TableRow](#table-row) | Specifies a table row
+tableColumn | [TableColumn](#table-column) | Specifies a table column
+style? | Object | Specifies cell styles
+colspan? | number | Specifies the number of columns the cell spans
+
+Can be extended by other plugins. See the Extensions section.
+
+### <a name="table-data-cell-args"></a>TableDataCellArgs
+
+Describes properties passed to the table cell template when it is being rendered.
+
+Extends [TableCellArgs](#table-cell-args) with the following shape:
+
+Field | Type | Description
+------|------|------------
+row | [Row](grid.md#row) | Specifies a table row
+column | [Column](grid.md#column) | Specifies a table column
 
 ## Plugin Developer Reference
 
@@ -126,4 +107,4 @@ tableBodyRows | Getter | Array&lt;[TableRow](#table-row)&gt; | Body rows to be r
 tableColumns | Getter | Array&lt;[TableColumn](#table-column)&gt; | Columns to be rendered
 tableExtraProps | Getter | { [key: string]: any } | Additional table properties that other plugins can provide
 tableView | Template | none | A template that renders a table
-tableViewCell | Template | { row: [TableRow](#table-row), column: [TableColumn](#table-column) } | A template that renders a table cell
+tableViewCell | Template | [TableCellArgs](#table-cell-args) | A template that renders a table cell

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -51,10 +51,11 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
+key | string | A string used to unique identify table row.
 type | string | Specifies the table row type. Defines a cell template used to render a row.
-id | number &#124; string | Specifies the table row id. Used to unique identify row of the given type.
+rowId? | number &#124; string  | Specifies the associated user data row id.
+row? | [Row](grid.md#row) | Specifies the associated user data row.
 height? | number | Specifies the table row height.
-row? | [Row](grid.md#row) | Specifies the associated row.
 
 Can be extended by other plugins. See the Extensions section.
 
@@ -66,10 +67,11 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-type | string | Specifies the table column type. Defines a cell template used to render a row.
-id | number &#124; string | Specifies the table column id. Used to unique identify column of the given type.
+key | string | A string used to unique identify table column.
+type | string | Specifies the table column type. Defines a cell template used to render a column.
+columnId? | number &#124; string  | Specifies the associated user data column id.
+column? | [Column](grid.md#column) | Specifies the associated user data column.
 width? | number | Specifies the table column width.
-column? | [Column](grid.md#column) | Specifies the associated column.
 
 Can be extended by other plugins. See the Extensions section.
 

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -20,17 +20,15 @@ tableStubCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElemen
 tableStubHeaderCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a stub header cell if the cell data is not provided
 allowColumnReordering | boolean | false | If true, it allows end-users to change the column's order by dragging it
 
-## Extensions
+## Interfaces
 
-### Column
+### <a name="column"></a>Column (Extension)
 
 Extends [Column](grid.md#column) with the following shape:
 
 Field | Type | Description
 ------|------|------------
 width? | number | Specifies the table column width.
-
-## Interfaces
 
 ### <a name="table-args"></a>TableArgs
 
@@ -57,8 +55,6 @@ rowId? | number &#124; string  | Specifies the associated user data row id.
 row? | [Row](grid.md#row) | Specifies the associated user data row.
 height? | number | Specifies the table row height.
 
-Can be extended by other plugins. See the Extensions section.
-
 ### <a name="table-column"></a>TableColumn
 
 Describes table column properties that the TableView plugin takes into account.
@@ -70,10 +66,8 @@ Field | Type | Description
 key | string | A string used to unique identify table column.
 type | string | Specifies the table column type. Defines a cell template used to render a column.
 columnId? | number &#124; string  | Specifies the associated user data column id.
-column? | [Column](grid.md#column) | Specifies the associated user data column.
+column? | [Column](#column) | Specifies the associated user data column.
 width? | number | Specifies the table column width.
-
-Can be extended by other plugins. See the Extensions section.
 
 ### <a name="table-cell-args"></a>TableCellArgs
 
@@ -88,8 +82,6 @@ tableColumn | [TableColumn](#table-column) | Specifies a table column
 style? | Object | Styles that should be applied to the root cell element
 colspan? | number | Specifies the number of columns the cell spans
 
-Can be extended by other plugins. See the Extensions section.
-
 ### <a name="table-data-cell-args"></a>TableDataCellArgs
 
 Describes properties passed to the table cell template when it is being rendered.
@@ -99,7 +91,7 @@ Extends [TableCellArgs](#table-cell-args) with the following shape:
 Field | Type | Description
 ------|------|------------
 row | [Row](grid.md#row) | Specifies a table row
-column | [Column](grid.md#column) | Specifies a table column
+column | [Column](#column) | Specifies a table column
 
 ## Plugin Developer Reference
 
@@ -108,7 +100,7 @@ column | [Column](grid.md#column) | Specifies a table column
 Name | Plugin | Type | Description
 -----|--------|------|------------
 rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be rendered by the table view
-columns | Getter | Array&lt;[Column](grid.md#column)&gt; | Columns to be rendered by the table view
+columns | Getter | Array&lt;[Column](#column)&gt; | Columns to be rendered by the table view
 getRowId | Getter | (row: [Row](grid.md#row)) => number &#124; string | The function used to get a unique row identifier
 
 ### Exports

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -65,7 +65,6 @@ Field | Type | Description
 ------|------|------------
 key | string | A unique identifier of the table column.
 type | string | Specifies the table column type. The specified value affects which cell template is used to render the column.
-columnId? | number &#124; string  | Specifies the ID of the associated user data column.
 column? | [Column](#column) | Specifies the associated user data column.
 width? | number | Specifies the table column width.
 

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -44,6 +44,7 @@ Field | Type | Description
 row | [TableRow](#table-row) | Specifies a table row
 column | [TableColumn](#table-column) | Specifies a table column
 style? | Object | Specifies cell styles
+colspan? | number | Specifies the number of columns the cell spans
 
 ### <a name="table-cell-args"></a>TableCellArgs
 
@@ -54,6 +55,7 @@ Field | Type | Description
 row | [TableRow](#table-row) | Specifies a table row
 column | [TableColumn](#table-column) | Specifies a table column
 style? | Object | Specifies cell styles
+colspan? | number | Specifies the number of columns the cell spans
 
 ### <a name="table-no-data-cell-args"></a>TableNoDataCellArgs
 
@@ -84,25 +86,27 @@ style? | Object | Specifies cell styles
 
 Describes properties of a table row rendered by the TableView plugin.
 
-Extends [Row](grid.md#row)
-
 A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-type? | string | Specifies the table row type. Defines a cell template used to render a row. The type is not defined for rows passed by a user.
+type | string | Specifies the table row type. Defines a cell template used to render a row.
+id | number &#124; string | Specifies the table row id. Used to unique identify row of the given type.
+height? | number &#124; string | Specifies the table row height.
+original? | [Row](grid.md#row) | Specifies the associated row.
 
 ### <a name="table-column"></a>TableColumn
 
 Describes table column properties that the TableView plugin takes into account.
 
-Extends [Column](grid.md#column)
-
 A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-type? | string | Specifies the table column type. Defines a cell template used to render a cell. The type is not defined for data rows
+type | string | Specifies the table column type. Defines a cell template used to render a row.
+id | number &#124; string | Specifies the table column id. Used to unique identify column of the given type.
+width? | number &#124; string | Specifies the table column width.
+original? | [Column](grid.md#column) | Specifies the associated column.
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -97,6 +97,7 @@ Name | Plugin | Type | Description
 -----|--------|------|------------
 rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be rendered by the table view
 columns | Getter | Array&lt;[Column](grid.md#column)&gt; | Columns to be rendered by the table view
+getRowId | Getter | (row: [Row](grid.md#row)) => number &#124; string | The function used to get a unique row identifier
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -20,6 +20,16 @@ tableStubCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElemen
 tableStubHeaderCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a stub header cell if the cell data is not provided
 allowColumnReordering | boolean | false | If true, it allows end-users to change the column's order by dragging it
 
+## Extensions
+
+### Column
+
+Extends [Column](grid.md#column) with the following shape:
+
+Field | Type | Description
+------|------|------------
+width? | number | Specifies the table column width.
+
 ## Interfaces
 
 ### <a name="table-args"></a>TableArgs
@@ -43,7 +53,7 @@ Field | Type | Description
 ------|------|------------
 type | string | Specifies the table row type. Defines a cell template used to render a row.
 id | number &#124; string | Specifies the table row id. Used to unique identify row of the given type.
-height? | number &#124; string | Specifies the table row height.
+height? | number | Specifies the table row height.
 row? | [Row](grid.md#row) | Specifies the associated row.
 
 Can be extended by other plugins. See the Extensions section.
@@ -58,7 +68,7 @@ Field | Type | Description
 ------|------|------------
 type | string | Specifies the table column type. Defines a cell template used to render a row.
 id | number &#124; string | Specifies the table column id. Used to unique identify column of the given type.
-width? | number &#124; string | Specifies the table column width.
+width? | number | Specifies the table column width.
 column? | [Column](grid.md#column) | Specifies the associated column.
 
 Can be extended by other plugins. See the Extensions section.

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -24,7 +24,7 @@ allowColumnReordering | boolean | false | If true, it allows end-users to change
 
 ### <a name="column"></a>Column (Extension)
 
-Extends [Column](grid.md#column) with the following shape:
+A value with the [Column](grid.md#column) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -49,9 +49,9 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-key | string | A string used to unique identify table row.
-type | string | Specifies the table row type. Defines a cell template used to render a row.
-rowId? | number &#124; string  | Specifies the associated user data row id.
+key | string | A unique identifier of the table row.
+type | string | Specifies the table row type. The specified value affects which cell template is used to render the row.
+rowId? | number &#124; string  | Specifies the ID of the associated user data row.
 row? | [Row](grid.md#row) | Specifies the associated user data row.
 height? | number | Specifies the table row height.
 
@@ -63,9 +63,9 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-key | string | A string used to unique identify table column.
-type | string | Specifies the table column type. Defines a cell template used to render a column.
-columnId? | number &#124; string  | Specifies the associated user data column id.
+key | string | A unique identifier of the table column.
+type | string | Specifies the table column type. The specified value affects which cell template is used to render the column.
+columnId? | number &#124; string  | Specifies the ID of the associated user data column.
 column? | [Column](#column) | Specifies the associated user data column.
 width? | number | Specifies the table column width.
 
@@ -86,7 +86,7 @@ colspan? | number | Specifies the number of columns the cell spans
 
 Describes properties passed to the table cell template when it is being rendered.
 
-Extends [TableCellArgs](#table-cell-args) with the following shape:
+A value with the [TableCellArgs](#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------

--- a/packages/dx-react-grid/src/components/group-panel-layout.jsx
+++ b/packages/dx-react-grid/src/components/group-panel-layout.jsx
@@ -6,7 +6,7 @@ import { getColumnSortingDirection, getGroupCellTargetIndex } from '@devexpress/
 
 const getSortingConfig = (sorting, column) => {
   const result = {
-    sortingSupported: !column.type && sorting !== undefined,
+    sortingSupported: sorting !== undefined,
   };
 
   if (result.sortingSupported) {

--- a/packages/dx-react-grid/src/components/group-panel-layout.test.jsx
+++ b/packages/dx-react-grid/src/components/group-panel-layout.test.jsx
@@ -61,7 +61,7 @@ describe('GroupPanelLayout', () => {
   it('should pass correct sorting parameters to cell template', () => {
     const groupedColumns = [{ name: 'a' }, { name: 'b' }];
     const sorting = [{ columnName: 'a', direction: 'desc' }];
-    const cellTemplate = jest.fn().mockImplementation(groupPanelCellTemplate);
+    const cellTemplate = jest.fn(groupPanelCellTemplate);
     mount(
       <GroupPanelLayout
         groupedColumns={groupedColumns}
@@ -85,7 +85,7 @@ describe('GroupPanelLayout', () => {
   it('should pass correct sorting parameters to cell template if sorting is disabled', () => {
     const groupedColumns = [{ name: 'a' }];
     const sorting = [{ columnName: 'a', direction: 'desc' }];
-    const cellTemplate = jest.fn().mockImplementation(groupPanelCellTemplate);
+    const cellTemplate = jest.fn(groupPanelCellTemplate);
     mount(
       <GroupPanelLayout
         groupedColumns={groupedColumns}

--- a/packages/dx-react-grid/src/components/table-layout.jsx
+++ b/packages/dx-react-grid/src/components/table-layout.jsx
@@ -3,13 +3,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
-
 import {
   DropTarget,
   TemplateRenderer,
 } from '@devexpress/dx-react-core';
-
 import {
+  TABLE_DATA_TYPE,
   tableKeyGetter,
   getTableColumnGeometries,
   getTableTargetColumnIndex,
@@ -20,7 +19,7 @@ import {
 
 import { RowsBlockLayout } from './table-layout/rows-block-layout';
 
-const FLEX_TYPE = 'flex';
+const TABLE_FLEX_TYPE = 'flex';
 
 export class TableLayout extends React.PureComponent {
   constructor(props) {
@@ -48,7 +47,7 @@ export class TableLayout extends React.PureComponent {
       const isFixedWidth = columns.filter(column => column.width === undefined).length === 0;
       if (isFixedWidth) {
         result = result.slice();
-        result.push({ type: FLEX_TYPE });
+        result.push({ type: TABLE_FLEX_TYPE });
       }
 
       if (sourceColumnIndex !== -1 && targetColumnIndex !== -1) {
@@ -74,17 +73,19 @@ export class TableLayout extends React.PureComponent {
       const columnGeometries = getTableColumnGeometries(columns, tableRect.width);
       const targetColumnIndex = getTableTargetColumnIndex(
         columnGeometries,
-        columns.findIndex(column => column.type === 'data' && column.id === sourceColumnName),
+        columns.findIndex(column =>
+          column.type === TABLE_DATA_TYPE && column.id === sourceColumnName),
         clientOffset.x - tableRect.left);
 
       if (targetColumnIndex === -1 ||
-        columns[targetColumnIndex].type !== 'data' ||
+        columns[targetColumnIndex].type !== TABLE_DATA_TYPE ||
         targetColumnIndex === this.state.targetColumnIndex) return;
 
       const { sourceColumnIndex } = this.state;
       this.setState({
         sourceColumnIndex: sourceColumnIndex === -1
-          ? columns.findIndex(column => column.type === 'data' && column.id === sourceColumnName)
+          ? columns.findIndex(column =>
+            column.type === TABLE_DATA_TYPE && column.id === sourceColumnName)
           : sourceColumnIndex,
         targetColumnIndex,
       });
@@ -164,7 +165,7 @@ export class TableLayout extends React.PureComponent {
     } = this.props;
     const columns = this.getColumns();
     const minWidth = columns
-      .map(column => column.width || (column.type === FLEX_TYPE ? 0 : minColumnWidth))
+      .map(column => column.width || (column.type === TABLE_FLEX_TYPE ? 0 : minColumnWidth))
       .reduce((accum, width) => accum + width, 0);
 
     const table = (

--- a/packages/dx-react-grid/src/components/table-layout.jsx
+++ b/packages/dx-react-grid/src/components/table-layout.jsx
@@ -9,7 +9,6 @@ import {
 } from '@devexpress/dx-react-core';
 import {
   TABLE_DATA_TYPE,
-  tableKeyGetter,
   getTableColumnGeometries,
   getTableTargetColumnIndex,
   getAnimations,
@@ -47,7 +46,7 @@ export class TableLayout extends React.PureComponent {
       const isFixedWidth = columns.filter(column => column.width === undefined).length === 0;
       if (isFixedWidth) {
         result = result.slice();
-        result.push({ type: TABLE_FLEX_TYPE });
+        result.push({ key: TABLE_FLEX_TYPE, type: TABLE_FLEX_TYPE });
       }
 
       if (sourceColumnIndex !== -1 && targetColumnIndex !== -1) {
@@ -59,8 +58,8 @@ export class TableLayout extends React.PureComponent {
 
       if (animationState.size) {
         result = result
-          .map(column => (animationState.has(tableKeyGetter(column))
-            ? { ...column, animationState: animationState.get(tableKeyGetter(column)) }
+          .map(column => (animationState.has(column.key)
+            ? { ...column, animationState: animationState.get(column.key) }
             : column));
       }
 
@@ -74,7 +73,7 @@ export class TableLayout extends React.PureComponent {
       const targetColumnIndex = getTableTargetColumnIndex(
         columnGeometries,
         columns.findIndex(column =>
-          column.type === TABLE_DATA_TYPE && column.id === sourceColumnName),
+          column.type === TABLE_DATA_TYPE && column.columnId === sourceColumnName),
         clientOffset.x - tableRect.left);
 
       if (targetColumnIndex === -1 ||
@@ -85,13 +84,13 @@ export class TableLayout extends React.PureComponent {
       this.setState({
         sourceColumnIndex: sourceColumnIndex === -1
           ? columns.findIndex(column =>
-            column.type === TABLE_DATA_TYPE && column.id === sourceColumnName)
+            column.type === TABLE_DATA_TYPE && column.columnId === sourceColumnName)
           : sourceColumnIndex,
         targetColumnIndex,
       });
 
       this.animations = getAnimations(columns, this.getColumns(), tableRect.width,
-        tableKeyGetter(this.props.columns[this.state.sourceColumnIndex]), this.animations);
+        this.props.columns[this.state.sourceColumnIndex].key, this.animations);
       this.processAnimationFrame();
     };
     this.onLeave = () => {
@@ -108,7 +107,7 @@ export class TableLayout extends React.PureComponent {
       if (sourceColumnIndex === -1) return;
 
       this.animations = getAnimations(columns, this.getColumns(), tableRect.width,
-        tableKeyGetter(this.props.columns[sourceColumnIndex]), this.animations);
+        this.props.columns[sourceColumnIndex].key, this.animations);
       this.processAnimationFrame();
     };
     this.onDrop = () => {
@@ -116,8 +115,8 @@ export class TableLayout extends React.PureComponent {
       const { columns } = this.props;
 
       this.props.setColumnOrder({
-        sourceColumnName: columns[sourceColumnIndex].id,
-        targetColumnName: columns[targetColumnIndex].id,
+        sourceColumnName: columns[sourceColumnIndex].columnId,
+        targetColumnName: columns[targetColumnIndex].columnId,
       });
       this.setState({
         sourceColumnIndex: -1,

--- a/packages/dx-react-grid/src/components/table-layout.jsx
+++ b/packages/dx-react-grid/src/components/table-layout.jsx
@@ -58,7 +58,7 @@ export class TableLayout extends React.PureComponent {
         result.splice(targetColumnIndex, 0, sourceColumn);
       }
 
-      if (animationState) {
+      if (animationState.size) {
         result = result
           .map(column => (animationState.has(tableKeyGetter(column))
             ? { ...column, animationState: animationState.get(tableKeyGetter(column)) }

--- a/packages/dx-react-grid/src/components/table-layout.jsx
+++ b/packages/dx-react-grid/src/components/table-layout.jsx
@@ -73,7 +73,7 @@ export class TableLayout extends React.PureComponent {
       const targetColumnIndex = getTableTargetColumnIndex(
         columnGeometries,
         columns.findIndex(column =>
-          column.type === TABLE_DATA_TYPE && column.columnId === sourceColumnName),
+          column.type === TABLE_DATA_TYPE && column.column.name === sourceColumnName),
         clientOffset.x - tableRect.left);
 
       if (targetColumnIndex === -1 ||
@@ -84,7 +84,7 @@ export class TableLayout extends React.PureComponent {
       this.setState({
         sourceColumnIndex: sourceColumnIndex === -1
           ? columns.findIndex(column =>
-            column.type === TABLE_DATA_TYPE && column.columnId === sourceColumnName)
+            column.type === TABLE_DATA_TYPE && column.column.name === sourceColumnName)
           : sourceColumnIndex,
         targetColumnIndex,
       });
@@ -115,8 +115,8 @@ export class TableLayout extends React.PureComponent {
       const { columns } = this.props;
 
       this.props.setColumnOrder({
-        sourceColumnName: columns[sourceColumnIndex].columnId,
-        targetColumnName: columns[targetColumnIndex].columnId,
+        sourceColumnName: columns[sourceColumnIndex].column.name,
+        targetColumnName: columns[targetColumnIndex].column.name,
       });
       this.setState({
         sourceColumnIndex: -1,

--- a/packages/dx-react-grid/src/components/table-layout.test.jsx
+++ b/packages/dx-react-grid/src/components/table-layout.test.jsx
@@ -84,10 +84,10 @@ describe('TableLayout', () => {
       { key: `${TABLE_DATA_TYPE}_3`, type: TABLE_DATA_TYPE, rowId: 3 },
     ];
     const columns = [
-      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
-      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
-      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, columnId: 'c' },
-      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, columnId: 'd' },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, columnId: 'c', column: { name: 'c' } },
+      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
     ];
     const tree = mount(
       <TableLayout
@@ -110,10 +110,10 @@ describe('TableLayout', () => {
       { key: `${TABLE_DATA_TYPE}_3`, type: TABLE_DATA_TYPE, rowId: 3 },
     ];
     const columns = [
-      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
-      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
-      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, columnId: 'c' },
-      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, columnId: 'd' },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, columnId: 'c', column: { name: 'c' } },
+      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
     ];
     const tree = mount(
       <TableLayout
@@ -137,10 +137,10 @@ describe('TableLayout', () => {
       { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2, colSpanStart: 1 },
     ];
     const columns = [
-      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
-      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
-      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, columnId: 'c' },
-      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, columnId: 'd' },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, columnId: 'c', column: { name: 'c' } },
+      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
     ];
     const tree = mount(
       <TableLayout
@@ -171,8 +171,8 @@ describe('TableLayout', () => {
       { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
     ];
     const columns = [
-      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', width: 100 },
-      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' }, width: 100 },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
     ];
     const tree = mount(
       <TableLayout
@@ -213,8 +213,8 @@ describe('TableLayout', () => {
       { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
     ];
     const columns = [
-      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
-      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
     ];
     const onClick = jest.fn();
     const tree = mount(
@@ -242,8 +242,8 @@ describe('TableLayout', () => {
       { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
     ];
     const columns = [
-      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
-      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
     ];
     const onClick = jest.fn();
     const tree = mount(
@@ -274,8 +274,8 @@ describe('TableLayout', () => {
         { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
       ];
       const columns = [
-        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', width: 100 },
-        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', width: 100 },
+        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' }, width: 100 },
+        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' }, width: 100 },
       ];
       const tree = mount(
         <TableLayout
@@ -321,8 +321,8 @@ describe('TableLayout', () => {
         { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
       ];
       const columns = [
-        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
-        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
+        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
+        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
       ];
       const tree = mount(
         <DragDropContext>
@@ -353,8 +353,8 @@ describe('TableLayout', () => {
         { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
       ];
       const columns = [
-        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
-        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
+        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
+        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
       ];
       const tree = mount(
         <DragDropContext>
@@ -386,8 +386,8 @@ describe('TableLayout', () => {
         { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
       ];
       const columns = [
-        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
-        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
+        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
+        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
       ];
       const setColumnOrder = jest.fn();
       const tree = mount(

--- a/packages/dx-react-grid/src/components/table-layout.test.jsx
+++ b/packages/dx-react-grid/src/components/table-layout.test.jsx
@@ -79,15 +79,15 @@ describe('TableLayout', () => {
 
   it('should render table with rows and columns', () => {
     const rows = [
-      { type: TABLE_DATA_TYPE, id: 1 },
-      { type: TABLE_DATA_TYPE, id: 2 },
-      { type: TABLE_DATA_TYPE, id: 3 },
+      { key: `${TABLE_DATA_TYPE}_1`, type: TABLE_DATA_TYPE, rowId: 1 },
+      { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
+      { key: `${TABLE_DATA_TYPE}_3`, type: TABLE_DATA_TYPE, rowId: 3 },
     ];
     const columns = [
-      { type: TABLE_DATA_TYPE, id: 'a' },
-      { type: TABLE_DATA_TYPE, id: 'b' },
-      { type: TABLE_DATA_TYPE, id: 'c' },
-      { type: TABLE_DATA_TYPE, id: 'd' },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
+      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, columnId: 'c' },
+      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, columnId: 'd' },
     ];
     const tree = mount(
       <TableLayout
@@ -105,15 +105,15 @@ describe('TableLayout', () => {
 
   it('should render table with headerRows and columns', () => {
     const rows = [
-      { type: TABLE_DATA_TYPE, id: 1 },
-      { type: TABLE_DATA_TYPE, id: 2 },
-      { type: TABLE_DATA_TYPE, id: 3 },
+      { key: `${TABLE_DATA_TYPE}_1`, type: TABLE_DATA_TYPE, rowId: 1 },
+      { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
+      { key: `${TABLE_DATA_TYPE}_3`, type: TABLE_DATA_TYPE, rowId: 3 },
     ];
     const columns = [
-      { type: TABLE_DATA_TYPE, id: 'a' },
-      { type: TABLE_DATA_TYPE, id: 'b' },
-      { type: TABLE_DATA_TYPE, id: 'c' },
-      { type: TABLE_DATA_TYPE, id: 'd' },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
+      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, columnId: 'c' },
+      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, columnId: 'd' },
     ];
     const tree = mount(
       <TableLayout
@@ -133,14 +133,14 @@ describe('TableLayout', () => {
 
   it('should span columns if specified', () => {
     const rows = [
-      { type: TABLE_DATA_TYPE, id: 1, colSpanStart: 0 },
-      { type: TABLE_DATA_TYPE, id: 2, colSpanStart: 1 },
+      { key: `${TABLE_DATA_TYPE}_1`, type: TABLE_DATA_TYPE, rowId: 1, colSpanStart: 0 },
+      { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2, colSpanStart: 1 },
     ];
     const columns = [
-      { type: TABLE_DATA_TYPE, id: 'a' },
-      { type: TABLE_DATA_TYPE, id: 'b' },
-      { type: TABLE_DATA_TYPE, id: 'c' },
-      { type: TABLE_DATA_TYPE, id: 'd' },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
+      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, columnId: 'c' },
+      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, columnId: 'd' },
     ];
     const tree = mount(
       <TableLayout
@@ -167,12 +167,12 @@ describe('TableLayout', () => {
 
   it('should have correct styles', () => {
     const rows = [
-      { type: TABLE_DATA_TYPE, id: 1, height: 100 },
-      { type: TABLE_DATA_TYPE, id: 2 },
+      { key: `${TABLE_DATA_TYPE}_1`, type: TABLE_DATA_TYPE, rowId: 1, height: 100 },
+      { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
     ];
     const columns = [
-      { type: TABLE_DATA_TYPE, id: 'a', width: 100 },
-      { type: TABLE_DATA_TYPE, id: 'b' },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', width: 100 },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
     ];
     const tree = mount(
       <TableLayout
@@ -209,12 +209,12 @@ describe('TableLayout', () => {
 
   it('should handle click in body', () => {
     const rows = [
-      { type: TABLE_DATA_TYPE, id: 1 },
-      { type: TABLE_DATA_TYPE, id: 2 },
+      { key: `${TABLE_DATA_TYPE}_1`, type: TABLE_DATA_TYPE, rowId: 1 },
+      { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
     ];
     const columns = [
-      { type: TABLE_DATA_TYPE, id: 'a' },
-      { type: TABLE_DATA_TYPE, id: 'b' },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
     ];
     const onClick = jest.fn();
     const tree = mount(
@@ -238,12 +238,12 @@ describe('TableLayout', () => {
 
   it('should handle click in head', () => {
     const rows = [
-      { type: TABLE_DATA_TYPE, id: 1 },
-      { type: TABLE_DATA_TYPE, id: 2 },
+      { key: `${TABLE_DATA_TYPE}_1`, type: TABLE_DATA_TYPE, rowId: 1 },
+      { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
     ];
     const columns = [
-      { type: TABLE_DATA_TYPE, id: 'a' },
-      { type: TABLE_DATA_TYPE, id: 'b' },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
     ];
     const onClick = jest.fn();
     const tree = mount(
@@ -270,12 +270,12 @@ describe('TableLayout', () => {
   describe('flex column', () => {
     it('should add flex column if all columns have fixed widths', () => {
       const rows = [
-        { type: TABLE_DATA_TYPE, id: 1 },
-        { type: TABLE_DATA_TYPE, id: 2 },
+        { key: `${TABLE_DATA_TYPE}_1`, type: TABLE_DATA_TYPE, rowId: 1 },
+        { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
       ];
       const columns = [
-        { type: TABLE_DATA_TYPE, id: 'a', width: 100 },
-        { type: TABLE_DATA_TYPE, id: 'b', width: 100 },
+        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', width: 100 },
+        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', width: 100 },
       ];
       const tree = mount(
         <TableLayout
@@ -317,12 +317,12 @@ describe('TableLayout', () => {
         ({ top: 100, left: 100, width: 100, height: 100, right: 200, bottom: 200 }));
 
       const rows = [
-        { type: TABLE_DATA_TYPE, id: 1 },
-        { type: TABLE_DATA_TYPE, id: 2 },
+        { key: `${TABLE_DATA_TYPE}_1`, type: TABLE_DATA_TYPE, rowId: 1 },
+        { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
       ];
       const columns = [
-        { type: TABLE_DATA_TYPE, id: 'a' },
-        { type: TABLE_DATA_TYPE, id: 'b' },
+        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
+        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
       ];
       const tree = mount(
         <DragDropContext>
@@ -349,12 +349,12 @@ describe('TableLayout', () => {
         ({ top: 100, left: 100, width: 100, height: 100, right: 200, bottom: 200 }));
 
       const rows = [
-        { type: TABLE_DATA_TYPE, id: 1 },
-        { type: TABLE_DATA_TYPE, id: 2 },
+        { key: `${TABLE_DATA_TYPE}_1`, type: TABLE_DATA_TYPE, rowId: 1 },
+        { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
       ];
       const columns = [
-        { type: TABLE_DATA_TYPE, id: 'a' },
-        { type: TABLE_DATA_TYPE, id: 'b' },
+        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
+        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
       ];
       const tree = mount(
         <DragDropContext>
@@ -382,12 +382,12 @@ describe('TableLayout', () => {
         ({ top: 100, left: 100, width: 100, height: 100, right: 200, bottom: 200 }));
 
       const rows = [
-        { type: TABLE_DATA_TYPE, id: 1 },
-        { type: TABLE_DATA_TYPE, id: 2 },
+        { key: `${TABLE_DATA_TYPE}_1`, type: TABLE_DATA_TYPE, rowId: 1 },
+        { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
       ];
       const columns = [
-        { type: TABLE_DATA_TYPE, id: 'a' },
-        { type: TABLE_DATA_TYPE, id: 'b' },
+        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a' },
+        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b' },
       ];
       const setColumnOrder = jest.fn();
       const tree = mount(

--- a/packages/dx-react-grid/src/components/table-layout.test.jsx
+++ b/packages/dx-react-grid/src/components/table-layout.test.jsx
@@ -84,10 +84,10 @@ describe('TableLayout', () => {
       { key: `${TABLE_DATA_TYPE}_3`, type: TABLE_DATA_TYPE, rowId: 3 },
     ];
     const columns = [
-      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
-      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
-      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, columnId: 'c', column: { name: 'c' } },
-      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, column: { name: 'a' } },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, column: { name: 'b' } },
+      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, column: { name: 'c' } },
+      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, column: { name: 'd' } },
     ];
     const tree = mount(
       <TableLayout
@@ -110,10 +110,10 @@ describe('TableLayout', () => {
       { key: `${TABLE_DATA_TYPE}_3`, type: TABLE_DATA_TYPE, rowId: 3 },
     ];
     const columns = [
-      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
-      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
-      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, columnId: 'c', column: { name: 'c' } },
-      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, column: { name: 'a' } },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, column: { name: 'b' } },
+      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, column: { name: 'c' } },
+      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, column: { name: 'd' } },
     ];
     const tree = mount(
       <TableLayout
@@ -137,10 +137,10 @@ describe('TableLayout', () => {
       { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2, colSpanStart: 1 },
     ];
     const columns = [
-      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
-      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
-      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, columnId: 'c', column: { name: 'c' } },
-      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, columnId: 'd', column: { name: 'd' } },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, column: { name: 'a' } },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, column: { name: 'b' } },
+      { key: `${TABLE_DATA_TYPE}_c'`, type: TABLE_DATA_TYPE, column: { name: 'c' } },
+      { key: `${TABLE_DATA_TYPE}_d'`, type: TABLE_DATA_TYPE, column: { name: 'd' } },
     ];
     const tree = mount(
       <TableLayout
@@ -171,8 +171,8 @@ describe('TableLayout', () => {
       { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
     ];
     const columns = [
-      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' }, width: 100 },
-      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, column: { name: 'a' }, width: 100 },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, column: { name: 'b' } },
     ];
     const tree = mount(
       <TableLayout
@@ -213,8 +213,8 @@ describe('TableLayout', () => {
       { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
     ];
     const columns = [
-      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
-      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, column: { name: 'a' } },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, column: { name: 'b' } },
     ];
     const onClick = jest.fn();
     const tree = mount(
@@ -242,8 +242,8 @@ describe('TableLayout', () => {
       { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
     ];
     const columns = [
-      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
-      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+      { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, column: { name: 'a' } },
+      { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, column: { name: 'b' } },
     ];
     const onClick = jest.fn();
     const tree = mount(
@@ -274,8 +274,8 @@ describe('TableLayout', () => {
         { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
       ];
       const columns = [
-        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' }, width: 100 },
-        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' }, width: 100 },
+        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, column: { name: 'a' }, width: 100 },
+        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, column: { name: 'b' }, width: 100 },
       ];
       const tree = mount(
         <TableLayout
@@ -321,8 +321,8 @@ describe('TableLayout', () => {
         { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
       ];
       const columns = [
-        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
-        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, column: { name: 'a' } },
+        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, column: { name: 'b' } },
       ];
       const tree = mount(
         <DragDropContext>
@@ -353,8 +353,8 @@ describe('TableLayout', () => {
         { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
       ];
       const columns = [
-        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
-        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, column: { name: 'a' } },
+        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, column: { name: 'b' } },
       ];
       const tree = mount(
         <DragDropContext>
@@ -386,8 +386,8 @@ describe('TableLayout', () => {
         { key: `${TABLE_DATA_TYPE}_2`, type: TABLE_DATA_TYPE, rowId: 2 },
       ];
       const columns = [
-        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, columnId: 'a', column: { name: 'a' } },
-        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, columnId: 'b', column: { name: 'b' } },
+        { key: `${TABLE_DATA_TYPE}_a'`, type: TABLE_DATA_TYPE, column: { name: 'a' } },
+        { key: `${TABLE_DATA_TYPE}_b'`, type: TABLE_DATA_TYPE, column: { name: 'b' } },
       ];
       const setColumnOrder = jest.fn();
       const tree = mount(

--- a/packages/dx-react-grid/src/components/table-layout.test.jsx
+++ b/packages/dx-react-grid/src/components/table-layout.test.jsx
@@ -71,8 +71,8 @@ describe('TableLayout', () => {
         const columnWrapper = columnWrappers.at(columnIndex);
         const columnData = columnWrapper.children(PropsContainer).props();
 
-        expect(columnData.row).toMatchObject(row);
-        expect(columnData.column).toMatchObject(column);
+        expect(columnData.tableRow).toMatchObject(row);
+        expect(columnData.tableColumn).toMatchObject(column);
       });
     });
   };
@@ -233,7 +233,7 @@ describe('TableLayout', () => {
     tree.find('tr').at(1).find('td').at(1)
       .simulate('click');
     expect(onClick.mock.calls[0][0])
-      .toMatchObject({ row: rows[1], column: columns[1], e: {} });
+      .toMatchObject({ tableRow: rows[1], tableColumn: columns[1], e: {} });
   });
 
   it('should handle click in head', () => {
@@ -264,7 +264,7 @@ describe('TableLayout', () => {
     tree.find('tr').at(1).find('td').at(1)
       .simulate('click');
     expect(onClick.mock.calls[0][0])
-      .toMatchObject({ row: rows[1], column: columns[1], e: {} });
+      .toMatchObject({ tableRow: rows[1], tableColumn: columns[1], e: {} });
   });
 
   describe('flex column', () => {

--- a/packages/dx-react-grid/src/components/table-layout.test.jsx
+++ b/packages/dx-react-grid/src/components/table-layout.test.jsx
@@ -78,8 +78,8 @@ describe('TableLayout', () => {
   };
 
   it('should render table with rows and columns', () => {
-    const rows = [{ id: 1 }, { id: 2 }, { id: 3 }];
-    const columns = [{ name: 'a' }, { name: 'b' }, { name: 'c' }, { name: 'd' }];
+    const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }, { type: 'data', id: 3 }];
+    const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }, { type: 'data', id: 'c' }, { type: 'data', id: 'd' }];
     const tree = mount(
       <TableLayout
         rows={rows}
@@ -88,7 +88,6 @@ describe('TableLayout', () => {
         bodyTemplate={bodyTemplateMock}
         rowTemplate={rowTemplateMock}
         cellTemplate={cellTemplateMock}
-        getRowId={row => row.id}
       />,
     );
 
@@ -96,8 +95,8 @@ describe('TableLayout', () => {
   });
 
   it('should render table with headerRows and columns', () => {
-    const rows = [{ id: 1 }, { id: 2 }, { id: 3 }];
-    const columns = [{ name: 'a' }, { name: 'b' }, { name: 'c' }, { name: 'd' }];
+    const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }, { type: 'data', id: 3 }];
+    const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }, { type: 'data', id: 'c' }, { type: 'data', id: 'd' }];
     const tree = mount(
       <TableLayout
         headerRows={rows}
@@ -108,7 +107,6 @@ describe('TableLayout', () => {
         headTemplate={headTemplateMock}
         rowTemplate={rowTemplateMock}
         cellTemplate={cellTemplateMock}
-        getRowId={row => row.id}
       />,
     );
 
@@ -116,8 +114,8 @@ describe('TableLayout', () => {
   });
 
   it('should span columns if specified', () => {
-    const rows = [{ id: 1, colspan: 0 }, { id: 2, colspan: 1 }];
-    const columns = [{ name: 'a' }, { name: 'b' }, { name: 'c' }, { name: 'd' }];
+    const rows = [{ type: 'data', id: 1, colspan: 0 }, { type: 'data', id: 2, colspan: 1 }];
+    const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }, { type: 'data', id: 'c' }, { type: 'data', id: 'd' }];
     const tree = mount(
       <TableLayout
         rows={rows}
@@ -126,7 +124,6 @@ describe('TableLayout', () => {
         bodyTemplate={bodyTemplateMock}
         rowTemplate={rowTemplateMock}
         cellTemplate={cellTemplateMock}
-        getRowId={row => row.id}
       />,
     );
 
@@ -143,8 +140,8 @@ describe('TableLayout', () => {
   });
 
   it('should have correct styles', () => {
-    const rows = [{ id: 1, height: 100 }, { id: 2 }];
-    const columns = [{ name: 'a', width: 100 }, { name: 'b' }];
+    const rows = [{ type: 'data', id: 1, height: 100 }, { type: 'data', id: 2 }];
+    const columns = [{ type: 'data', id: 'a', width: 100 }, { type: 'data', id: 'b' }];
     const tree = mount(
       <TableLayout
         rows={rows}
@@ -154,7 +151,6 @@ describe('TableLayout', () => {
         bodyTemplate={bodyTemplateMock}
         rowTemplate={rowTemplateMock}
         cellTemplate={cellTemplateMock}
-        getRowId={row => row.id}
       />,
     );
 
@@ -180,8 +176,8 @@ describe('TableLayout', () => {
   });
 
   it('should handle click in body', () => {
-    const rows = [{ id: 1 }, { id: 2 }];
-    const columns = [{ name: 'a' }, { name: 'b' }];
+    const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }];
+    const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }];
     const onClick = jest.fn();
     const tree = mount(
       <TableLayout
@@ -192,7 +188,6 @@ describe('TableLayout', () => {
         bodyTemplate={bodyTemplateMock}
         rowTemplate={rowTemplateMock}
         cellTemplate={cellTemplateMock}
-        getRowId={row => row.id}
         onClick={onClick}
       />,
     );
@@ -204,8 +199,8 @@ describe('TableLayout', () => {
   });
 
   it('should handle click in head', () => {
-    const rows = [{ id: 1 }, { id: 2 }];
-    const columns = [{ name: 'a' }, { name: 'b' }];
+    const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }];
+    const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }];
     const onClick = jest.fn();
     const tree = mount(
       <TableLayout
@@ -218,7 +213,6 @@ describe('TableLayout', () => {
         bodyTemplate={bodyTemplateMock}
         rowTemplate={rowTemplateMock}
         cellTemplate={cellTemplateMock}
-        getRowId={row => row.id}
         onClick={onClick}
       />,
     );
@@ -231,8 +225,8 @@ describe('TableLayout', () => {
 
   describe('flex column', () => {
     it('should add flex column if all columns have fixed widths', () => {
-      const rows = [{ id: 1 }, { id: 2 }];
-      const columns = [{ name: 'a', width: 100 }, { name: 'b', width: 100 }];
+      const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }];
+      const columns = [{ type: 'data', id: 'a', width: 100 }, { type: 'data', id: 'b', width: 100 }];
       const tree = mount(
         <TableLayout
           rows={rows}
@@ -241,7 +235,6 @@ describe('TableLayout', () => {
           bodyTemplate={bodyTemplateMock}
           rowTemplate={rowTemplateMock}
           cellTemplate={cellTemplateMock}
-          getRowId={row => row.id}
         />,
       );
 
@@ -273,8 +266,8 @@ describe('TableLayout', () => {
       getRect.mockImplementation(() =>
         ({ top: 100, left: 100, width: 100, height: 100, right: 200, bottom: 200 }));
 
-      const rows = [{ id: 1 }, { id: 2 }];
-      const columns = [{ name: 'a' }, { name: 'b' }];
+      const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }];
+      const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }];
       const tree = mount(
         <DragDropContext>
           <TableLayout
@@ -284,7 +277,6 @@ describe('TableLayout', () => {
             bodyTemplate={bodyTemplateMock}
             rowTemplate={rowTemplateMock}
             cellTemplate={cellTemplateMock}
-            getRowId={row => row.id}
             allowColumnReordering
           />
         </DragDropContext>,
@@ -300,8 +292,8 @@ describe('TableLayout', () => {
       getRect.mockImplementation(() =>
         ({ top: 100, left: 100, width: 100, height: 100, right: 200, bottom: 200 }));
 
-      const rows = [{ id: 1 }, { id: 2 }];
-      const columns = [{ name: 'a' }, { name: 'b' }];
+      const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }];
+      const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }];
       const tree = mount(
         <DragDropContext>
           <TableLayout
@@ -311,7 +303,6 @@ describe('TableLayout', () => {
             bodyTemplate={bodyTemplateMock}
             rowTemplate={rowTemplateMock}
             cellTemplate={cellTemplateMock}
-            getRowId={row => row.id}
             allowColumnReordering
           />
         </DragDropContext>,
@@ -328,8 +319,8 @@ describe('TableLayout', () => {
       getRect.mockImplementation(() =>
         ({ top: 100, left: 100, width: 100, height: 100, right: 200, bottom: 200 }));
 
-      const rows = [{ id: 1 }, { id: 2 }];
-      const columns = [{ name: 'a' }, { name: 'b' }];
+      const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }];
+      const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }];
       const setColumnOrder = jest.fn();
       const tree = mount(
         <DragDropContext>
@@ -341,7 +332,6 @@ describe('TableLayout', () => {
             bodyTemplate={bodyTemplateMock}
             rowTemplate={rowTemplateMock}
             cellTemplate={cellTemplateMock}
-            getRowId={row => row.id}
             allowColumnReordering
             setColumnOrder={setColumnOrder}
           />

--- a/packages/dx-react-grid/src/components/table-layout.test.jsx
+++ b/packages/dx-react-grid/src/components/table-layout.test.jsx
@@ -2,8 +2,8 @@
 
 import React from 'react';
 import { mount } from 'enzyme';
-
 import { DragDropContext, DropTarget } from '@devexpress/dx-react-core';
+import { TABLE_DATA_TYPE } from '@devexpress/dx-grid-core';
 import { setupConsole } from '@devexpress/dx-testing';
 
 import { TableLayout } from './table-layout';
@@ -58,28 +58,37 @@ describe('TableLayout', () => {
 
   const testTablePart = ({ tree, rows, columns }) => {
     const rowWrappers = tree.find('tr');
-    expect(rowWrappers.length).toBe(rows.length);
+    expect(rowWrappers).toHaveLength(rows.length);
     rows.forEach((row, rowIndex) => {
       const rowWrapper = rowWrappers.at(rowIndex);
       const rowData = rowWrapper.children(PropsContainer).props();
 
-      expect(rowData.row).toBe(row);
+      expect(rowData.row).toMatchObject(row);
 
       const columnWrappers = rowWrapper.find('td');
-      expect(columnWrappers.length).toBe(columns.length);
+      expect(columnWrappers).toHaveLength(columns.length);
       columns.forEach((column, columnIndex) => {
         const columnWrapper = columnWrappers.at(columnIndex);
         const columnData = columnWrapper.children(PropsContainer).props();
 
-        expect(columnData.row).toBe(row);
-        expect(columnData.column).toBe(column);
+        expect(columnData.row).toMatchObject(row);
+        expect(columnData.column).toMatchObject(column);
       });
     });
   };
 
   it('should render table with rows and columns', () => {
-    const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }, { type: 'data', id: 3 }];
-    const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }, { type: 'data', id: 'c' }, { type: 'data', id: 'd' }];
+    const rows = [
+      { type: TABLE_DATA_TYPE, id: 1 },
+      { type: TABLE_DATA_TYPE, id: 2 },
+      { type: TABLE_DATA_TYPE, id: 3 },
+    ];
+    const columns = [
+      { type: TABLE_DATA_TYPE, id: 'a' },
+      { type: TABLE_DATA_TYPE, id: 'b' },
+      { type: TABLE_DATA_TYPE, id: 'c' },
+      { type: TABLE_DATA_TYPE, id: 'd' },
+    ];
     const tree = mount(
       <TableLayout
         rows={rows}
@@ -95,8 +104,17 @@ describe('TableLayout', () => {
   });
 
   it('should render table with headerRows and columns', () => {
-    const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }, { type: 'data', id: 3 }];
-    const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }, { type: 'data', id: 'c' }, { type: 'data', id: 'd' }];
+    const rows = [
+      { type: TABLE_DATA_TYPE, id: 1 },
+      { type: TABLE_DATA_TYPE, id: 2 },
+      { type: TABLE_DATA_TYPE, id: 3 },
+    ];
+    const columns = [
+      { type: TABLE_DATA_TYPE, id: 'a' },
+      { type: TABLE_DATA_TYPE, id: 'b' },
+      { type: TABLE_DATA_TYPE, id: 'c' },
+      { type: TABLE_DATA_TYPE, id: 'd' },
+    ];
     const tree = mount(
       <TableLayout
         headerRows={rows}
@@ -114,8 +132,16 @@ describe('TableLayout', () => {
   });
 
   it('should span columns if specified', () => {
-    const rows = [{ type: 'data', id: 1, colspan: 0 }, { type: 'data', id: 2, colspan: 1 }];
-    const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }, { type: 'data', id: 'c' }, { type: 'data', id: 'd' }];
+    const rows = [
+      { type: TABLE_DATA_TYPE, id: 1, colspan: 0 },
+      { type: TABLE_DATA_TYPE, id: 2, colspan: 1 },
+    ];
+    const columns = [
+      { type: TABLE_DATA_TYPE, id: 'a' },
+      { type: TABLE_DATA_TYPE, id: 'b' },
+      { type: TABLE_DATA_TYPE, id: 'c' },
+      { type: TABLE_DATA_TYPE, id: 'd' },
+    ];
     const tree = mount(
       <TableLayout
         rows={rows}
@@ -140,8 +166,14 @@ describe('TableLayout', () => {
   });
 
   it('should have correct styles', () => {
-    const rows = [{ type: 'data', id: 1, height: 100 }, { type: 'data', id: 2 }];
-    const columns = [{ type: 'data', id: 'a', width: 100 }, { type: 'data', id: 'b' }];
+    const rows = [
+      { type: TABLE_DATA_TYPE, id: 1, height: 100 },
+      { type: TABLE_DATA_TYPE, id: 2 },
+    ];
+    const columns = [
+      { type: TABLE_DATA_TYPE, id: 'a', width: 100 },
+      { type: TABLE_DATA_TYPE, id: 'b' },
+    ];
     const tree = mount(
       <TableLayout
         rows={rows}
@@ -176,8 +208,14 @@ describe('TableLayout', () => {
   });
 
   it('should handle click in body', () => {
-    const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }];
-    const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }];
+    const rows = [
+      { type: TABLE_DATA_TYPE, id: 1 },
+      { type: TABLE_DATA_TYPE, id: 2 },
+    ];
+    const columns = [
+      { type: TABLE_DATA_TYPE, id: 'a' },
+      { type: TABLE_DATA_TYPE, id: 'b' },
+    ];
     const onClick = jest.fn();
     const tree = mount(
       <TableLayout
@@ -199,8 +237,14 @@ describe('TableLayout', () => {
   });
 
   it('should handle click in head', () => {
-    const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }];
-    const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }];
+    const rows = [
+      { type: TABLE_DATA_TYPE, id: 1 },
+      { type: TABLE_DATA_TYPE, id: 2 },
+    ];
+    const columns = [
+      { type: TABLE_DATA_TYPE, id: 'a' },
+      { type: TABLE_DATA_TYPE, id: 'b' },
+    ];
     const onClick = jest.fn();
     const tree = mount(
       <TableLayout
@@ -225,8 +269,14 @@ describe('TableLayout', () => {
 
   describe('flex column', () => {
     it('should add flex column if all columns have fixed widths', () => {
-      const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }];
-      const columns = [{ type: 'data', id: 'a', width: 100 }, { type: 'data', id: 'b', width: 100 }];
+      const rows = [
+        { type: TABLE_DATA_TYPE, id: 1 },
+        { type: TABLE_DATA_TYPE, id: 2 },
+      ];
+      const columns = [
+        { type: TABLE_DATA_TYPE, id: 'a', width: 100 },
+        { type: TABLE_DATA_TYPE, id: 'b', width: 100 },
+      ];
       const tree = mount(
         <TableLayout
           rows={rows}
@@ -266,8 +316,14 @@ describe('TableLayout', () => {
       getRect.mockImplementation(() =>
         ({ top: 100, left: 100, width: 100, height: 100, right: 200, bottom: 200 }));
 
-      const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }];
-      const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }];
+      const rows = [
+        { type: TABLE_DATA_TYPE, id: 1 },
+        { type: TABLE_DATA_TYPE, id: 2 },
+      ];
+      const columns = [
+        { type: TABLE_DATA_TYPE, id: 'a' },
+        { type: TABLE_DATA_TYPE, id: 'b' },
+      ];
       const tree = mount(
         <DragDropContext>
           <TableLayout
@@ -292,8 +348,14 @@ describe('TableLayout', () => {
       getRect.mockImplementation(() =>
         ({ top: 100, left: 100, width: 100, height: 100, right: 200, bottom: 200 }));
 
-      const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }];
-      const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }];
+      const rows = [
+        { type: TABLE_DATA_TYPE, id: 1 },
+        { type: TABLE_DATA_TYPE, id: 2 },
+      ];
+      const columns = [
+        { type: TABLE_DATA_TYPE, id: 'a' },
+        { type: TABLE_DATA_TYPE, id: 'b' },
+      ];
       const tree = mount(
         <DragDropContext>
           <TableLayout
@@ -319,8 +381,14 @@ describe('TableLayout', () => {
       getRect.mockImplementation(() =>
         ({ top: 100, left: 100, width: 100, height: 100, right: 200, bottom: 200 }));
 
-      const rows = [{ type: 'data', id: 1 }, { type: 'data', id: 2 }];
-      const columns = [{ type: 'data', id: 'a' }, { type: 'data', id: 'b' }];
+      const rows = [
+        { type: TABLE_DATA_TYPE, id: 1 },
+        { type: TABLE_DATA_TYPE, id: 2 },
+      ];
+      const columns = [
+        { type: TABLE_DATA_TYPE, id: 'a' },
+        { type: TABLE_DATA_TYPE, id: 'b' },
+      ];
       const setColumnOrder = jest.fn();
       const tree = mount(
         <DragDropContext>

--- a/packages/dx-react-grid/src/components/table-layout/row-layout.jsx
+++ b/packages/dx-react-grid/src/components/table-layout/row-layout.jsx
@@ -36,14 +36,14 @@ export class RowLayout extends React.PureComponent {
       >
         {
           getTableRowColumnsWithColSpan(columns, row.colSpanStart)
-            .map(({ original: column, colspan }) => (
+            .map(column => (
               <TemplateRenderer
                 key={tableKeyGetter(column)}
                 template={cellTemplate}
                 tableRow={row}
                 tableColumn={column}
                 style={getColumnStyle({ column })}
-                {...colspan ? { colspan } : null}
+                {...column.colspan ? { colspan: column.colspan } : null}
               />
             ))
         }

--- a/packages/dx-react-grid/src/components/table-layout/row-layout.jsx
+++ b/packages/dx-react-grid/src/components/table-layout/row-layout.jsx
@@ -43,8 +43,8 @@ export class RowLayout extends React.PureComponent {
                 <TemplateRenderer
                   key={tableKeyGetter(column)}
                   template={cellTemplate}
-                  row={row}
-                  column={column}
+                  tableRow={row}
+                  tableColumn={column}
                   style={getColumnStyle({ column })}
                   {...colspan ? { colspan } : null}
                 />

--- a/packages/dx-react-grid/src/components/table-layout/row-layout.jsx
+++ b/packages/dx-react-grid/src/components/table-layout/row-layout.jsx
@@ -6,13 +6,13 @@ import {
 } from '@devexpress/dx-react-core';
 
 import {
-  tableColumnKeyGetter,
+  tableKeyGetter,
   getTableCellInfo,
 } from '@devexpress/dx-grid-core';
 
-const getColumnStyle = ({ column, animationState = {} }) => ({
+const getColumnStyle = ({ column }) => ({
   width: column.width !== undefined ? `${column.width}px` : undefined,
-  ...animationState,
+  ...column.animationState,
 });
 
 const getRowStyle = ({ row }) => ({
@@ -26,7 +26,6 @@ export class RowLayout extends React.PureComponent {
       columns,
       rowTemplate,
       cellTemplate,
-      animationState,
     } = this.props;
 
     return (
@@ -39,15 +38,14 @@ export class RowLayout extends React.PureComponent {
           columns
             .filter((column, columnIndex) => !getTableCellInfo({ row, columns, columnIndex }).skip)
             .map((column, columnIndex) => {
-              const key = tableColumnKeyGetter(column, columnIndex);
               const colspan = getTableCellInfo({ row, columns, columnIndex }).colspan;
               return (
                 <TemplateRenderer
-                  key={key}
+                  key={tableKeyGetter(column)}
                   template={cellTemplate}
                   row={row}
                   column={column}
-                  style={getColumnStyle({ column, animationState: animationState.get(key) })}
+                  style={getColumnStyle({ column })}
                   {...colspan ? { colspan } : null}
                 />
               );
@@ -63,5 +61,4 @@ RowLayout.propTypes = {
   columns: PropTypes.array.isRequired,
   rowTemplate: PropTypes.func.isRequired,
   cellTemplate: PropTypes.func.isRequired,
-  animationState: PropTypes.instanceOf(Map).isRequired,
 };

--- a/packages/dx-react-grid/src/components/table-layout/row-layout.jsx
+++ b/packages/dx-react-grid/src/components/table-layout/row-layout.jsx
@@ -6,7 +6,6 @@ import {
 } from '@devexpress/dx-react-core';
 
 import {
-  tableKeyGetter,
   getTableRowColumnsWithColSpan,
 } from '@devexpress/dx-grid-core';
 
@@ -38,7 +37,7 @@ export class RowLayout extends React.PureComponent {
           getTableRowColumnsWithColSpan(columns, row.colSpanStart)
             .map(column => (
               <TemplateRenderer
-                key={tableKeyGetter(column)}
+                key={column.key}
                 template={cellTemplate}
                 tableRow={row}
                 tableColumn={column}

--- a/packages/dx-react-grid/src/components/table-layout/rows-block-layout.jsx
+++ b/packages/dx-react-grid/src/components/table-layout/rows-block-layout.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-core';
 
 import {
-  tableRowKeyGetter,
+  tableKeyGetter,
   findTableCellTarget,
 } from '@devexpress/dx-grid-core';
 
@@ -16,13 +16,11 @@ export class RowsBlockLayout extends React.PureComponent {
   render() {
     const {
       rows,
-      getRowId,
       columns,
       blockTemplate,
       rowTemplate,
       cellTemplate,
       onClick,
-      animationState,
     } = this.props;
 
     return (
@@ -36,14 +34,13 @@ export class RowsBlockLayout extends React.PureComponent {
       >
         {
           rows
-            .map((row, rowIndex) => (
+            .map(row => (
               <RowLayout
-                key={tableRowKeyGetter(getRowId, row, rowIndex)}
+                key={tableKeyGetter(row)}
                 row={row}
                 columns={columns}
                 rowTemplate={rowTemplate}
                 cellTemplate={cellTemplate}
-                animationState={animationState}
               />
             ))
         }
@@ -54,11 +51,9 @@ export class RowsBlockLayout extends React.PureComponent {
 
 RowsBlockLayout.propTypes = {
   rows: PropTypes.array.isRequired,
-  getRowId: PropTypes.func.isRequired,
   columns: PropTypes.array.isRequired,
   blockTemplate: PropTypes.func.isRequired,
   rowTemplate: PropTypes.func.isRequired,
   cellTemplate: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
-  animationState: PropTypes.instanceOf(Map).isRequired,
 };

--- a/packages/dx-react-grid/src/components/table-layout/rows-block-layout.jsx
+++ b/packages/dx-react-grid/src/components/table-layout/rows-block-layout.jsx
@@ -6,7 +6,6 @@ import {
 } from '@devexpress/dx-react-core';
 
 import {
-  tableKeyGetter,
   findTableCellTarget,
 } from '@devexpress/dx-grid-core';
 
@@ -36,7 +35,7 @@ export class RowsBlockLayout extends React.PureComponent {
           rows
             .map(row => (
               <RowLayout
-                key={tableKeyGetter(row)}
+                key={row.key}
                 row={row}
                 columns={columns}
                 rowTemplate={rowTemplate}

--- a/packages/dx-react-grid/src/components/table-layout/rows-block-layout.jsx
+++ b/packages/dx-react-grid/src/components/table-layout/rows-block-layout.jsx
@@ -29,7 +29,7 @@ export class RowsBlockLayout extends React.PureComponent {
         onClick={(e) => {
           const { rowIndex, columnIndex } = findTableCellTarget(e);
           if (rowIndex === -1 || columnIndex === -1) return;
-          onClick({ e, row: rows[rowIndex], column: columns[columnIndex] });
+          onClick({ e, tableRow: rows[rowIndex], tableColumn: columns[columnIndex] });
         }}
       >
         {

--- a/packages/dx-react-grid/src/grid.jsx
+++ b/packages/dx-react-grid/src/grid.jsx
@@ -5,10 +5,9 @@ import { PluginHost, Getter, Template, TemplatePlaceholder } from '@devexpress/d
 const rowIdGetter = (getRowId, rows) => {
   let rowsMap;
   return (row) => {
-    const originalRow = row._originalRow || row;
-    if (getRowId) return getRowId(originalRow);
+    if (getRowId) return getRowId(row);
     if (!rowsMap) rowsMap = new Map(rows.map((r, rowIndex) => [r, rowIndex]));
-    return rowsMap.get(originalRow);
+    return rowsMap.get(row);
   };
 };
 

--- a/packages/dx-react-grid/src/plugins/table-edit-column.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.jsx
@@ -113,7 +113,7 @@ export class TableEditColumn extends React.PureComponent {
         </Template>
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => !row.type && column.type === 'edit'}
+          predicate={({ column, row }) => row.type === 'data' && column.type === 'edit'}
           connectGetters={(getter, { row }) => ({
             rowId: getter('getRowId')(row),
           })}

--- a/packages/dx-react-grid/src/plugins/table-edit-column.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.jsx
@@ -61,8 +61,8 @@ export class TableEditColumn extends React.PureComponent {
           {({ startEditRows, deleteRows, ...restParams }) =>
             cellTemplate({
               row: restParams.tableRow.row,
-              startEditing: () => startEditRows({ rowIds: [restParams.tableRow.id] }),
-              deleteRow: () => deleteRows({ rowIds: [restParams.tableRow.id] }),
+              startEditing: () => startEditRows({ rowIds: [restParams.tableRow.rowId] }),
+              deleteRow: () => deleteRows({ rowIds: [restParams.tableRow.rowId] }),
               commandTemplate,
               allowEditing,
               allowDeleting,
@@ -83,10 +83,10 @@ export class TableEditColumn extends React.PureComponent {
             cellTemplate({
               row: restParams.tableRow.row,
               cancelEditing: () => {
-                cancelAddedRows({ rowIds: [restParams.tableRow.id] });
+                cancelAddedRows({ rowIds: [restParams.tableRow.rowId] });
               },
               commitChanges: () => {
-                commitAddedRows({ rowIds: [restParams.tableRow.id] });
+                commitAddedRows({ rowIds: [restParams.tableRow.rowId] });
               },
               isEditing: true,
               commandTemplate,
@@ -113,12 +113,12 @@ export class TableEditColumn extends React.PureComponent {
             row: restParams.tableRow.row,
             column: restParams.tableColumn.column,
             cancelEditing: () => {
-              stopEditRows({ rowIds: [restParams.tableRow.id] });
-              cancelChangedRows({ rowIds: [restParams.tableRow.id] });
+              stopEditRows({ rowIds: [restParams.tableRow.rowId] });
+              cancelChangedRows({ rowIds: [restParams.tableRow.rowId] });
             },
             commitChanges: () => {
-              stopEditRows({ rowIds: [restParams.tableRow.id] });
-              commitChangedRows({ rowIds: [restParams.tableRow.id] });
+              stopEditRows({ rowIds: [restParams.tableRow.rowId] });
+              commitChangedRows({ rowIds: [restParams.tableRow.rowId] });
             },
             isEditing: true,
             commandTemplate,

--- a/packages/dx-react-grid/src/plugins/table-edit-column.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
 import {
   tableColumnsWithEditing,
-  isHeaderEditCommandsTableCell,
+  isHeadingEditCommandsTableCell,
   isDataEditCommandsTableCell,
   isEditNewRowCommandsTableCell,
   isEditExistingRowCommandsTableCell,
@@ -33,7 +33,7 @@ export class TableEditColumn extends React.PureComponent {
         <Template
           name="tableViewCell"
           predicate={({ tableRow, tableColumn }) =>
-            isHeaderEditCommandsTableCell(tableRow, tableColumn)}
+            isHeadingEditCommandsTableCell(tableRow, tableColumn)}
           connectActions={action => ({
             addRow: () => action('addRow')(),
           })}

--- a/packages/dx-react-grid/src/plugins/table-edit-column.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.jsx
@@ -44,10 +44,10 @@ export class TableEditColumn extends React.PureComponent {
         </Template>
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => row.type === 'edit' && !row.isNew && column.type === 'edit'}
+          predicate={({ column, row }) => row.type === 'edit' && column.type === 'edit'}
           connectGetters={(getter, { row }) => {
-            const originalRow = row._originalRow;
-            const rowId = getter('getRowId')(row);
+            const originalRow = row.original;
+            const rowId = getter('getRowId')(originalRow);
             return {
               rowId,
               row: originalRow,
@@ -60,36 +60,36 @@ export class TableEditColumn extends React.PureComponent {
           })}
         >
           {({
-              rowId,
-              row,
-              column,
-              stopEditRows,
-              cancelChangedRows,
-              commitChangedRows,
-              style,
-            }) =>
-            cellTemplate({
-              row,
-              column,
-              cancelEditing: () => {
-                stopEditRows({ rowIds: [rowId] });
-                cancelChangedRows({ rowIds: [rowId] });
-              },
-              commitChanges: () => {
-                stopEditRows({ rowIds: [rowId] });
-                commitChangedRows({ rowIds: [rowId] });
-              },
-              isEditing: true,
-              commandTemplate,
-              style,
-            })}
+            rowId,
+            row,
+            column,
+            stopEditRows,
+            cancelChangedRows,
+            commitChangedRows,
+            style,
+          }) =>
+          cellTemplate({
+            row,
+            column,
+            cancelEditing: () => {
+              stopEditRows({ rowIds: [rowId] });
+              cancelChangedRows({ rowIds: [rowId] });
+            },
+            commitChanges: () => {
+              stopEditRows({ rowIds: [rowId] });
+              commitChangedRows({ rowIds: [rowId] });
+            },
+            isEditing: true,
+            commandTemplate,
+            style,
+          })}
         </Template>
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => row.type === 'edit' && row.isNew && column.type === 'edit'}
+          predicate={({ column, row }) => row.type === 'add' && column.type === 'edit'}
           connectGetters={(_, { row }) => ({
-            rowId: row.index,
-            row: row._originalRow,
+            rowId: row.id,
+            row: row.original,
           })}
           connectActions={action => ({
             cancelAddedRows: ({ rowIds }) => action('cancelAddedRows')({ rowIds }),
@@ -115,7 +115,7 @@ export class TableEditColumn extends React.PureComponent {
           name="tableViewCell"
           predicate={({ column, row }) => row.type === 'data' && column.type === 'edit'}
           connectGetters={(getter, { row }) => ({
-            rowId: getter('getRowId')(row),
+            rowId: getter('getRowId')(row.original),
           })}
           connectActions={action => ({
             startEditRows: ({ rowIds }) => action('startEditRows')({ rowIds }),

--- a/packages/dx-react-grid/src/plugins/table-edit-column.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.jsx
@@ -32,27 +32,24 @@ export class TableEditColumn extends React.PureComponent {
         />
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => isHeaderEditCommandsTableCell(row, column)}
+          predicate={({ tableRow, tableColumn }) =>
+            isHeaderEditCommandsTableCell(tableRow, tableColumn)}
           connectActions={action => ({
             addRow: () => action('addRow')(),
           })}
         >
-          {({ row, column, addRow, style }) =>
+          {({ addRow, ...restParams }) =>
             headingCellTemplate({
-              row,
-              column,
               addRow: () => addRow(),
               commandTemplate,
               allowAdding,
-              style,
+              ...restParams,
             })}
         </Template>
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => isDataEditCommandsTableCell(row, column)}
-          connectGetters={(getter, { row }) => ({
-            rowId: row.id,
-          })}
+          predicate={({ tableRow, tableColumn }) =>
+            isDataEditCommandsTableCell(tableRow, tableColumn)}
           connectActions={action => ({
             startEditRows: ({ rowIds }) => action('startEditRows')({ rowIds }),
             deleteRows: ({ rowIds }) => {
@@ -61,11 +58,11 @@ export class TableEditColumn extends React.PureComponent {
             },
           })}
         >
-          {({ rowId, row: { original: row }, column, startEditRows, deleteRows, ...restParams }) =>
+          {({ startEditRows, deleteRows, ...restParams }) =>
             cellTemplate({
-              row,
-              startEditing: () => startEditRows({ rowIds: [rowId] }),
-              deleteRow: () => deleteRows({ rowIds: [rowId] }),
+              row: restParams.tableRow.row,
+              startEditing: () => startEditRows({ rowIds: [restParams.tableRow.id] }),
+              deleteRow: () => deleteRows({ rowIds: [restParams.tableRow.id] }),
               commandTemplate,
               allowEditing,
               allowDeleting,
@@ -75,42 +72,31 @@ export class TableEditColumn extends React.PureComponent {
         </Template>
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => isEditNewRowCommandsTableCell(row, column)}
-          connectGetters={(_, { row }) => ({
-            rowId: row.id,
-            row: row.original,
-          })}
+          predicate={({ tableRow, tableColumn }) =>
+            isEditNewRowCommandsTableCell(tableRow, tableColumn)}
           connectActions={action => ({
             cancelAddedRows: ({ rowIds }) => action('cancelAddedRows')({ rowIds }),
             commitAddedRows: ({ rowIds }) => action('commitAddedRows')({ rowIds }),
           })}
         >
-          {({ rowId, row, column, cancelAddedRows, commitAddedRows, style }) =>
+          {({ cancelAddedRows, commitAddedRows, ...restParams }) =>
             cellTemplate({
-              row,
-              column,
+              row: restParams.tableRow.row,
               cancelEditing: () => {
-                cancelAddedRows({ rowIds: [rowId] });
+                cancelAddedRows({ rowIds: [restParams.tableRow.id] });
               },
               commitChanges: () => {
-                commitAddedRows({ rowIds: [rowId] });
+                commitAddedRows({ rowIds: [restParams.tableRow.id] });
               },
               isEditing: true,
               commandTemplate,
-              style,
+              ...restParams,
             })}
         </Template>
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => isEditExistingRowCommandsTableCell(row, column)}
-          connectGetters={(getter, { row }) => {
-            const originalRow = row.original;
-            const rowId = row.id;
-            return {
-              rowId,
-              row: originalRow,
-            };
-          }}
+          predicate={({ tableRow, tableColumn }) =>
+            isEditExistingRowCommandsTableCell(tableRow, tableColumn)}
           connectActions={action => ({
             stopEditRows: ({ rowIds }) => action('stopEditRows')({ rowIds }),
             cancelChangedRows: ({ rowIds }) => action('cancelChangedRows')({ rowIds }),
@@ -118,28 +104,25 @@ export class TableEditColumn extends React.PureComponent {
           })}
         >
           {({
-            rowId,
-            row,
-            column,
             stopEditRows,
             cancelChangedRows,
             commitChangedRows,
-            style,
+            ...restParams
           }) =>
           cellTemplate({
-            row,
-            column,
+            row: restParams.tableRow.row,
+            column: restParams.tableColumn.column,
             cancelEditing: () => {
-              stopEditRows({ rowIds: [rowId] });
-              cancelChangedRows({ rowIds: [rowId] });
+              stopEditRows({ rowIds: [restParams.tableRow.id] });
+              cancelChangedRows({ rowIds: [restParams.tableRow.id] });
             },
             commitChanges: () => {
-              stopEditRows({ rowIds: [rowId] });
-              commitChangedRows({ rowIds: [rowId] });
+              stopEditRows({ rowIds: [restParams.tableRow.id] });
+              commitChangedRows({ rowIds: [restParams.tableRow.id] });
             },
             isEditing: true,
             commandTemplate,
-            style,
+            ...restParams,
           })}
         </Template>
       </PluginContainer>

--- a/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
@@ -1,0 +1,213 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { setupConsole } from '@devexpress/dx-testing';
+import {
+  Getter,
+  Template,
+  TemplatePlaceholder,
+  PluginHost,
+} from '@devexpress/dx-react-core';
+import {
+  tableColumnsWithEditing,
+  isHeaderEditCommandsTableCell,
+  isDataEditCommandsTableCell,
+  isEditNewRowCommandsTableCell,
+  isEditExistingRowCommandsTableCell,
+} from '@devexpress/dx-grid-core';
+import { TableEditColumn } from './table-edit-column';
+
+jest.mock('@devexpress/dx-grid-core', () => ({
+  tableColumnsWithEditing: jest.fn(),
+  isHeaderEditCommandsTableCell: jest.fn(),
+  isDataEditCommandsTableCell: jest.fn(),
+  isEditNewRowCommandsTableCell: jest.fn(),
+  isEditExistingRowCommandsTableCell: jest.fn(),
+}));
+
+const defaultPluginProps = {
+  cellTemplate: () => null,
+  headingCellTemplate: () => null,
+  commandTemplate: () => null,
+};
+
+describe('TableHeaderRow', () => {
+  let resetConsole;
+  beforeAll(() => {
+    resetConsole = setupConsole({ ignore: ['validateDOMNesting'] });
+  });
+  afterAll(() => {
+    resetConsole();
+  });
+
+  beforeEach(() => {
+    tableColumnsWithEditing.mockImplementation(() => 'tableColumnsWithEditing');
+    isHeaderEditCommandsTableCell.mockImplementation(() => false);
+    isDataEditCommandsTableCell.mockImplementation(() => false);
+    isEditNewRowCommandsTableCell.mockImplementation(() => false);
+    isEditExistingRowCommandsTableCell.mockImplementation(() => false);
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('table layout getters', () => {
+    it('should extend tableColumns', () => {
+      let tableColumns = null;
+      mount(
+        <PluginHost>
+          <Getter name="tableColumns" value="tableColumns" />
+          <TableEditColumn
+            {...defaultPluginProps}
+            width={120}
+          />
+          <Template
+            name="root"
+            connectGetters={getter => (tableColumns = getter('tableColumns'))}
+          >
+            {() => <div />}
+          </Template>
+        </PluginHost>,
+      );
+
+      expect(tableColumnsWithEditing)
+        .toBeCalledWith('tableColumns', 120);
+      expect(tableColumns)
+        .toBe('tableColumnsWithEditing');
+    });
+  });
+
+  it('should render edit commands cell on edit-commands column and header row intersection', () => {
+    isHeaderEditCommandsTableCell.mockImplementation(() => true);
+
+    const headingCellTemplate = jest.fn(() => null);
+
+    mount(
+      <PluginHost>
+        <Template name="root">
+          <TemplatePlaceholder
+            name="tableViewCell"
+            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+          />
+        </Template>
+        <TableEditColumn
+          {...defaultPluginProps}
+          headingCellTemplate={headingCellTemplate}
+        />
+      </PluginHost>,
+    );
+
+    expect(isHeaderEditCommandsTableCell)
+      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+    expect(headingCellTemplate)
+      .not.toBeCalledWith(expect.objectContaining({
+        row: 'row',
+        column: 'column',
+      }));
+    expect(headingCellTemplate)
+      .toBeCalledWith(expect.objectContaining({
+        style: {},
+      }));
+  });
+
+  it('should render edit commands cell on edit-commands column and user-defined row intersection', () => {
+    isDataEditCommandsTableCell.mockImplementation(() => true);
+
+    const cellTemplate = jest.fn(() => null);
+
+    mount(
+      <PluginHost>
+        <Template name="root">
+          <TemplatePlaceholder
+            name="tableViewCell"
+            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+          />
+        </Template>
+        <TableEditColumn
+          {...defaultPluginProps}
+          cellTemplate={cellTemplate}
+        />
+      </PluginHost>,
+    );
+
+    expect(isHeaderEditCommandsTableCell)
+      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+    expect(cellTemplate)
+      .not.toBeCalledWith(expect.objectContaining({
+        column: 'column',
+      }));
+    expect(cellTemplate)
+      .toBeCalledWith(expect.objectContaining({
+        row: 'row',
+        style: {},
+        isEditing: false,
+      }));
+  });
+
+  it('should render edit commands cell on edit-commands column and added row intersection', () => {
+    isEditNewRowCommandsTableCell.mockImplementation(() => true);
+
+    const cellTemplate = jest.fn(() => null);
+
+    mount(
+      <PluginHost>
+        <Template name="root">
+          <TemplatePlaceholder
+            name="tableViewCell"
+            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+          />
+        </Template>
+        <TableEditColumn
+          {...defaultPluginProps}
+          cellTemplate={cellTemplate}
+        />
+      </PluginHost>,
+    );
+
+    expect(isEditNewRowCommandsTableCell)
+      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+    expect(cellTemplate)
+      .not.toBeCalledWith(expect.objectContaining({
+        column: 'column',
+      }));
+    expect(cellTemplate)
+      .toBeCalledWith(expect.objectContaining({
+        row: 'row',
+        style: {},
+        isEditing: true,
+      }));
+  });
+
+  it('should render edit commands cell on edit-commands column and editing row intersection', () => {
+    isEditExistingRowCommandsTableCell.mockImplementation(() => true);
+
+    const cellTemplate = jest.fn(() => null);
+
+    mount(
+      <PluginHost>
+        <Template name="root">
+          <TemplatePlaceholder
+            name="tableViewCell"
+            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+          />
+        </Template>
+        <TableEditColumn
+          {...defaultPluginProps}
+          cellTemplate={cellTemplate}
+        />
+      </PluginHost>,
+    );
+
+    expect(isEditExistingRowCommandsTableCell)
+      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+    expect(cellTemplate)
+      .not.toBeCalledWith(expect.objectContaining({
+        column: 'column',
+      }));
+    expect(cellTemplate)
+      .toBeCalledWith(expect.objectContaining({
+        row: 'row',
+        style: {},
+        isEditing: true,
+      }));
+  });
+});

--- a/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { setupConsole } from '@devexpress/dx-testing';
-import {
-  Getter,
-  Template,
-  TemplatePlaceholder,
-  PluginHost,
-} from '@devexpress/dx-react-core';
+import { PluginHost } from '@devexpress/dx-react-core';
 import {
   tableColumnsWithEditing,
   isHeaderEditCommandsTableCell,
@@ -15,6 +10,7 @@ import {
   isEditExistingRowCommandsTableCell,
 } from '@devexpress/dx-grid-core';
 import { TableEditColumn } from './table-edit-column';
+import { pluginDepsToComponents } from './test-utils';
 
 jest.mock('@devexpress/dx-grid-core', () => ({
   tableColumnsWithEditing: jest.fn(),
@@ -23,6 +19,30 @@ jest.mock('@devexpress/dx-grid-core', () => ({
   isEditNewRowCommandsTableCell: jest.fn(),
   isEditExistingRowCommandsTableCell: jest.fn(),
 }));
+
+const defaultDeps = {
+  getter: {
+    tableColumns: [{ type: 'undefined', id: 1 }],
+  },
+  action: {
+    addRow: jest.fn(),
+    cancelAddedRows: jest.fn(),
+    commitAddedRows: jest.fn(),
+    startEditRows: jest.fn(),
+    stopEditRows: jest.fn(),
+    cancelChangedRows: jest.fn(),
+    commitChangedRows: jest.fn(),
+    deleteRows: jest.fn(),
+    commitDeletedRows: jest.fn(),
+  },
+  template: {
+    tableViewCell: {
+      tableRow: { type: 'undefined', id: 1, row: 'row' },
+      tableColumn: { type: 'undefined', id: 1, column: 'column' },
+      style: {},
+    },
+  },
+};
 
 const defaultProps = {
   cellTemplate: () => null,
@@ -52,44 +72,31 @@ describe('TableHeaderRow', () => {
 
   describe('table layout getters', () => {
     it('should extend tableColumns', () => {
-      let tableColumns = null;
+      const deps = {};
       mount(
         <PluginHost>
-          <Getter name="tableColumns" value="tableColumns" />
+          {pluginDepsToComponents(defaultDeps, deps)}
           <TableEditColumn
             {...defaultProps}
             width={120}
           />
-          <Template
-            name="root"
-            connectGetters={getter => (tableColumns = getter('tableColumns'))}
-          >
-            {() => <div />}
-          </Template>
         </PluginHost>,
       );
 
-      expect(tableColumnsWithEditing)
-        .toBeCalledWith('tableColumns', 120);
-      expect(tableColumns)
+      expect(deps.computedGetter('tableColumns'))
         .toBe('tableColumnsWithEditing');
+      expect(tableColumnsWithEditing)
+        .toBeCalledWith(defaultDeps.getter.tableColumns, 120);
     });
   });
 
   it('should render edit commands cell on edit-commands column and header row intersection', () => {
     isHeaderEditCommandsTableCell.mockImplementation(() => true);
-
     const headingCellTemplate = jest.fn(() => null);
-    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
-        <Template name="root">
-          <TemplatePlaceholder
-            name="tableViewCell"
-            params={tableCellArgs}
-          />
-        </Template>
+        {pluginDepsToComponents(defaultDeps)}
         <TableEditColumn
           {...defaultProps}
           headingCellTemplate={headingCellTemplate}
@@ -98,27 +105,23 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isHeaderEditCommandsTableCell)
-      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
+      .toBeCalledWith(
+        defaultDeps.template.tableViewCell.tableRow,
+        defaultDeps.template.tableViewCell.tableColumn,
+      );
     expect(headingCellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        ...tableCellArgs,
+        ...defaultDeps.template.tableViewCell,
       }));
   });
 
   it('should render edit commands cell on edit-commands column and user-defined row intersection', () => {
     isDataEditCommandsTableCell.mockImplementation(() => true);
-
     const cellTemplate = jest.fn(() => null);
-    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
-        <Template name="root">
-          <TemplatePlaceholder
-            name="tableViewCell"
-            params={tableCellArgs}
-          />
-        </Template>
+        {pluginDepsToComponents(defaultDeps)}
         <TableEditColumn
           {...defaultProps}
           cellTemplate={cellTemplate}
@@ -127,29 +130,25 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isHeaderEditCommandsTableCell)
-      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
+      .toBeCalledWith(
+        defaultDeps.template.tableViewCell.tableRow,
+        defaultDeps.template.tableViewCell.tableColumn,
+      );
     expect(cellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        ...tableCellArgs,
-        row: tableCellArgs.tableRow.row,
+        ...defaultDeps.template.tableViewCell,
+        row: defaultDeps.template.tableViewCell.tableRow.row,
         isEditing: false,
       }));
   });
 
   it('should render edit commands cell on edit-commands column and added row intersection', () => {
     isEditNewRowCommandsTableCell.mockImplementation(() => true);
-
     const cellTemplate = jest.fn(() => null);
-    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
-        <Template name="root">
-          <TemplatePlaceholder
-            name="tableViewCell"
-            params={tableCellArgs}
-          />
-        </Template>
+        {pluginDepsToComponents(defaultDeps)}
         <TableEditColumn
           {...defaultProps}
           cellTemplate={cellTemplate}
@@ -158,29 +157,25 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isEditNewRowCommandsTableCell)
-      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
+      .toBeCalledWith(
+        defaultDeps.template.tableViewCell.tableRow,
+        defaultDeps.template.tableViewCell.tableColumn,
+      );
     expect(cellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        ...tableCellArgs,
-        row: tableCellArgs.tableRow.row,
+        ...defaultDeps.template.tableViewCell,
+        row: defaultDeps.template.tableViewCell.tableRow.row,
         isEditing: true,
       }));
   });
 
   it('should render edit commands cell on edit-commands column and editing row intersection', () => {
     isEditExistingRowCommandsTableCell.mockImplementation(() => true);
-
     const cellTemplate = jest.fn(() => null);
-    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
-        <Template name="root">
-          <TemplatePlaceholder
-            name="tableViewCell"
-            params={tableCellArgs}
-          />
-        </Template>
+        {pluginDepsToComponents(defaultDeps)}
         <TableEditColumn
           {...defaultProps}
           cellTemplate={cellTemplate}
@@ -189,11 +184,14 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isEditExistingRowCommandsTableCell)
-      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
+      .toBeCalledWith(
+        defaultDeps.template.tableViewCell.tableRow,
+        defaultDeps.template.tableViewCell.tableColumn,
+      );
     expect(cellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        ...tableCellArgs,
-        row: tableCellArgs.tableRow.row,
+        ...defaultDeps.template.tableViewCell,
+        row: defaultDeps.template.tableViewCell.tableRow.row,
         isEditing: true,
       }));
   });

--- a/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
@@ -80,13 +80,14 @@ describe('TableHeaderRow', () => {
     isHeaderEditCommandsTableCell.mockImplementation(() => true);
 
     const headingCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
         <Template name="root">
           <TemplatePlaceholder
             name="tableViewCell"
-            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+            params={tableCellArgs}
           />
         </Template>
         <TableEditColumn
@@ -97,15 +98,10 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isHeaderEditCommandsTableCell)
-      .toBeCalledWith({ original: 'row' }, { original: 'column' });
-    expect(headingCellTemplate)
-      .not.toBeCalledWith(expect.objectContaining({
-        row: 'row',
-        column: 'column',
-      }));
+      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
     expect(headingCellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        style: {},
+        ...tableCellArgs,
       }));
   });
 
@@ -113,13 +109,14 @@ describe('TableHeaderRow', () => {
     isDataEditCommandsTableCell.mockImplementation(() => true);
 
     const cellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
         <Template name="root">
           <TemplatePlaceholder
             name="tableViewCell"
-            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+            params={tableCellArgs}
           />
         </Template>
         <TableEditColumn
@@ -130,15 +127,11 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isHeaderEditCommandsTableCell)
-      .toBeCalledWith({ original: 'row' }, { original: 'column' });
-    expect(cellTemplate)
-      .not.toBeCalledWith(expect.objectContaining({
-        column: 'column',
-      }));
+      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
     expect(cellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        row: 'row',
-        style: {},
+        ...tableCellArgs,
+        row: tableCellArgs.tableRow.row,
         isEditing: false,
       }));
   });
@@ -147,13 +140,14 @@ describe('TableHeaderRow', () => {
     isEditNewRowCommandsTableCell.mockImplementation(() => true);
 
     const cellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
         <Template name="root">
           <TemplatePlaceholder
             name="tableViewCell"
-            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+            params={tableCellArgs}
           />
         </Template>
         <TableEditColumn
@@ -164,15 +158,11 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isEditNewRowCommandsTableCell)
-      .toBeCalledWith({ original: 'row' }, { original: 'column' });
-    expect(cellTemplate)
-      .not.toBeCalledWith(expect.objectContaining({
-        column: 'column',
-      }));
+      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
     expect(cellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        row: 'row',
-        style: {},
+        ...tableCellArgs,
+        row: tableCellArgs.tableRow.row,
         isEditing: true,
       }));
   });
@@ -181,13 +171,14 @@ describe('TableHeaderRow', () => {
     isEditExistingRowCommandsTableCell.mockImplementation(() => true);
 
     const cellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
         <Template name="root">
           <TemplatePlaceholder
             name="tableViewCell"
-            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+            params={tableCellArgs}
           />
         </Template>
         <TableEditColumn
@@ -198,15 +189,11 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isEditExistingRowCommandsTableCell)
-      .toBeCalledWith({ original: 'row' }, { original: 'column' });
-    expect(cellTemplate)
-      .not.toBeCalledWith(expect.objectContaining({
-        column: 'column',
-      }));
+      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
     expect(cellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        row: 'row',
-        style: {},
+        ...tableCellArgs,
+        row: tableCellArgs.tableRow.row,
         isEditing: true,
       }));
   });

--- a/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
@@ -4,7 +4,7 @@ import { setupConsole } from '@devexpress/dx-testing';
 import { PluginHost } from '@devexpress/dx-react-core';
 import {
   tableColumnsWithEditing,
-  isHeaderEditCommandsTableCell,
+  isHeadingEditCommandsTableCell,
   isDataEditCommandsTableCell,
   isEditNewRowCommandsTableCell,
   isEditExistingRowCommandsTableCell,
@@ -14,7 +14,7 @@ import { pluginDepsToComponents } from './test-utils';
 
 jest.mock('@devexpress/dx-grid-core', () => ({
   tableColumnsWithEditing: jest.fn(),
-  isHeaderEditCommandsTableCell: jest.fn(),
+  isHeadingEditCommandsTableCell: jest.fn(),
   isDataEditCommandsTableCell: jest.fn(),
   isEditNewRowCommandsTableCell: jest.fn(),
   isEditExistingRowCommandsTableCell: jest.fn(),
@@ -61,7 +61,7 @@ describe('TableHeaderRow', () => {
 
   beforeEach(() => {
     tableColumnsWithEditing.mockImplementation(() => 'tableColumnsWithEditing');
-    isHeaderEditCommandsTableCell.mockImplementation(() => false);
+    isHeadingEditCommandsTableCell.mockImplementation(() => false);
     isDataEditCommandsTableCell.mockImplementation(() => false);
     isEditNewRowCommandsTableCell.mockImplementation(() => false);
     isEditExistingRowCommandsTableCell.mockImplementation(() => false);
@@ -91,7 +91,7 @@ describe('TableHeaderRow', () => {
   });
 
   it('should render edit commands cell on edit-commands column and header row intersection', () => {
-    isHeaderEditCommandsTableCell.mockImplementation(() => true);
+    isHeadingEditCommandsTableCell.mockImplementation(() => true);
     const headingCellTemplate = jest.fn(() => null);
 
     mount(
@@ -104,7 +104,7 @@ describe('TableHeaderRow', () => {
       </PluginHost>,
     );
 
-    expect(isHeaderEditCommandsTableCell)
+    expect(isHeadingEditCommandsTableCell)
       .toBeCalledWith(
         defaultDeps.template.tableViewCell.tableRow,
         defaultDeps.template.tableViewCell.tableColumn,
@@ -129,7 +129,7 @@ describe('TableHeaderRow', () => {
       </PluginHost>,
     );
 
-    expect(isHeaderEditCommandsTableCell)
+    expect(isHeadingEditCommandsTableCell)
       .toBeCalledWith(
         defaultDeps.template.tableViewCell.tableRow,
         defaultDeps.template.tableViewCell.tableColumn,

--- a/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
@@ -22,7 +22,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 
 const defaultDeps = {
   getter: {
-    tableColumns: [{ type: 'undefined', columnId: 1 }],
+    tableColumns: [{ type: 'undefined' }],
   },
   action: {
     addRow: jest.fn(),
@@ -38,7 +38,7 @@ const defaultDeps = {
   template: {
     tableViewCell: {
       tableRow: { type: 'undefined', rowId: 1, row: 'row' },
-      tableColumn: { type: 'undefined', columnId: 1, column: 'column' },
+      tableColumn: { type: 'undefined', column: 'column' },
       style: {},
     },
   },

--- a/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
@@ -24,7 +24,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
   isEditExistingRowCommandsTableCell: jest.fn(),
 }));
 
-const defaultPluginProps = {
+const defaultProps = {
   cellTemplate: () => null,
   headingCellTemplate: () => null,
   commandTemplate: () => null,
@@ -57,7 +57,7 @@ describe('TableHeaderRow', () => {
         <PluginHost>
           <Getter name="tableColumns" value="tableColumns" />
           <TableEditColumn
-            {...defaultPluginProps}
+            {...defaultProps}
             width={120}
           />
           <Template
@@ -91,7 +91,7 @@ describe('TableHeaderRow', () => {
           />
         </Template>
         <TableEditColumn
-          {...defaultPluginProps}
+          {...defaultProps}
           headingCellTemplate={headingCellTemplate}
         />
       </PluginHost>,
@@ -120,7 +120,7 @@ describe('TableHeaderRow', () => {
           />
         </Template>
         <TableEditColumn
-          {...defaultPluginProps}
+          {...defaultProps}
           cellTemplate={cellTemplate}
         />
       </PluginHost>,
@@ -151,7 +151,7 @@ describe('TableHeaderRow', () => {
           />
         </Template>
         <TableEditColumn
-          {...defaultPluginProps}
+          {...defaultProps}
           cellTemplate={cellTemplate}
         />
       </PluginHost>,
@@ -182,7 +182,7 @@ describe('TableHeaderRow', () => {
           />
         </Template>
         <TableEditColumn
-          {...defaultPluginProps}
+          {...defaultProps}
           cellTemplate={cellTemplate}
         />
       </PluginHost>,

--- a/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
@@ -22,7 +22,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 
 const defaultDeps = {
   getter: {
-    tableColumns: [{ type: 'undefined', id: 1 }],
+    tableColumns: [{ type: 'undefined', columnId: 1 }],
   },
   action: {
     addRow: jest.fn(),
@@ -37,8 +37,8 @@ const defaultDeps = {
   },
   template: {
     tableViewCell: {
-      tableRow: { type: 'undefined', id: 1, row: 'row' },
-      tableColumn: { type: 'undefined', id: 1, column: 'column' },
+      tableRow: { type: 'undefined', rowId: 1, row: 'row' },
+      tableColumn: { type: 'undefined', columnId: 1, column: 'column' },
       style: {},
     },
   },

--- a/packages/dx-react-grid/src/plugins/table-edit-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.jsx
@@ -26,7 +26,7 @@ export class TableEditRow extends React.PureComponent {
         <Template
           name="tableViewCell"
           predicate={({ tableRow, tableColumn }) => isEditExistingTableCell(tableRow, tableColumn)}
-          connectGetters={(getter, { tableColumn: { column }, tableRow: { id: rowId, row } }) => {
+          connectGetters={(getter, { tableColumn: { column }, tableRow: { rowId, row } }) => {
             const change = getRowChange(getter('changedRows'), rowId);
             return {
               value: column.name in change ? change[column.name] : row[column.name],
@@ -57,9 +57,6 @@ export class TableEditRow extends React.PureComponent {
         <Template
           name="tableViewCell"
           predicate={({ tableRow, tableColumn }) => isEditNewTableCell(tableRow, tableColumn)}
-          connectGetters={(_, { tableColumn: { column }, tableRow: { row } }) => ({
-            value: row[column.name],
-          })}
           connectActions={action => ({
             changeAddedRow: ({ rowId, change }) => action('changeAddedRow')({ rowId, change }),
           })}
@@ -72,7 +69,7 @@ export class TableEditRow extends React.PureComponent {
             editCellTemplate({
               row: restParams.tableRow.row,
               column: restParams.tableColumn.column,
-              value,
+              value: restParams.tableRow.row[restParams.tableColumn.column.name],
               onValueChange: newValue => changeAddedRow({
                 rowId: restParams.tableRow.rowId,
                 change: {

--- a/packages/dx-react-grid/src/plugins/table-edit-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.jsx
@@ -24,7 +24,7 @@ export class TableEditRow extends React.PureComponent {
         />
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => row.type === 'edit' && !row.isNew && !column.type}
+          predicate={({ column, row }) => row.type === 'edit' && !row.isNew && column.type === 'data'}
           connectGetters={(getter, { column, row }) => {
             const originalRow = row._originalRow;
             const rowId = getter('getRowId')(row);
@@ -55,7 +55,7 @@ export class TableEditRow extends React.PureComponent {
         </Template>
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => row.type === 'edit' && row.isNew && !column.type}
+          predicate={({ column, row }) => row.type === 'edit' && row.isNew && column.type === 'data'}
           connectGetters={(_, { column, row }) => {
             const originalRow = row._originalRow;
             return {

--- a/packages/dx-react-grid/src/plugins/table-edit-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.jsx
@@ -26,13 +26,11 @@ export class TableEditRow extends React.PureComponent {
         />
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => isEditExistingTableCell(row, column)}
-          connectGetters={(getter, { column: { original: column }, row }) => {
-            const rowId = row.id;
+          predicate={({ tableRow, tableColumn }) => isEditExistingTableCell(tableRow, tableColumn)}
+          connectGetters={(getter, { tableColumn: { column }, tableRow: { id: rowId, row } }) => {
             const change = getRowChange(getter('changedRows'), rowId);
             return {
-              rowId,
-              value: column.name in change ? change[column.name] : row.original[column.name],
+              value: column.name in change ? change[column.name] : row[column.name],
             };
           }}
           connectActions={action => ({
@@ -40,21 +38,18 @@ export class TableEditRow extends React.PureComponent {
           })}
         >
           {({
-            rowId,
-            row: { original: row },
-            column: { original: column },
             value,
             changeRow,
             ...restParams
           }) =>
             editCellTemplate({
-              row,
-              column,
+              row: restParams.tableRow.row,
+              column: restParams.tableColumn.column,
               value,
               onValueChange: newValue => changeRow({
-                rowId,
+                rowId: restParams.tableRow.id,
                 change: {
-                  [column.name]: newValue,
+                  [restParams.tableColumn.column.name]: newValue,
                 },
               }),
               ...restParams,
@@ -62,31 +57,27 @@ export class TableEditRow extends React.PureComponent {
         </Template>
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => isEditNewTableCell(row, column)}
-          connectGetters={(_, { column: { original: column }, row }) => ({
-            rowId: row.id,
-            value: row.original[column.name],
+          predicate={({ tableRow, tableColumn }) => isEditNewTableCell(tableRow, tableColumn)}
+          connectGetters={(_, { tableColumn: { column }, tableRow: { row } }) => ({
+            value: row[column.name],
           })}
           connectActions={action => ({
             changeAddedRow: ({ rowId, change }) => action('changeAddedRow')({ rowId, change }),
           })}
         >
           {({
-            row: { original: row },
-            rowId,
-            column: { original: column },
             value,
             changeAddedRow,
             ...restParams
           }) =>
             editCellTemplate({
-              row,
-              column,
+              row: restParams.tableRow.row,
+              column: restParams.tableColumn.column,
               value,
               onValueChange: newValue => changeAddedRow({
-                rowId,
+                rowId: restParams.tableRow.id,
                 change: {
-                  [column.name]: newValue,
+                  [restParams.tableColumn.column.name]: newValue,
                 },
               }),
               ...restParams,

--- a/packages/dx-react-grid/src/plugins/table-edit-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.jsx
@@ -27,12 +27,12 @@ export class TableEditRow extends React.PureComponent {
         <Template
           name="tableViewCell"
           predicate={({ column, row }) => isEditExistingTableCell(row, column)}
-          connectGetters={(getter, { column, row }) => {
+          connectGetters={(getter, { column: { original: column }, row }) => {
             const rowId = row.id;
             const change = getRowChange(getter('changedRows'), rowId);
             return {
               rowId,
-              value: change[column.name] || row.original[column.name],
+              value: column.name in change ? change[column.name] : row.original[column.name],
             };
           }}
           connectActions={action => ({
@@ -63,8 +63,8 @@ export class TableEditRow extends React.PureComponent {
         <Template
           name="tableViewCell"
           predicate={({ column, row }) => isEditNewTableCell(row, column)}
-          connectGetters={(_, { column, row }) => ({
-            rowId: row.index,
+          connectGetters={(_, { column: { original: column }, row }) => ({
+            rowId: row.id,
             value: row.original[column.name],
           })}
           connectActions={action => ({

--- a/packages/dx-react-grid/src/plugins/table-edit-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.jsx
@@ -20,7 +20,6 @@ export class TableEditRow extends React.PureComponent {
             getter('tableBodyRows'),
             getter('editingRows'),
             getter('addedRows'),
-            getter('getRowId'),
             rowHeight,
           ]}
         />

--- a/packages/dx-react-grid/src/plugins/table-edit-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.jsx
@@ -46,7 +46,7 @@ export class TableEditRow extends React.PureComponent {
               column: restParams.tableColumn.column,
               value,
               onValueChange: newValue => changeRow({
-                rowId: restParams.tableRow.id,
+                rowId: restParams.tableRow.rowId,
                 change: {
                   [restParams.tableColumn.column.name]: newValue,
                 },
@@ -74,7 +74,7 @@ export class TableEditRow extends React.PureComponent {
               column: restParams.tableColumn.column,
               value,
               onValueChange: newValue => changeAddedRow({
-                rowId: restParams.tableRow.id,
+                rowId: restParams.tableRow.rowId,
                 change: {
                   [restParams.tableColumn.column.name]: newValue,
                 },

--- a/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
@@ -20,7 +20,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 
 const defaultDeps = {
   getter: {
-    tableBodyRows: [{ type: 'undefined', id: 1 }],
+    tableBodyRows: [{ type: 'undefined', rowId: 1 }],
     editingRows: [1, 2],
     addedRows: [{ a: 'text' }, {}],
     changedRows: [{ 1: { a: 'text' } }],
@@ -31,8 +31,8 @@ const defaultDeps = {
   },
   template: {
     tableViewCell: {
-      tableRow: { type: 'undefined', id: 1, row: 'row' },
-      tableColumn: { type: 'undefined', id: 1, column: 'column' },
+      tableRow: { type: 'undefined', rowId: 1, row: 'row' },
+      tableColumn: { type: 'undefined', columnId: 1, column: 'column' },
       style: {},
     },
   },

--- a/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { setupConsole } from '@devexpress/dx-testing';
-import {
-  Getter,
-  Template,
-  TemplatePlaceholder,
-  PluginHost,
-} from '@devexpress/dx-react-core';
+import { PluginHost } from '@devexpress/dx-react-core';
 import {
   getRowChange,
   tableRowsWithEditing,
@@ -14,6 +9,7 @@ import {
   isEditExistingTableCell,
 } from '@devexpress/dx-grid-core';
 import { TableEditRow } from './table-edit-row';
+import { pluginDepsToComponents } from './test-utils';
 
 jest.mock('@devexpress/dx-grid-core', () => ({
   getRowChange: jest.fn(),
@@ -21,6 +17,26 @@ jest.mock('@devexpress/dx-grid-core', () => ({
   isEditNewTableCell: jest.fn(),
   isEditExistingTableCell: jest.fn(),
 }));
+
+const defaultDeps = {
+  getter: {
+    tableBodyRows: [{ type: 'undefined', id: 1 }],
+    editingRows: [1, 2],
+    addedRows: [{ a: 'text' }, {}],
+    changedRows: [{ 1: { a: 'text' } }],
+  },
+  action: {
+    changeAddRow: jest.fn(),
+    changeRow: jest.fn(),
+  },
+  template: {
+    tableViewCell: {
+      tableRow: { type: 'undefined', id: 1, row: 'row' },
+      tableColumn: { type: 'undefined', id: 1, column: 'column' },
+      style: {},
+    },
+  },
+};
 
 const defaultProps = {
   editCellTemplate: () => null,
@@ -47,46 +63,36 @@ describe('TableHeaderRow', () => {
 
   describe('table layout getters', () => {
     it('should extend tableBodyRows', () => {
-      let tableBodyRows = null;
+      const deps = {};
       mount(
         <PluginHost>
-          <Getter name="tableBodyRows" value="tableBodyRows" />
-          <Getter name="editingRows" value="editingRows" />
-          <Getter name="addedRows" value="addedRows" />
+          {pluginDepsToComponents(defaultDeps, deps)}
           <TableEditRow
             {...defaultProps}
             rowHeight={120}
           />
-          <Template
-            name="root"
-            connectGetters={getter => (tableBodyRows = getter('tableBodyRows'))}
-          >
-            {() => <div />}
-          </Template>
         </PluginHost>,
       );
 
-      expect(tableRowsWithEditing)
-        .toBeCalledWith('tableBodyRows', 'editingRows', 'addedRows', 120);
-      expect(tableBodyRows)
+      expect(deps.computedGetter('tableBodyRows'))
         .toBe('tableRowsWithEditing');
+      expect(tableRowsWithEditing)
+        .toBeCalledWith(
+          defaultDeps.getter.tableBodyRows,
+          defaultDeps.getter.editingRows,
+          defaultDeps.getter.addedRows,
+          120,
+        );
     });
   });
 
   it('should render edit cell on user-defined column and added row intersection', () => {
     isEditNewTableCell.mockImplementation(() => true);
-
     const editCellTemplate = jest.fn(() => null);
-    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
-        <Template name="root">
-          <TemplatePlaceholder
-            name="tableViewCell"
-            params={tableCellArgs}
-          />
-        </Template>
+        {pluginDepsToComponents(defaultDeps)}
         <TableEditRow
           {...defaultProps}
           editCellTemplate={editCellTemplate}
@@ -95,29 +101,25 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isEditNewTableCell)
-      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
+      .toBeCalledWith(
+        defaultDeps.template.tableViewCell.tableRow,
+        defaultDeps.template.tableViewCell.tableColumn,
+      );
     expect(editCellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        ...tableCellArgs,
-        row: tableCellArgs.tableRow.row,
-        column: tableCellArgs.tableColumn.column,
+        ...defaultDeps.template.tableViewCell,
+        row: defaultDeps.template.tableViewCell.tableRow.row,
+        column: defaultDeps.template.tableViewCell.tableColumn.column,
       }));
   });
 
   it('should render edit cell on user-defined column and edit row intersection', () => {
     isEditExistingTableCell.mockImplementation(() => true);
-
     const editCellTemplate = jest.fn(() => null);
-    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
-        <Template name="root">
-          <TemplatePlaceholder
-            name="tableViewCell"
-            params={tableCellArgs}
-          />
-        </Template>
+        {pluginDepsToComponents(defaultDeps)}
         <TableEditRow
           {...defaultProps}
           editCellTemplate={editCellTemplate}
@@ -126,12 +128,15 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isEditExistingTableCell)
-      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
+      .toBeCalledWith(
+        defaultDeps.template.tableViewCell.tableRow,
+        defaultDeps.template.tableViewCell.tableColumn,
+      );
     expect(editCellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        ...tableCellArgs,
-        row: tableCellArgs.tableRow.row,
-        column: tableCellArgs.tableColumn.column,
+        ...defaultDeps.template.tableViewCell,
+        row: defaultDeps.template.tableViewCell.tableRow.row,
+        column: defaultDeps.template.tableViewCell.tableColumn.column,
       }));
   });
 });

--- a/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { setupConsole } from '@devexpress/dx-testing';
+import {
+  Getter,
+  Template,
+  TemplatePlaceholder,
+  PluginHost,
+} from '@devexpress/dx-react-core';
+import {
+  getRowChange,
+  tableRowsWithEditing,
+  isEditNewTableCell,
+  isEditExistingTableCell,
+} from '@devexpress/dx-grid-core';
+import { TableEditRow } from './table-edit-row';
+
+jest.mock('@devexpress/dx-grid-core', () => ({
+  getRowChange: jest.fn(),
+  tableRowsWithEditing: jest.fn(),
+  isEditNewTableCell: jest.fn(),
+  isEditExistingTableCell: jest.fn(),
+}));
+
+const defaultPluginProps = {
+  editCellTemplate: () => null,
+};
+
+describe('TableHeaderRow', () => {
+  let resetConsole;
+  beforeAll(() => {
+    resetConsole = setupConsole({ ignore: ['validateDOMNesting'] });
+  });
+  afterAll(() => {
+    resetConsole();
+  });
+
+  beforeEach(() => {
+    getRowChange.mockImplementation(() => ({}));
+    tableRowsWithEditing.mockImplementation(() => 'tableRowsWithEditing');
+    isEditNewTableCell.mockImplementation(() => false);
+    isEditExistingTableCell.mockImplementation(() => false);
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('table layout getters', () => {
+    it('should extend tableBodyRows', () => {
+      let tableBodyRows = null;
+      mount(
+        <PluginHost>
+          <Getter name="tableBodyRows" value="tableBodyRows" />
+          <Getter name="editingRows" value="editingRows" />
+          <Getter name="addedRows" value="addedRows" />
+          <Getter name="getRowId" value="getRowId" />
+          <TableEditRow
+            {...defaultPluginProps}
+            rowHeight={120}
+          />
+          <Template
+            name="root"
+            connectGetters={getter => (tableBodyRows = getter('tableBodyRows'))}
+          >
+            {() => <div />}
+          </Template>
+        </PluginHost>,
+      );
+
+      expect(tableRowsWithEditing)
+        .toBeCalledWith('tableBodyRows', 'editingRows', 'addedRows', 'getRowId', 120);
+      expect(tableBodyRows)
+        .toBe('tableRowsWithEditing');
+    });
+  });
+
+  it('should render edit cell on user-defined column and added row intersection', () => {
+    isEditNewTableCell.mockImplementation(() => true);
+
+    const editCellTemplate = jest.fn(() => null);
+
+    mount(
+      <PluginHost>
+        <Template name="root">
+          <TemplatePlaceholder
+            name="tableViewCell"
+            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+          />
+        </Template>
+        <TableEditRow
+          {...defaultPluginProps}
+          editCellTemplate={editCellTemplate}
+        />
+      </PluginHost>,
+    );
+
+    expect(isEditNewTableCell)
+      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+    expect(editCellTemplate)
+      .toBeCalledWith(expect.objectContaining({
+        row: 'row',
+        column: 'column',
+        style: {},
+      }));
+  });
+
+  it('should render edit cell on user-defined column and edit row intersection', () => {
+    isEditExistingTableCell.mockImplementation(() => true);
+
+    const editCellTemplate = jest.fn(() => null);
+
+    mount(
+      <PluginHost>
+        <Template name="root">
+          <TemplatePlaceholder
+            name="tableViewCell"
+            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+          />
+        </Template>
+        <TableEditRow
+          {...defaultPluginProps}
+          editCellTemplate={editCellTemplate}
+        />
+      </PluginHost>,
+    );
+
+    expect(isEditExistingTableCell)
+      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+    expect(editCellTemplate)
+      .toBeCalledWith(expect.objectContaining({
+        row: 'row',
+        column: 'column',
+        style: {},
+      }));
+  });
+});

--- a/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
@@ -32,7 +32,7 @@ const defaultDeps = {
   template: {
     tableViewCell: {
       tableRow: { type: 'undefined', rowId: 1, row: 'row' },
-      tableColumn: { type: 'undefined', columnId: 1, column: 'column' },
+      tableColumn: { type: 'undefined', column: 'column' },
       style: {},
     },
   },

--- a/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
@@ -78,13 +78,14 @@ describe('TableHeaderRow', () => {
     isEditNewTableCell.mockImplementation(() => true);
 
     const editCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
         <Template name="root">
           <TemplatePlaceholder
             name="tableViewCell"
-            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+            params={tableCellArgs}
           />
         </Template>
         <TableEditRow
@@ -95,12 +96,12 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isEditNewTableCell)
-      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
     expect(editCellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        row: 'row',
-        column: 'column',
-        style: {},
+        ...tableCellArgs,
+        row: tableCellArgs.tableRow.row,
+        column: tableCellArgs.tableColumn.column,
       }));
   });
 
@@ -108,13 +109,14 @@ describe('TableHeaderRow', () => {
     isEditExistingTableCell.mockImplementation(() => true);
 
     const editCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
         <Template name="root">
           <TemplatePlaceholder
             name="tableViewCell"
-            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+            params={tableCellArgs}
           />
         </Template>
         <TableEditRow
@@ -125,12 +127,12 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isEditExistingTableCell)
-      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
     expect(editCellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        row: 'row',
-        column: 'column',
-        style: {},
+        ...tableCellArgs,
+        row: tableCellArgs.tableRow.row,
+        column: tableCellArgs.tableColumn.column,
       }));
   });
 });

--- a/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
@@ -22,7 +22,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
   isEditExistingTableCell: jest.fn(),
 }));
 
-const defaultPluginProps = {
+const defaultProps = {
   editCellTemplate: () => null,
 };
 
@@ -54,7 +54,7 @@ describe('TableHeaderRow', () => {
           <Getter name="editingRows" value="editingRows" />
           <Getter name="addedRows" value="addedRows" />
           <TableEditRow
-            {...defaultPluginProps}
+            {...defaultProps}
             rowHeight={120}
           />
           <Template
@@ -88,7 +88,7 @@ describe('TableHeaderRow', () => {
           />
         </Template>
         <TableEditRow
-          {...defaultPluginProps}
+          {...defaultProps}
           editCellTemplate={editCellTemplate}
         />
       </PluginHost>,
@@ -119,7 +119,7 @@ describe('TableHeaderRow', () => {
           />
         </Template>
         <TableEditRow
-          {...defaultPluginProps}
+          {...defaultProps}
           editCellTemplate={editCellTemplate}
         />
       </PluginHost>,

--- a/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
@@ -53,7 +53,6 @@ describe('TableHeaderRow', () => {
           <Getter name="tableBodyRows" value="tableBodyRows" />
           <Getter name="editingRows" value="editingRows" />
           <Getter name="addedRows" value="addedRows" />
-          <Getter name="getRowId" value="getRowId" />
           <TableEditRow
             {...defaultPluginProps}
             rowHeight={120}
@@ -68,7 +67,7 @@ describe('TableHeaderRow', () => {
       );
 
       expect(tableRowsWithEditing)
-        .toBeCalledWith('tableBodyRows', 'editingRows', 'addedRows', 'getRowId', 120);
+        .toBeCalledWith('tableBodyRows', 'editingRows', 'addedRows', 120);
       expect(tableBodyRows)
         .toBe('tableRowsWithEditing');
     });

--- a/packages/dx-react-grid/src/plugins/table-filter-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-filter-row.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
-import { getColumnFilterConfig, tableHeaderRowsWithFilter } from '@devexpress/dx-grid-core';
+import {
+  getColumnFilterConfig,
+  tableHeaderRowsWithFilter,
+  isFilterTableCell,
+} from '@devexpress/dx-grid-core';
 
 export class TableFilterRow extends React.PureComponent {
   render() {
@@ -20,15 +24,16 @@ export class TableFilterRow extends React.PureComponent {
 
         <Template
           name="tableViewCell"
-          predicate={({ row, column }) => row.type === 'filter' && !column.type}
-          connectGetters={(getter, { column }) => ({
+          predicate={({ row, column }) => isFilterTableCell(row, column)}
+          connectGetters={(getter, { column: { original: column } }) => ({
             filter: getColumnFilterConfig(getter('filters'), column.name),
           })}
-          connectActions={(action, { column }) => ({
+          connectActions={(action, { column: { original: column } }) => ({
             setFilter: config => action('setColumnFilter')({ columnName: column.name, config }),
           })}
         >
-          {({ row, ...restParams }) => filterCellTemplate(restParams)}
+          {({ row, column: { original: column }, ...restParams }) =>
+            filterCellTemplate({ column, ...restParams })}
         </Template>
       </PluginContainer>
     );

--- a/packages/dx-react-grid/src/plugins/table-filter-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-filter-row.jsx
@@ -24,16 +24,15 @@ export class TableFilterRow extends React.PureComponent {
 
         <Template
           name="tableViewCell"
-          predicate={({ row, column }) => isFilterTableCell(row, column)}
-          connectGetters={(getter, { column: { original: column } }) => ({
+          predicate={({ tableRow, tableColumn }) => isFilterTableCell(tableRow, tableColumn)}
+          connectGetters={(getter, { tableColumn: { column } }) => ({
             filter: getColumnFilterConfig(getter('filters'), column.name),
           })}
-          connectActions={(action, { column: { original: column } }) => ({
+          connectActions={(action, { tableColumn: { column } }) => ({
             setFilter: config => action('setColumnFilter')({ columnName: column.name, config }),
           })}
         >
-          {({ row, column: { original: column }, ...restParams }) =>
-            filterCellTemplate({ column, ...restParams })}
+          {params => filterCellTemplate({ ...params, column: params.tableColumn.column })}
         </Template>
       </PluginContainer>
     );

--- a/packages/dx-react-grid/src/plugins/table-filter-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-filter-row.test.jsx
@@ -26,7 +26,7 @@ const defaultDeps = {
   template: {
     tableViewCell: {
       tableRow: { type: 'undefined', rowId: 1, row: 'row' },
-      tableColumn: { type: 'undefined', columnId: 1, column: 'column' },
+      tableColumn: { type: 'undefined', column: 'column' },
       style: {},
     },
   },

--- a/packages/dx-react-grid/src/plugins/table-filter-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-filter-row.test.jsx
@@ -19,7 +19,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
   getColumnFilterConfig: jest.fn(),
 }));
 
-const defaultPluginProps = {
+const defaultProps = {
   filterCellTemplate: () => null,
 };
 
@@ -47,7 +47,7 @@ describe('TableHeaderRow', () => {
         <PluginHost>
           <Getter name="tableHeaderRows" value="tableHeaderRows" />
           <TableFilterRow
-            {...defaultPluginProps}
+            {...defaultProps}
           />
           <Template
             name="root"
@@ -80,7 +80,7 @@ describe('TableHeaderRow', () => {
           />
         </Template>
         <TableFilterRow
-          {...defaultPluginProps}
+          {...defaultProps}
           filterCellTemplate={filterCellTemplate}
         />
       </PluginHost>,

--- a/packages/dx-react-grid/src/plugins/table-filter-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-filter-row.test.jsx
@@ -69,13 +69,14 @@ describe('TableHeaderRow', () => {
     isFilterTableCell.mockImplementation(() => true);
 
     const filterCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
         <Template name="root">
           <TemplatePlaceholder
             name="tableViewCell"
-            params={{ row: { original: 'row' }, column: { original: { name: 'a' } }, style: {} }}
+            params={tableCellArgs}
           />
         </Template>
         <TableFilterRow
@@ -86,13 +87,11 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isFilterTableCell)
-      .toBeCalledWith({ original: 'row' }, { original: { name: 'a' } });
-    expect(filterCellTemplate)
-      .not.toBeCalledWith(expect.objectContaining({ row: 'row' }));
+      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
     expect(filterCellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        column: { name: 'a' },
-        style: {},
+        ...tableCellArgs,
+        column: tableCellArgs.tableColumn.column,
       }));
   });
 });

--- a/packages/dx-react-grid/src/plugins/table-filter-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-filter-row.test.jsx
@@ -17,7 +17,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 
 const defaultDeps = {
   getter: {
-    tableHeaderRows: [{ type: 'undefined', id: 1 }],
+    tableHeaderRows: [{ type: 'undefined', rowId: 1 }],
     filters: [{ columnName: 'a', value: 'b' }],
   },
   action: {
@@ -25,8 +25,8 @@ const defaultDeps = {
   },
   template: {
     tableViewCell: {
-      tableRow: { type: 'undefined', id: 1, row: 'row' },
-      tableColumn: { type: 'undefined', id: 1, column: 'column' },
+      tableRow: { type: 'undefined', rowId: 1, row: 'row' },
+      tableColumn: { type: 'undefined', columnId: 1, column: 'column' },
       style: {},
     },
   },

--- a/packages/dx-react-grid/src/plugins/table-group-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-group-row.jsx
@@ -4,6 +4,8 @@ import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
 import {
   tableColumnsWithGrouping,
   tableRowsWithGrouping,
+  isGroupTableCell,
+  isGroupIndentTableCell,
 } from '@devexpress/dx-grid-core';
 
 export class TableGroupRow extends React.PureComponent {
@@ -36,30 +38,23 @@ export class TableGroupRow extends React.PureComponent {
 
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => row.type === 'groupRow'
-            && column.type === 'groupColumn'
-            && row.column.name === column.group.columnName}
+          predicate={({ tableRow, tableColumn }) => isGroupTableCell(tableRow, tableColumn)}
           connectGetters={getter => ({ expandedGroups: getter('expandedGroups') })}
           connectActions={action => ({ toggleGroupExpanded: action('toggleGroupExpanded') })}
         >
           {({ expandedGroups, toggleGroupExpanded, ...params }) => groupCellTemplate({
             ...params,
-            isExpanded: expandedGroups.has(params.row.key),
-            toggleGroupExpanded: () => toggleGroupExpanded({ groupKey: params.row.key }),
+            row: params.tableRow.row,
+            isExpanded: expandedGroups.has(params.tableRow.row.key),
+            toggleGroupExpanded: () => toggleGroupExpanded({ groupKey: params.tableRow.row.key }),
           })}
         </Template>
         {groupIndentCellTemplate && (
           <Template
             name="tableViewCell"
-            predicate={({ column, row }) => (
-              column.type === 'groupColumn'
-              && (
-                !row.type
-                || (row.type === 'groupRow' && row.column.name !== column.group.columnName)
-              )
-            )}
+            predicate={({ tableRow, tableColumn }) => isGroupIndentTableCell(tableRow, tableColumn)}
           >
-            {groupIndentCellTemplate}
+            {params => groupIndentCellTemplate({ row: params.tableRow.row, ...params })}
           </Template>
         )}
       </PluginContainer>

--- a/packages/dx-react-grid/src/plugins/table-group-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-group-row.test.jsx
@@ -1,21 +1,49 @@
 import React from 'react';
 import { mount } from 'enzyme';
-
 import { setupConsole } from '@devexpress/dx-testing';
-import {
-  Getter, Template, TemplatePlaceholder, PluginHost,
-} from '@devexpress/dx-react-core';
+import { PluginHost } from '@devexpress/dx-react-core';
 import {
   tableColumnsWithGrouping,
   tableRowsWithGrouping,
+  isGroupTableCell,
+  isGroupIndentTableCell,
 } from '@devexpress/dx-grid-core';
-
 import { TableGroupRow } from './table-group-row';
+import { pluginDepsToComponents } from './test-utils';
 
 jest.mock('@devexpress/dx-grid-core', () => ({
   tableColumnsWithGrouping: jest.fn(),
   tableRowsWithGrouping: jest.fn(),
+  isGroupTableCell: jest.fn(),
+  isGroupIndentTableCell: jest.fn(),
 }));
+
+const defaultDeps = {
+  getter: {
+    tableColumns: [{ type: 'undefined', id: 1, column: 'column' }],
+    tableBodyRows: [{ type: 'undefined', id: 1, row: 'row' }],
+    grouping: [{ columnName: 'a' }],
+    draftGrouping: [{ columnName: 'a' }, { columnName: 'b', mode: 'add' }],
+    expandedGroups: new Map(),
+  },
+  action: {
+    toggleGroupExpanded: jest.fn(),
+  },
+  template: {
+    tableViewCell: {
+      tableRow: { type: 'undefined', id: 1, row: 'row' },
+      tableColumn: { type: 'undefined', id: 1, column: 'column' },
+      style: {},
+    },
+  },
+};
+
+const defaultProps = {
+  tableTemplate: () => null,
+  groupCellTemplate: () => null,
+  groupIndentCellTemplate: () => null,
+  groupIndentColumnWidth: 100,
+};
 
 describe('TableGroupRow', () => {
   let resetConsole;
@@ -27,117 +55,110 @@ describe('TableGroupRow', () => {
     jest.resetAllMocks();
   });
 
+  beforeEach(() => {
+    tableColumnsWithGrouping.mockImplementation(() => 'tableColumnsWithGrouping');
+    tableRowsWithGrouping.mockImplementation(() => 'tableRowsWithGrouping');
+    isGroupTableCell.mockImplementation(() => false);
+    isGroupIndentTableCell.mockImplementation(() => false);
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   describe('table layout getters extending', () => {
     it('should extend tableBodyRows', () => {
       tableRowsWithGrouping.mockImplementation(() => 'tableRowsWithGrouping');
+      const deps = {};
 
-      let tableBodyRows = null;
       mount(
         <PluginHost>
-          <Getter name="tableBodyRows" value="tableBodyRows" />
+          {pluginDepsToComponents(defaultDeps, deps)}
           <TableGroupRow
-            groupCellTemplate={() => null}
-            groupIndentColumnWidth={40}
+            {...defaultProps}
           />
-          <Template
-            name="root"
-            connectGetters={getter => (tableBodyRows = getter('tableBodyRows'))}
-          >
-            {() => <div />}
-          </Template>
         </PluginHost>,
       );
 
-      expect(tableRowsWithGrouping)
-        .toBeCalledWith('tableBodyRows');
-      expect(tableBodyRows)
+      expect(deps.computedGetter('tableBodyRows'))
         .toBe('tableRowsWithGrouping');
+      expect(tableRowsWithGrouping)
+        .toBeCalledWith(defaultDeps.getter.tableBodyRows);
     });
 
     it('should extend tableColumns', () => {
       tableColumnsWithGrouping.mockImplementation(() => 'tableColumnsWithGrouping');
+      const deps = {};
 
-      let tableColumns = null;
       mount(
         <PluginHost>
-          <Getter name="tableColumns" value="tableColumns" />
-          <Getter name="grouping" value="grouping" />
-          <Getter name="draftGrouping" value="draftGrouping" />
+          {pluginDepsToComponents(defaultDeps, deps)}
           <TableGroupRow
-            groupCellTemplate={() => null}
-            groupIndentColumnWidth={40}
+            {...defaultProps}
           />
-          <Template
-            name="root"
-            connectGetters={getter => (tableColumns = getter('tableColumns'))}
-          >
-            {() => <div />}
-          </Template>
         </PluginHost>,
       );
 
-      expect(tableColumnsWithGrouping)
-        .toBeCalledWith('tableColumns', 'grouping', 'draftGrouping', 40);
-      expect(tableColumns)
+      expect(deps.computedGetter('tableColumns'))
         .toBe('tableColumnsWithGrouping');
+      expect(tableColumnsWithGrouping)
+        .toBeCalledWith(
+          defaultDeps.getter.tableColumns,
+          defaultDeps.getter.grouping,
+          defaultDeps.getter.draftGrouping,
+          defaultProps.groupIndentColumnWidth,
+        );
     });
   });
 
-  describe('groupIndentCellTemplate', () => {
-    const testIndentCell = ({
-      cellParams,
-      shouldRender,
-      template = () => <td className="group-indent" />,
-    }) => {
-      const tree = mount(
-        <PluginHost>
-          <Template name="root">
-            <TemplatePlaceholder
-              name="tableViewCell"
-              params={cellParams}
-            />
-          </Template>
-          <TableGroupRow
-            groupCellTemplate={() => null}
-            groupIndentColumnWidth={40}
-            groupIndentCellTemplate={template}
-          />
-        </PluginHost>,
+  it('should render groupIndent cell on select group column and foregn group row intersection', () => {
+    isGroupIndentTableCell.mockImplementation(() => true);
+    const groupIndentCellTemplate = jest.fn(() => null);
+
+    mount(
+      <PluginHost>
+        {pluginDepsToComponents(defaultDeps)}
+        <TableGroupRow
+          {...defaultProps}
+          groupIndentCellTemplate={groupIndentCellTemplate}
+        />
+      </PluginHost>,
+    );
+
+    expect(isGroupIndentTableCell)
+      .toBeCalledWith(
+        defaultDeps.template.tableViewCell.tableRow,
+        defaultDeps.template.tableViewCell.tableColumn,
       );
+    expect(groupIndentCellTemplate)
+      .toBeCalledWith(expect.objectContaining({
+        ...defaultDeps.template.tableViewCell,
+        row: defaultDeps.template.tableViewCell.tableRow.row,
+      }));
+  });
 
-      expect(tree.find('td.group-indent').exists())
-        .toBe(shouldRender);
-    };
+  it('should render group cell on select group column and group row intersection', () => {
+    isGroupTableCell.mockImplementation(() => true);
+    const groupCellTemplate = jest.fn(() => null);
 
-    it('should render indent cell in a group column intersection with a foreign group row', () => {
-      testIndentCell({
-        cellParams: {
-          column: { type: 'groupColumn', group: { columnName: 'a' } },
-          row: { type: 'groupRow', column: { name: 'b' } },
-        },
-        shouldRender: true,
-      });
-    });
+    mount(
+      <PluginHost>
+        {pluginDepsToComponents(defaultDeps)}
+        <TableGroupRow
+          {...defaultProps}
+          groupCellTemplate={groupCellTemplate}
+        />
+      </PluginHost>,
+    );
 
-    it('should render indent cell in a group column intersection with a data row', () => {
-      testIndentCell({
-        cellParams: {
-          column: { type: 'groupColumn', group: { columnName: 'a' } },
-          row: { id: 1 },
-        },
-        shouldRender: true,
-      });
-    });
-
-    it('should not render indent cell if it is undefined', () => {
-      testIndentCell({
-        cellParams: {
-          column: { type: 'groupColumn', group: { columnName: 'a' } },
-          row: { id: 1 },
-        },
-        template: null,
-        shouldRender: false,
-      });
-    });
+    expect(isGroupTableCell)
+      .toBeCalledWith(
+        defaultDeps.template.tableViewCell.tableRow,
+        defaultDeps.template.tableViewCell.tableColumn,
+      );
+    expect(groupCellTemplate)
+      .toBeCalledWith(expect.objectContaining({
+        ...defaultDeps.template.tableViewCell,
+        row: defaultDeps.template.tableViewCell.tableRow.row,
+      }));
   });
 });

--- a/packages/dx-react-grid/src/plugins/table-header-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-header-row.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
-import { getColumnSortingDirection, tableRowsWithHeading } from '@devexpress/dx-grid-core';
+import {
+  getColumnSortingDirection,
+  tableRowsWithHeading,
+  isHeadingTableCell,
+} from '@devexpress/dx-grid-core';
 
 export class TableHeaderRow extends React.PureComponent {
   render() {
@@ -18,8 +22,8 @@ export class TableHeaderRow extends React.PureComponent {
         />
         <Template
           name="tableViewCell"
-          predicate={({ row, column }) => row.type === 'heading' && !column.type}
-          connectGetters={(getter, { column }) => {
+          predicate={({ row, column }) => isHeadingTableCell(row, column)}
+          connectGetters={(getter, { column: { original: column } }) => {
             const sorting = getter('sorting');
             const columns = getter('columns');
             const grouping = getter('grouping');
@@ -39,22 +43,25 @@ export class TableHeaderRow extends React.PureComponent {
 
             return result;
           }}
-          connectActions={(action, { column }) => ({
+          connectActions={(action, { column: { original: column } }) => ({
             changeSortingDirection: ({ keepOther, cancel }) => action('setColumnSorting')({ columnName: column.name, keepOther, cancel }),
             groupByColumn: () => action('groupByColumn')({ columnName: column.name }),
           })}
         >
           {({
+            row,
+            column: { original: column },
             sortingSupported,
             groupingSupported,
             draggingSupported,
             ...restParams
           }) => headerCellTemplate({
-            ...restParams,
+            column,
             allowSorting: allowSorting && sortingSupported,
             allowGroupingByClick: allowGroupingByClick && groupingSupported,
             allowDragging: allowDragging && draggingSupported,
-            dragPayload: [{ type: 'column', columnName: restParams.column.name }],
+            dragPayload: [{ type: 'column', columnName: column.name }],
+            ...restParams,
           })}
         </Template>
       </PluginContainer>

--- a/packages/dx-react-grid/src/plugins/table-header-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-header-row.jsx
@@ -22,8 +22,8 @@ export class TableHeaderRow extends React.PureComponent {
         />
         <Template
           name="tableViewCell"
-          predicate={({ row, column }) => isHeadingTableCell(row, column)}
-          connectGetters={(getter, { column: { original: column } }) => {
+          predicate={({ tableRow, tableColumn }) => isHeadingTableCell(tableRow, tableColumn)}
+          connectGetters={(getter, { tableColumn: { column } }) => {
             const sorting = getter('sorting');
             const columns = getter('columns');
             const grouping = getter('grouping');
@@ -41,27 +41,28 @@ export class TableHeaderRow extends React.PureComponent {
               result.sortingDirection = getColumnSortingDirection(sorting, column.name);
             }
 
+            if (result.draggingSupported) {
+              result.dragPayload = [{ type: 'column', columnName: column.name }];
+            }
+
             return result;
           }}
-          connectActions={(action, { column: { original: column } }) => ({
+          connectActions={(action, { tableColumn: { column } }) => ({
             changeSortingDirection: ({ keepOther, cancel }) => action('setColumnSorting')({ columnName: column.name, keepOther, cancel }),
             groupByColumn: () => action('groupByColumn')({ columnName: column.name }),
           })}
         >
           {({
-            row,
-            column: { original: column },
             sortingSupported,
             groupingSupported,
             draggingSupported,
             ...restParams
           }) => headerCellTemplate({
-            column,
+            ...restParams,
             allowSorting: allowSorting && sortingSupported,
             allowGroupingByClick: allowGroupingByClick && groupingSupported,
             allowDragging: allowDragging && draggingSupported,
-            dragPayload: [{ type: 'column', columnName: column.name }],
-            ...restParams,
+            column: restParams.tableColumn.column,
           })}
         </Template>
       </PluginContainer>

--- a/packages/dx-react-grid/src/plugins/table-header-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-header-row.test.jsx
@@ -68,13 +68,14 @@ describe('TableHeaderRow', () => {
     isHeadingTableCell.mockImplementation(() => true);
 
     const headerCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
         <Template name="root">
           <TemplatePlaceholder
             name="tableViewCell"
-            params={{ row: { original: 'row' }, column: { original: { name: 'a' } }, style: {} }}
+            params={tableCellArgs}
           />
         </Template>
         <TableHeaderRow
@@ -85,13 +86,11 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isHeadingTableCell)
-      .toBeCalledWith({ original: 'row' }, { original: { name: 'a' } });
-    expect(headerCellTemplate)
-      .not.toBeCalledWith(expect.objectContaining({ row: 'row' }));
+      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
     expect(headerCellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        column: { name: 'a' },
-        style: {},
+        ...tableCellArgs,
+        column: tableCellArgs.tableColumn.column,
       }));
   });
 });

--- a/packages/dx-react-grid/src/plugins/table-header-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-header-row.test.jsx
@@ -22,7 +22,7 @@ const defaultDeps = {
   template: {
     tableViewCell: {
       tableRow: { type: 'undefined', rowId: 1, row: 'row' },
-      tableColumn: { type: 'undefined', columnId: 1, column: 'column' },
+      tableColumn: { type: 'undefined', column: 'column' },
       style: {},
     },
   },

--- a/packages/dx-react-grid/src/plugins/table-header-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-header-row.test.jsx
@@ -8,19 +8,18 @@ import {
   PluginHost,
 } from '@devexpress/dx-react-core';
 import {
-  tableHeaderRowsWithFilter,
-  isFilterTableCell,
+  tableRowsWithHeading,
+  isHeadingTableCell,
 } from '@devexpress/dx-grid-core';
-import { TableFilterRow } from './table-filter-row';
+import { TableHeaderRow } from './table-header-row';
 
 jest.mock('@devexpress/dx-grid-core', () => ({
-  tableHeaderRowsWithFilter: jest.fn(),
-  isFilterTableCell: jest.fn(),
-  getColumnFilterConfig: jest.fn(),
+  tableRowsWithHeading: jest.fn(),
+  isHeadingTableCell: jest.fn(),
 }));
 
 const defaultPluginProps = {
-  filterCellTemplate: () => null,
+  headerCellTemplate: () => null,
 };
 
 describe('TableHeaderRow', () => {
@@ -33,8 +32,8 @@ describe('TableHeaderRow', () => {
   });
 
   beforeEach(() => {
-    tableHeaderRowsWithFilter.mockImplementation(() => 'tableHeaderRowsWithFilter');
-    isFilterTableCell.mockImplementation(() => false);
+    tableRowsWithHeading.mockImplementation(() => 'tableRowsWithHeading');
+    isHeadingTableCell.mockImplementation(() => false);
   });
   afterEach(() => {
     jest.resetAllMocks();
@@ -46,7 +45,7 @@ describe('TableHeaderRow', () => {
       mount(
         <PluginHost>
           <Getter name="tableHeaderRows" value="tableHeaderRows" />
-          <TableFilterRow
+          <TableHeaderRow
             {...defaultPluginProps}
           />
           <Template
@@ -58,17 +57,17 @@ describe('TableHeaderRow', () => {
         </PluginHost>,
       );
 
-      expect(tableHeaderRowsWithFilter)
-        .toBeCalledWith('tableHeaderRows', undefined);
+      expect(tableRowsWithHeading)
+        .toBeCalledWith('tableHeaderRows');
       expect(tableHeaderRows)
-        .toBe('tableHeaderRowsWithFilter');
+        .toBe('tableRowsWithHeading');
     });
   });
 
-  it('should render heading cell on user-defined column and filter row intersection', () => {
-    isFilterTableCell.mockImplementation(() => true);
+  it('should render heading cell on user-defined column and heading row intersection', () => {
+    isHeadingTableCell.mockImplementation(() => true);
 
-    const filterCellTemplate = jest.fn(() => null);
+    const headerCellTemplate = jest.fn(() => null);
 
     mount(
       <PluginHost>
@@ -78,18 +77,18 @@ describe('TableHeaderRow', () => {
             params={{ row: { original: 'row' }, column: { original: { name: 'a' } }, style: {} }}
           />
         </Template>
-        <TableFilterRow
+        <TableHeaderRow
           {...defaultPluginProps}
-          filterCellTemplate={filterCellTemplate}
+          headerCellTemplate={headerCellTemplate}
         />
       </PluginHost>,
     );
 
-    expect(isFilterTableCell)
+    expect(isHeadingTableCell)
       .toBeCalledWith({ original: 'row' }, { original: { name: 'a' } });
-    expect(filterCellTemplate)
+    expect(headerCellTemplate)
       .not.toBeCalledWith(expect.objectContaining({ row: 'row' }));
-    expect(filterCellTemplate)
+    expect(headerCellTemplate)
       .toBeCalledWith(expect.objectContaining({
         column: { name: 'a' },
         style: {},

--- a/packages/dx-react-grid/src/plugins/table-header-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-header-row.test.jsx
@@ -17,12 +17,12 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 const defaultDeps = {
   getter: {
     columns: [{ name: 'a' }],
-    tableHeaderRows: [{ type: 'undefined', id: 1 }],
+    tableHeaderRows: [{ type: 'undefined', rowId: 1 }],
   },
   template: {
     tableViewCell: {
-      tableRow: { type: 'undefined', id: 1, row: 'row' },
-      tableColumn: { type: 'undefined', id: 1, column: 'column' },
+      tableRow: { type: 'undefined', rowId: 1, row: 'row' },
+      tableColumn: { type: 'undefined', columnId: 1, column: 'column' },
       style: {},
     },
   },

--- a/packages/dx-react-grid/src/plugins/table-header-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-header-row.test.jsx
@@ -18,7 +18,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
   isHeadingTableCell: jest.fn(),
 }));
 
-const defaultPluginProps = {
+const defaultProps = {
   headerCellTemplate: () => null,
 };
 
@@ -46,7 +46,7 @@ describe('TableHeaderRow', () => {
         <PluginHost>
           <Getter name="tableHeaderRows" value="tableHeaderRows" />
           <TableHeaderRow
-            {...defaultPluginProps}
+            {...defaultProps}
           />
           <Template
             name="root"
@@ -79,7 +79,7 @@ describe('TableHeaderRow', () => {
           />
         </Template>
         <TableHeaderRow
-          {...defaultPluginProps}
+          {...defaultProps}
           headerCellTemplate={headerCellTemplate}
         />
       </PluginHost>,

--- a/packages/dx-react-grid/src/plugins/table-row-detail.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.jsx
@@ -41,13 +41,13 @@ export class TableRowDetail extends React.PureComponent {
         >
           {({
             column,
-            row: { original: row },
+            row,
             expandedRows,
             setDetailRowExpanded,
             ...restParams
           }) => detailToggleCellTemplate({
             ...restParams,
-            row,
+            row: row.original,
             expanded: isDetailRowExpanded(expandedRows, row.id),
             toggleExpanded: () => setDetailRowExpanded({ rowId: row.id }),
           })}

--- a/packages/dx-react-grid/src/plugins/table-row-detail.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.jsx
@@ -31,7 +31,7 @@ export class TableRowDetail extends React.PureComponent {
         />
         <Template
           name="tableViewCell"
-          predicate={({ column, row }) => isDetailToggleTableCell(row, column)}
+          predicate={({ tableRow, tableColumn }) => isDetailToggleTableCell(tableRow, tableColumn)}
           connectGetters={getter => ({
             expandedRows: getter('expandedRows'),
           })}
@@ -40,16 +40,14 @@ export class TableRowDetail extends React.PureComponent {
           })}
         >
           {({
-            column,
-            row,
             expandedRows,
             setDetailRowExpanded,
             ...restParams
           }) => detailToggleCellTemplate({
             ...restParams,
-            row: row.original,
-            expanded: isDetailRowExpanded(expandedRows, row.id),
-            toggleExpanded: () => setDetailRowExpanded({ rowId: row.id }),
+            row: restParams.tableRow.row,
+            expanded: isDetailRowExpanded(expandedRows, restParams.tableRow.id),
+            toggleExpanded: () => setDetailRowExpanded({ rowId: restParams.tableRow.id }),
           })}
         </Template>
 
@@ -63,15 +61,11 @@ export class TableRowDetail extends React.PureComponent {
             rowHeight,
           ]}
         />
-        <Template name="tableViewCell" predicate={({ row }) => isDetailTableRow(row)}>
-          {({
-            column,
-            row: { original: row },
-            ...params
-          }) => detailCellTemplate({
-            row,
-            template: () => template({ row }),
+        <Template name="tableViewCell" predicate={({ tableRow }) => isDetailTableRow(tableRow)}>
+          {params => detailCellTemplate({
             ...params,
+            row: params.tableRow.row,
+            template: () => template({ row: params.tableRow.row }),
           })}
         </Template>
       </PluginContainer>

--- a/packages/dx-react-grid/src/plugins/table-row-detail.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.jsx
@@ -46,8 +46,8 @@ export class TableRowDetail extends React.PureComponent {
           }) => detailToggleCellTemplate({
             ...restParams,
             row: restParams.tableRow.row,
-            expanded: isDetailRowExpanded(expandedRows, restParams.tableRow.id),
-            toggleExpanded: () => setDetailRowExpanded({ rowId: restParams.tableRow.id }),
+            expanded: isDetailRowExpanded(expandedRows, restParams.tableRow.rowId),
+            toggleExpanded: () => setDetailRowExpanded({ rowId: restParams.tableRow.rowId }),
           })}
         </Template>
 

--- a/packages/dx-react-grid/src/plugins/table-row-detail.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.jsx
@@ -57,7 +57,6 @@ export class TableRowDetail extends React.PureComponent {
           connectArgs={getter => [
             getter('tableBodyRows'),
             getter('expandedRows'),
-            getter('getRowId'),
             rowHeight,
           ]}
         />

--- a/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { setupConsole } from '@devexpress/dx-testing';
+import {
+  Getter,
+  Template,
+  TemplatePlaceholder,
+  PluginHost,
+} from '@devexpress/dx-react-core';
+import {
+  tableRowsWithExpandedDetail,
+  isDetailRowExpanded,
+  tableColumnsWithDetail,
+  isDetailToggleTableCell,
+  isDetailTableRow,
+} from '@devexpress/dx-grid-core';
+import { TableRowDetail } from './table-row-detail';
+
+jest.mock('@devexpress/dx-grid-core', () => ({
+  tableRowsWithExpandedDetail: jest.fn(),
+  isDetailRowExpanded: jest.fn(),
+  tableColumnsWithDetail: jest.fn(),
+  isDetailToggleTableCell: jest.fn(),
+  isDetailTableRow: jest.fn(),
+}));
+
+const defaultPluginProps = {
+  detailToggleCellTemplate: () => null,
+  detailCellTemplate: () => null,
+  detailToggleCellWidth: 100,
+};
+
+describe('TableRowDetail', () => {
+  let resetConsole;
+  beforeAll(() => {
+    resetConsole = setupConsole({ ignore: ['validateDOMNesting'] });
+  });
+  afterAll(() => {
+    resetConsole();
+  });
+
+  beforeEach(() => {
+    tableRowsWithExpandedDetail.mockImplementation(() => 'tableRowsWithExpandedDetail');
+    isDetailRowExpanded.mockImplementation(() => false);
+    tableColumnsWithDetail.mockImplementation(() => 'tableColumnsWithDetail');
+    isDetailToggleTableCell.mockImplementation(() => false);
+    isDetailTableRow.mockImplementation(() => false);
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('table layout getters', () => {
+    it('should extend tableBodyRows', () => {
+      let tableBodyRows = null;
+      mount(
+        <PluginHost>
+          <Getter name="tableBodyRows" value="tableBodyRows" />
+          <Getter name="expandedRows" value="expandedRows" />
+          <Getter name="getRowId" value="getRowId" />
+          <TableRowDetail
+            {...defaultPluginProps}
+            rowHeight={120}
+          />
+          <Template
+            name="root"
+            connectGetters={getter => (tableBodyRows = getter('tableBodyRows'))}
+          >
+            {() => <div />}
+          </Template>
+        </PluginHost>,
+      );
+
+      expect(tableRowsWithExpandedDetail)
+        .toBeCalledWith('tableBodyRows', 'expandedRows', 'getRowId', 120);
+      expect(tableBodyRows)
+        .toBe('tableRowsWithExpandedDetail');
+    });
+
+    it('should extend tableColumns', () => {
+      let tableColumns = null;
+      mount(
+        <PluginHost>
+          <Getter name="tableColumns" value="tableColumns" />
+
+          <TableRowDetail
+            {...defaultPluginProps}
+            detailToggleCellWidth={120}
+          />
+          <Template
+            name="root"
+            connectGetters={getter => (tableColumns = getter('tableColumns'))}
+          >
+            {() => <div />}
+          </Template>
+        </PluginHost>,
+      );
+
+      expect(tableColumnsWithDetail)
+        .toBeCalledWith('tableColumns', 120);
+      expect(tableColumns)
+        .toBe('tableColumnsWithDetail');
+    });
+  });
+
+  it('should render detailToggle cell on detail column and user-defined row intersection', () => {
+    isDetailToggleTableCell.mockImplementation(() => true);
+
+    const detailToggleCellTemplate = jest.fn(() => null);
+
+    mount(
+      <PluginHost>
+        <Template name="root">
+          <TemplatePlaceholder
+            name="tableViewCell"
+            params={{ row: { original: { id: 0 } }, column: 'column', style: {} }}
+          />
+        </Template>
+        <TableRowDetail
+          {...defaultPluginProps}
+          detailToggleCellTemplate={detailToggleCellTemplate}
+        />
+      </PluginHost>,
+    );
+
+    expect(isDetailToggleTableCell)
+      .toBeCalledWith({ original: { id: 0 } }, 'column');
+    expect(detailToggleCellTemplate)
+      .not.toBeCalledWith(expect.objectContaining({ column: 'column' }));
+    expect(detailToggleCellTemplate)
+      .toBeCalledWith(expect.objectContaining({
+        row: { id: 0 },
+        style: {},
+      }));
+  });
+
+  it('should render detail cell on detail row', () => {
+    isDetailTableRow.mockImplementation(() => true);
+
+    const detailCellTemplate = jest.fn(() => null);
+
+    mount(
+      <PluginHost>
+        <Template name="root">
+          <TemplatePlaceholder
+            name="tableViewCell"
+            params={{ row: { original: { id: 0 } }, column: 'column', style: {}, colspan: 3 }}
+          />
+        </Template>
+        <TableRowDetail
+          {...defaultPluginProps}
+          detailCellTemplate={detailCellTemplate}
+        />
+      </PluginHost>,
+    );
+
+    expect(isDetailTableRow)
+      .toBeCalledWith({ original: { id: 0 } });
+    expect(detailCellTemplate)
+      .not.toBeCalledWith(expect.objectContaining({ column: 'column' }));
+    expect(detailCellTemplate)
+      .toBeCalledWith(expect.objectContaining({
+        row: { id: 0 },
+        style: {},
+        colspan: 3,
+      }));
+  });
+});

--- a/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
@@ -22,8 +22,8 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 
 const defaultDeps = {
   getter: {
-    tableColumns: [{ type: 'undefined', id: 1, column: 'column' }],
-    tableBodyRows: [{ type: 'undefined', id: 1, row: 'row' }],
+    tableColumns: [{ type: 'undefined', columnId: 1, column: 'column' }],
+    tableBodyRows: [{ type: 'undefined', rowId: 1, row: 'row' }],
     expandedRows: { onClick: () => {} },
   },
   action: {
@@ -31,8 +31,8 @@ const defaultDeps = {
   },
   template: {
     tableViewCell: {
-      tableRow: { type: 'undefined', id: 1, row: 'row' },
-      tableColumn: { type: 'undefined', id: 1, column: 'column' },
+      tableRow: { type: 'undefined', rowId: 1, row: 'row' },
+      tableColumn: { type: 'undefined', columnId: 1, column: 'column' },
       style: {},
     },
   },

--- a/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
@@ -57,7 +57,6 @@ describe('TableRowDetail', () => {
         <PluginHost>
           <Getter name="tableBodyRows" value="tableBodyRows" />
           <Getter name="expandedRows" value="expandedRows" />
-          <Getter name="getRowId" value="getRowId" />
           <TableRowDetail
             {...defaultPluginProps}
             rowHeight={120}
@@ -72,7 +71,7 @@ describe('TableRowDetail', () => {
       );
 
       expect(tableRowsWithExpandedDetail)
-        .toBeCalledWith('tableBodyRows', 'expandedRows', 'getRowId', 120);
+        .toBeCalledWith('tableBodyRows', 'expandedRows', 120);
       expect(tableBodyRows)
         .toBe('tableRowsWithExpandedDetail');
     });

--- a/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
@@ -24,7 +24,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
   isDetailTableRow: jest.fn(),
 }));
 
-const defaultPluginProps = {
+const defaultProps = {
   detailToggleCellTemplate: () => null,
   detailCellTemplate: () => null,
   detailToggleCellWidth: 100,
@@ -58,7 +58,7 @@ describe('TableRowDetail', () => {
           <Getter name="tableBodyRows" value="tableBodyRows" />
           <Getter name="expandedRows" value="expandedRows" />
           <TableRowDetail
-            {...defaultPluginProps}
+            {...defaultProps}
             rowHeight={120}
           />
           <Template
@@ -83,7 +83,7 @@ describe('TableRowDetail', () => {
           <Getter name="tableColumns" value="tableColumns" />
 
           <TableRowDetail
-            {...defaultPluginProps}
+            {...defaultProps}
             detailToggleCellWidth={120}
           />
           <Template
@@ -117,7 +117,7 @@ describe('TableRowDetail', () => {
           />
         </Template>
         <TableRowDetail
-          {...defaultPluginProps}
+          {...defaultProps}
           detailToggleCellTemplate={detailToggleCellTemplate}
         />
       </PluginHost>,
@@ -147,7 +147,7 @@ describe('TableRowDetail', () => {
           />
         </Template>
         <TableRowDetail
-          {...defaultPluginProps}
+          {...defaultProps}
           detailCellTemplate={detailCellTemplate}
         />
       </PluginHost>,

--- a/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
@@ -107,13 +107,14 @@ describe('TableRowDetail', () => {
     isDetailToggleTableCell.mockImplementation(() => true);
 
     const detailToggleCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
         <Template name="root">
           <TemplatePlaceholder
             name="tableViewCell"
-            params={{ row: { original: { id: 0 } }, column: 'column', style: {} }}
+            params={tableCellArgs}
           />
         </Template>
         <TableRowDetail
@@ -124,13 +125,11 @@ describe('TableRowDetail', () => {
     );
 
     expect(isDetailToggleTableCell)
-      .toBeCalledWith({ original: { id: 0 } }, 'column');
-    expect(detailToggleCellTemplate)
-      .not.toBeCalledWith(expect.objectContaining({ column: 'column' }));
+      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
     expect(detailToggleCellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        row: { id: 0 },
-        style: {},
+        ...tableCellArgs,
+        row: tableCellArgs.tableRow.row,
       }));
   });
 
@@ -138,13 +137,14 @@ describe('TableRowDetail', () => {
     isDetailTableRow.mockImplementation(() => true);
 
     const detailCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {}, colspan: 4 };
 
     mount(
       <PluginHost>
         <Template name="root">
           <TemplatePlaceholder
             name="tableViewCell"
-            params={{ row: { original: { id: 0 } }, column: 'column', style: {}, colspan: 3 }}
+            params={tableCellArgs}
           />
         </Template>
         <TableRowDetail
@@ -155,14 +155,11 @@ describe('TableRowDetail', () => {
     );
 
     expect(isDetailTableRow)
-      .toBeCalledWith({ original: { id: 0 } });
-    expect(detailCellTemplate)
-      .not.toBeCalledWith(expect.objectContaining({ column: 'column' }));
+      .toBeCalledWith(tableCellArgs.tableRow);
     expect(detailCellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        row: { id: 0 },
-        style: {},
-        colspan: 3,
+        ...tableCellArgs,
+        row: tableCellArgs.tableRow.row,
       }));
   });
 });

--- a/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
@@ -22,7 +22,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 
 const defaultDeps = {
   getter: {
-    tableColumns: [{ type: 'undefined', columnId: 1, column: 'column' }],
+    tableColumns: [{ type: 'undefined', column: 'column' }],
     tableBodyRows: [{ type: 'undefined', rowId: 1, row: 'row' }],
     expandedRows: { onClick: () => {} },
   },
@@ -32,7 +32,7 @@ const defaultDeps = {
   template: {
     tableViewCell: {
       tableRow: { type: 'undefined', rowId: 1, row: 'row' },
-      tableColumn: { type: 'undefined', columnId: 1, column: 'column' },
+      tableColumn: { type: 'undefined', column: 'column' },
       style: {},
     },
   },

--- a/packages/dx-react-grid/src/plugins/table-selection.jsx
+++ b/packages/dx-react-grid/src/plugins/table-selection.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
 import {
   tableColumnsWithSelection,
-  tableBodyRowsWithSelection,
+  tableRowsWithSelection,
   tableExtraPropsWithSelection,
   isSelectTableCell,
   isSelectAllTableCell,
@@ -36,7 +36,7 @@ export class TableSelection extends React.PureComponent {
         {highlightSelected && (
           <Getter
             name="tableBodyRows"
-            pureComputed={tableBodyRowsWithSelection}
+            pureComputed={tableRowsWithSelection}
             connectArgs={getter => [
               getter('tableBodyRows'),
               getter('selection'),
@@ -59,7 +59,7 @@ export class TableSelection extends React.PureComponent {
         {(showSelectionColumn && showSelectAll) && (
           <Template
             name="tableViewCell"
-            predicate={({ column, row }) => isSelectAllTableCell(row, column)}
+            predicate={({ tableRow, tableColumn }) => isSelectAllTableCell(tableRow, tableColumn)}
             connectGetters={(getter) => {
               const availableToSelect = getter('availableToSelect');
               const selection = getter('selection');
@@ -76,8 +76,6 @@ export class TableSelection extends React.PureComponent {
             })}
           >
             {({
-              row,
-              column,
               toggleAll,
               availableToSelect,
               ...restParams
@@ -90,7 +88,7 @@ export class TableSelection extends React.PureComponent {
         {showSelectionColumn && (
           <Template
             name="tableViewCell"
-            predicate={({ column, row }) => isSelectTableCell(row, column)}
+            predicate={({ tableRow, tableColumn }) => isSelectTableCell(tableRow, tableColumn)}
             connectGetters={getter => ({
               selection: getter('selection'),
             })}
@@ -99,14 +97,13 @@ export class TableSelection extends React.PureComponent {
             })}
           >
             {({
-              row: { id: rowId, original: row },
               selection,
               toggleSelected,
               ...restParams
             }) => selectCellTemplate({
-              row,
-              selected: selection.indexOf(rowId) > -1,
-              changeSelected: () => toggleSelected({ rowId }),
+              row: restParams.tableRow.row,
+              selected: selection.indexOf(restParams.tableRow.id) > -1,
+              changeSelected: () => toggleSelected({ rowId: restParams.tableRow.id }),
               ...restParams,
             })}
           </Template>

--- a/packages/dx-react-grid/src/plugins/table-selection.jsx
+++ b/packages/dx-react-grid/src/plugins/table-selection.jsx
@@ -100,8 +100,8 @@ export class TableSelection extends React.PureComponent {
               ...restParams
             }) => selectCellTemplate({
               row: restParams.tableRow.row,
-              selected: selection.indexOf(restParams.tableRow.id) > -1,
-              changeSelected: () => toggleSelected({ rowId: restParams.tableRow.id }),
+              selected: selection.indexOf(restParams.tableRow.rowId) > -1,
+              changeSelected: () => toggleSelected({ rowId: restParams.tableRow.rowId }),
               ...restParams,
             })}
           </Template>

--- a/packages/dx-react-grid/src/plugins/table-selection.jsx
+++ b/packages/dx-react-grid/src/plugins/table-selection.jsx
@@ -40,7 +40,6 @@ export class TableSelection extends React.PureComponent {
             connectArgs={getter => [
               getter('tableBodyRows'),
               getter('selection'),
-              getter('getRowId'),
             ]}
           />
         )}
@@ -51,7 +50,6 @@ export class TableSelection extends React.PureComponent {
             connectArgs={(getter, action) => [
               getter('tableExtraProps'),
               action('setRowSelection'),
-              getter('getRowId'),
             ]}
           />
         )}

--- a/packages/dx-react-grid/src/plugins/table-selection.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-selection.test.jsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { setupConsole } from '@devexpress/dx-testing';
+import {
+  Getter,
+  Template,
+  TemplatePlaceholder,
+  PluginHost,
+} from '@devexpress/dx-react-core';
+import {
+  tableColumnsWithSelection,
+  tableBodyRowsWithSelection,
+  tableExtraPropsWithSelection,
+  isSelectTableCell,
+  isSelectAllTableCell,
+} from '@devexpress/dx-grid-core';
+import { TableSelection } from './table-selection';
+
+jest.mock('@devexpress/dx-grid-core', () => ({
+  tableColumnsWithSelection: jest.fn(),
+  tableBodyRowsWithSelection: jest.fn(),
+  tableExtraPropsWithSelection: jest.fn(),
+  isSelectTableCell: jest.fn(),
+  isSelectAllTableCell: jest.fn(),
+}));
+
+const defaultPluginProps = {
+  selectAllCellTemplate: () => null,
+  selectCellTemplate: () => null,
+  selectionColumnWidth: 100,
+};
+
+describe('TableHeaderRow', () => {
+  let resetConsole;
+  beforeAll(() => {
+    resetConsole = setupConsole({ ignore: ['validateDOMNesting'] });
+  });
+  afterAll(() => {
+    resetConsole();
+  });
+
+  beforeEach(() => {
+    tableColumnsWithSelection.mockImplementation(() => 'tableColumnsWithSelection');
+    tableBodyRowsWithSelection.mockImplementation(() => 'tableBodyRowsWithSelection');
+    tableExtraPropsWithSelection.mockImplementation(() => 'tableExtraPropsWithSelection');
+    isSelectTableCell.mockImplementation(() => false);
+    isSelectAllTableCell.mockImplementation(() => false);
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('table layout getters', () => {
+    it('should extend tableBodyRows', () => {
+      let tableBodyRows = null;
+      // TODO: extract plugin dependencies
+      mount(
+        <PluginHost>
+          <Getter name="tableBodyRows" value="tableBodyRows" />
+          <Getter name="selection" value="selection" />
+          <Getter name="getRowId" value="getRowId" />
+          <TableSelection
+            {...defaultPluginProps}
+            highlightSelected
+          />
+          <Template
+            name="root"
+            connectGetters={getter => (tableBodyRows = getter('tableBodyRows'))}
+          >
+            {() => <div />}
+          </Template>
+        </PluginHost>,
+      );
+
+      expect(tableBodyRowsWithSelection)
+        .toBeCalledWith('tableBodyRows', 'selection', 'getRowId');
+      expect(tableBodyRows)
+        .toBe('tableBodyRowsWithSelection');
+    });
+
+    it('should extend tableColumns', () => {
+      let tableColumns = null;
+      mount(
+        <PluginHost>
+          <Getter name="tableColumns" value="tableColumns" />
+          <TableSelection
+            {...defaultPluginProps}
+            selectionColumnWidth={120}
+          />
+          <Template
+            name="root"
+            connectGetters={getter => (tableColumns = getter('tableColumns'))}
+          >
+            {() => <div />}
+          </Template>
+        </PluginHost>,
+      );
+
+      expect(tableColumnsWithSelection)
+        .toBeCalledWith('tableColumns', 120);
+      expect(tableColumns)
+        .toBe('tableColumnsWithSelection');
+    });
+
+    it('should extend tableExtraProps', () => {
+      let tableExtraProps = null;
+      mount(
+        <PluginHost>
+          <Getter name="tableExtraProps" value="tableExtraProps" />
+          <Getter name="getRowId" value="getRowId" />
+          <TableSelection
+            {...defaultPluginProps}
+            selectByRowClick
+          />
+          <Template
+            name="root"
+            connectGetters={getter => (tableExtraProps = getter('tableExtraProps'))}
+          >
+            {() => <div />}
+          </Template>
+        </PluginHost>,
+      );
+
+      expect(tableExtraPropsWithSelection)
+        .toBeCalledWith('tableExtraProps', expect.any(Function), 'getRowId');
+      expect(tableExtraProps)
+        .toBe('tableExtraPropsWithSelection');
+    });
+  });
+
+  it('should render selectAll cell on select column and heading row intersection', () => {
+    isSelectTableCell.mockImplementation(() => true);
+
+    const selectCellTemplate = jest.fn(() => null);
+
+    mount(
+      <PluginHost>
+        <Getter name="selection" value={[]} />
+        <Getter name="availableToSelect" value={[]} />
+        <Template name="root">
+          <TemplatePlaceholder
+            name="tableViewCell"
+            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+          />
+        </Template>
+        <TableSelection
+          {...defaultPluginProps}
+          selectCellTemplate={selectCellTemplate}
+        />
+      </PluginHost>,
+    );
+
+    expect(isSelectTableCell)
+      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+    expect(selectCellTemplate)
+      .not.toBeCalledWith(expect.objectContaining({ column: 'column' }));
+    expect(selectCellTemplate)
+      .toBeCalledWith(expect.objectContaining({
+        row: 'row',
+        style: {},
+      }));
+  });
+
+  it('should render select cell on select column and user-defined row intersection', () => {
+    isSelectAllTableCell.mockImplementation(() => true);
+
+    const selectAllCellTemplate = jest.fn(() => null);
+
+    mount(
+      <PluginHost>
+        <Getter name="selection" value={[]} />
+        <Getter name="availableToSelect" value={[]} />
+        <Template name="root">
+          <TemplatePlaceholder
+            name="tableViewCell"
+            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+          />
+        </Template>
+        <TableSelection
+          {...defaultPluginProps}
+          selectAllCellTemplate={selectAllCellTemplate}
+        />
+      </PluginHost>,
+    );
+
+    expect(isSelectAllTableCell)
+      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+    expect(selectAllCellTemplate)
+      .not.toBeCalledWith(expect.objectContaining({ row: 'row', column: 'column' }));
+    expect(selectAllCellTemplate)
+      .toBeCalledWith(expect.objectContaining({
+        style: {},
+      }));
+  });
+});

--- a/packages/dx-react-grid/src/plugins/table-selection.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-selection.test.jsx
@@ -22,7 +22,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 
 const defaultDeps = {
   getter: {
-    tableColumns: [{ type: 'undefined', columnId: 1, column: 'column' }],
+    tableColumns: [{ type: 'undefined', column: 'column' }],
     tableBodyRows: [{ type: 'undefined', rowId: 1, row: 'row' }],
     tableExtraProps: { onClick: () => {} },
     selection: [1, 2],
@@ -35,7 +35,7 @@ const defaultDeps = {
   template: {
     tableViewCell: {
       tableRow: { type: 'undefined', rowId: 1, row: 'row' },
-      tableColumn: { type: 'undefined', columnId: 1, column: 'column' },
+      tableColumn: { type: 'undefined', column: 'column' },
       style: {},
     },
   },

--- a/packages/dx-react-grid/src/plugins/table-selection.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-selection.test.jsx
@@ -22,8 +22,8 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 
 const defaultDeps = {
   getter: {
-    tableColumns: [{ type: 'undefined', id: 1, column: 'column' }],
-    tableBodyRows: [{ type: 'undefined', id: 1, row: 'row' }],
+    tableColumns: [{ type: 'undefined', columnId: 1, column: 'column' }],
+    tableBodyRows: [{ type: 'undefined', rowId: 1, row: 'row' }],
     tableExtraProps: { onClick: () => {} },
     selection: [1, 2],
     availableToSelect: [1, 2, 3, 4],
@@ -34,8 +34,8 @@ const defaultDeps = {
   },
   template: {
     tableViewCell: {
-      tableRow: { type: 'undefined', id: 1, row: 'row' },
-      tableColumn: { type: 'undefined', id: 1, column: 'column' },
+      tableRow: { type: 'undefined', rowId: 1, row: 'row' },
+      tableColumn: { type: 'undefined', columnId: 1, column: 'column' },
       style: {},
     },
   },

--- a/packages/dx-react-grid/src/plugins/table-selection.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-selection.test.jsx
@@ -69,12 +69,7 @@ describe('TableHeaderRow', () => {
 
   describe('table layout getters', () => {
     it('should extend tableBodyRows', () => {
-      const deps = {
-        checkGetter: (getter) => {
-          expect(getter('tableBodyRows'))
-            .toBe('tableRowsWithSelection');
-        },
-      };
+      const deps = {};
 
       mount(
         <PluginHost>
@@ -86,17 +81,14 @@ describe('TableHeaderRow', () => {
         </PluginHost>,
       );
 
+      expect(deps.computedGetter('tableBodyRows'))
+        .toBe('tableRowsWithSelection');
       expect(tableRowsWithSelection)
         .toHaveBeenCalledWith(defaultDeps.getter.tableBodyRows, defaultDeps.getter.selection);
     });
 
     it('should extend tableColumns', () => {
-      const deps = {
-        checkGetter: (getter) => {
-          expect(getter('tableColumns'))
-            .toBe('tableColumnsWithSelection');
-        },
-      };
+      const deps = {};
 
       mount(
         <PluginHost>
@@ -108,17 +100,14 @@ describe('TableHeaderRow', () => {
         </PluginHost>,
       );
 
+      expect(deps.computedGetter('tableColumns'))
+        .toBe('tableColumnsWithSelection');
       expect(tableColumnsWithSelection)
         .toBeCalledWith(defaultDeps.getter.tableColumns, 120);
     });
 
     it('should extend tableExtraProps', () => {
-      const deps = {
-        checkGetter: (getter) => {
-          expect(getter('tableExtraProps'))
-            .toBe('tableExtraPropsWithSelection');
-        },
-      };
+      const deps = {};
 
       mount(
         <PluginHost>
@@ -130,6 +119,8 @@ describe('TableHeaderRow', () => {
         </PluginHost>,
       );
 
+      expect(deps.computedGetter('tableExtraProps'))
+        .toBe('tableExtraPropsWithSelection');
       expect(tableExtraPropsWithSelection)
         .toBeCalledWith(defaultDeps.getter.tableExtraProps, expect.any(Function));
     });

--- a/packages/dx-react-grid/src/plugins/table-selection.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-selection.test.jsx
@@ -9,7 +9,7 @@ import {
 } from '@devexpress/dx-react-core';
 import {
   tableColumnsWithSelection,
-  tableBodyRowsWithSelection,
+  tableRowsWithSelection,
   tableExtraPropsWithSelection,
   isSelectTableCell,
   isSelectAllTableCell,
@@ -18,7 +18,7 @@ import { TableSelection } from './table-selection';
 
 jest.mock('@devexpress/dx-grid-core', () => ({
   tableColumnsWithSelection: jest.fn(),
-  tableBodyRowsWithSelection: jest.fn(),
+  tableRowsWithSelection: jest.fn(),
   tableExtraPropsWithSelection: jest.fn(),
   isSelectTableCell: jest.fn(),
   isSelectAllTableCell: jest.fn(),
@@ -41,7 +41,7 @@ describe('TableHeaderRow', () => {
 
   beforeEach(() => {
     tableColumnsWithSelection.mockImplementation(() => 'tableColumnsWithSelection');
-    tableBodyRowsWithSelection.mockImplementation(() => 'tableBodyRowsWithSelection');
+    tableRowsWithSelection.mockImplementation(() => 'tableRowsWithSelection');
     tableExtraPropsWithSelection.mockImplementation(() => 'tableExtraPropsWithSelection');
     isSelectTableCell.mockImplementation(() => false);
     isSelectAllTableCell.mockImplementation(() => false);
@@ -72,10 +72,10 @@ describe('TableHeaderRow', () => {
         </PluginHost>,
       );
 
-      expect(tableBodyRowsWithSelection)
+      expect(tableRowsWithSelection)
         .toBeCalledWith('tableBodyRows', 'selection', 'getRowId');
       expect(tableBodyRows)
-        .toBe('tableBodyRowsWithSelection');
+        .toBe('tableRowsWithSelection');
     });
 
     it('should extend tableColumns', () => {
@@ -132,6 +132,7 @@ describe('TableHeaderRow', () => {
     isSelectTableCell.mockImplementation(() => true);
 
     const selectCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
@@ -140,7 +141,7 @@ describe('TableHeaderRow', () => {
         <Template name="root">
           <TemplatePlaceholder
             name="tableViewCell"
-            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+            params={tableCellArgs}
           />
         </Template>
         <TableSelection
@@ -151,13 +152,11 @@ describe('TableHeaderRow', () => {
     );
 
     expect(isSelectTableCell)
-      .toBeCalledWith({ original: 'row' }, { original: 'column' });
-    expect(selectCellTemplate)
-      .not.toBeCalledWith(expect.objectContaining({ column: 'column' }));
+      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
     expect(selectCellTemplate)
       .toBeCalledWith(expect.objectContaining({
-        row: 'row',
-        style: {},
+        ...tableCellArgs,
+        row: tableCellArgs.tableRow.row,
       }));
   });
 
@@ -165,6 +164,7 @@ describe('TableHeaderRow', () => {
     isSelectAllTableCell.mockImplementation(() => true);
 
     const selectAllCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
@@ -173,7 +173,7 @@ describe('TableHeaderRow', () => {
         <Template name="root">
           <TemplatePlaceholder
             name="tableViewCell"
-            params={{ row: { original: 'row' }, column: { original: 'column' }, style: {} }}
+            params={tableCellArgs}
           />
         </Template>
         <TableSelection
@@ -183,13 +183,9 @@ describe('TableHeaderRow', () => {
       </PluginHost>,
     );
 
-    expect(isSelectAllTableCell)
-      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+    expect(isSelectTableCell)
+      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
     expect(selectAllCellTemplate)
-      .not.toBeCalledWith(expect.objectContaining({ row: 'row', column: 'column' }));
-    expect(selectAllCellTemplate)
-      .toBeCalledWith(expect.objectContaining({
-        style: {},
-      }));
+      .toBeCalledWith(expect.objectContaining(tableCellArgs));
   });
 });

--- a/packages/dx-react-grid/src/plugins/table-selection.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-selection.test.jsx
@@ -58,7 +58,6 @@ describe('TableHeaderRow', () => {
         <PluginHost>
           <Getter name="tableBodyRows" value="tableBodyRows" />
           <Getter name="selection" value="selection" />
-          <Getter name="getRowId" value="getRowId" />
           <TableSelection
             {...defaultPluginProps}
             highlightSelected
@@ -73,7 +72,7 @@ describe('TableHeaderRow', () => {
       );
 
       expect(tableRowsWithSelection)
-        .toBeCalledWith('tableBodyRows', 'selection', 'getRowId');
+        .toBeCalledWith('tableBodyRows', 'selection');
       expect(tableBodyRows)
         .toBe('tableRowsWithSelection');
     });
@@ -107,7 +106,6 @@ describe('TableHeaderRow', () => {
       mount(
         <PluginHost>
           <Getter name="tableExtraProps" value="tableExtraProps" />
-          <Getter name="getRowId" value="getRowId" />
           <TableSelection
             {...defaultPluginProps}
             selectByRowClick
@@ -122,7 +120,7 @@ describe('TableHeaderRow', () => {
       );
 
       expect(tableExtraPropsWithSelection)
-        .toBeCalledWith('tableExtraProps', expect.any(Function), 'getRowId');
+        .toBeCalledWith('tableExtraProps', expect.any(Function));
       expect(tableExtraProps)
         .toBe('tableExtraPropsWithSelection');
     });

--- a/packages/dx-react-grid/src/plugins/table-view.jsx
+++ b/packages/dx-react-grid/src/plugins/table-view.jsx
@@ -68,27 +68,27 @@ export class TableView extends React.PureComponent {
             headerRows: getter('tableHeaderRows'),
           })}
         >
-          {({ row, column, headerRows, ...restParams }) => (
-            isHeaderStubTableCell(row, headerRows)
+          {({ headerRows, ...restParams }) => (
+            isHeaderStubTableCell(restParams.tableRow, headerRows)
               ? tableStubHeaderCellTemplate(restParams)
               : tableStubCellTemplate(restParams)
           )}
         </Template>
         <Template
           name="tableViewCell"
-          predicate={({ row, column }) => isDataTableCell(row, column)}
+          predicate={({ tableRow, tableColumn }) => isDataTableCell(tableRow, tableColumn)}
         >
-          {({
-            row: { original: row },
-            column: { original: column },
-            ...restParams
-          }) => tableCellTemplate({ row, column, ...restParams })}
+          {params => tableCellTemplate({
+            ...params,
+            row: params.tableRow.row,
+            column: params.tableColumn.column,
+          })}
         </Template>
         <Template
           name="tableViewCell"
-          predicate={({ row }) => isNoDataTableRow(row)}
+          predicate={({ tableRow }) => isNoDataTableRow(tableRow)}
         >
-          {({ row, column, ...restParams }) => tableNoDataCellTemplate(restParams)}
+          {params => tableNoDataCellTemplate(params)}
         </Template>
       </PluginContainer>
     );

--- a/packages/dx-react-grid/src/plugins/table-view.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-view.test.jsx
@@ -64,12 +64,7 @@ describe('TableView', () => {
 
   describe('table layout getters', () => {
     it('should provide tableBodyRows', () => {
-      const deps = {
-        checkGetter: (getter) => {
-          expect(getter('tableBodyRows'))
-            .toBe('tableRowsWithDataRows');
-        },
-      };
+      const deps = {};
 
       mount(
         <PluginHost>
@@ -82,6 +77,8 @@ describe('TableView', () => {
 
       expect(tableRowsWithDataRows)
         .toBeCalledWith(defaultDeps.getter.rows, defaultDeps.getter.getRowId);
+      expect(deps.computedGetter('tableBodyRows'))
+        .toBe('tableRowsWithDataRows');
     });
 
     it('should extend tableColumns', () => {
@@ -155,12 +152,7 @@ describe('TableView', () => {
     isHeaderStubTableCell.mockImplementation(() => true);
     const tableStubHeaderCellTemplate = jest.fn(() => null);
     const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
-    let tableHeaderRows;
-    const deps = {
-      checkGetter: (getter) => {
-        tableHeaderRows = getter('tableHeaderRows');
-      },
-    };
+    const deps = {};
 
     mount(
       <PluginHost>
@@ -174,7 +166,7 @@ describe('TableView', () => {
     );
 
     expect(isHeaderStubTableCell)
-      .toBeCalledWith(tableCellArgs.tableRow, tableHeaderRows);
+      .toBeCalledWith(tableCellArgs.tableRow, deps.computedGetter('tableHeaderRows'));
     expect(tableStubHeaderCellTemplate)
       .toBeCalledWith(tableCellArgs);
   });

--- a/packages/dx-react-grid/src/plugins/table-view.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-view.test.jsx
@@ -105,6 +105,7 @@ describe('TableView', () => {
     isDataTableCell.mockImplementation(() => true);
 
     const tableCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
@@ -113,20 +114,25 @@ describe('TableView', () => {
         </Template>
         <TableView
           {...defaultPluginProps}
-          tableTemplate={({ cellTemplate }) => cellTemplate({ row: { original: 'row' }, column: { original: 'column' }, style: {} })}
+          tableTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableCellTemplate={tableCellTemplate}
         />
       </PluginHost>,
     );
 
     expect(isDataTableCell)
-      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+      .toBeCalledWith(tableCellArgs.tableRow, tableCellArgs.tableColumn);
     expect(tableCellTemplate)
-      .toBeCalledWith({ row: 'row', column: 'column', style: {} });
+      .toBeCalledWith({
+        ...tableCellArgs,
+        row: tableCellArgs.tableRow.row,
+        column: tableCellArgs.tableColumn.column,
+      });
   });
 
   it('should render stub cell on plugin-defined column and row intersection', () => {
     const tableStubCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
@@ -135,23 +141,21 @@ describe('TableView', () => {
         </Template>
         <TableView
           {...defaultPluginProps}
-          tableTemplate={({ cellTemplate }) =>
-            cellTemplate({ row: { original: 'row' }, column: { original: 'column' }, style: {} })}
+          tableTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableStubCellTemplate={tableStubCellTemplate}
         />
       </PluginHost>,
     );
 
     expect(tableStubCellTemplate)
-      .not.toBeCalledWith({ row: 'row', column: 'column' });
-    expect(tableStubCellTemplate)
-      .toBeCalledWith({ style: {} });
+      .toBeCalledWith(tableCellArgs);
   });
 
   it('should render stub header cell on plugin-defined column and row intersection', () => {
     isHeaderStubTableCell.mockImplementation(() => true);
 
     const tableStubHeaderCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
@@ -160,8 +164,7 @@ describe('TableView', () => {
         </Template>
         <TableView
           {...defaultPluginProps}
-          tableTemplate={({ cellTemplate }) =>
-            cellTemplate({ row: { original: 'row' }, column: { original: 'column' }, style: {} })}
+          tableTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableStubHeaderCellTemplate={tableStubHeaderCellTemplate}
         />
         <Getter name="tableHeaderRows" value="tableHeaderRows" />
@@ -169,17 +172,16 @@ describe('TableView', () => {
     );
 
     expect(isHeaderStubTableCell)
-      .toBeCalledWith({ original: 'row' }, 'tableHeaderRows');
+      .toBeCalledWith(tableCellArgs.tableRow, 'tableHeaderRows');
     expect(tableStubHeaderCellTemplate)
-      .not.toBeCalledWith({ row: 'row', column: 'column' });
-    expect(tableStubHeaderCellTemplate)
-      .toBeCalledWith({ style: {} });
+      .toBeCalledWith(tableCellArgs);
   });
 
   it('should render no data cell if rows are empty', () => {
     isNoDataTableRow.mockImplementation(() => true);
 
     const tableNoDataCellTemplate = jest.fn(() => null);
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {}, colspan: 4 };
 
     mount(
       <PluginHost>
@@ -188,20 +190,15 @@ describe('TableView', () => {
         </Template>
         <TableView
           {...defaultPluginProps}
-          tableTemplate={({ cellTemplate }) =>
-            cellTemplate({ row: { original: 'row' }, column: { original: 'column' }, style: {}, colspan: 3 })}
+          tableTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableNoDataCellTemplate={tableNoDataCellTemplate}
         />
-        <Getter name="tableHeaderRows" value="tableHeaderRows" />
       </PluginHost>,
     );
 
     expect(isNoDataTableRow)
-      .toBeCalledWith({ original: 'row' });
-
+      .toBeCalledWith(tableCellArgs.tableRow);
     expect(tableNoDataCellTemplate)
-      .not.toBeCalledWith(expect.objectContaining({ row: 'row', column: 'column' }));
-    expect(tableNoDataCellTemplate)
-      .toBeCalledWith(expect.objectContaining({ style: {}, colspan: 3 }));
+      .toBeCalledWith(tableCellArgs);
   });
 });

--- a/packages/dx-react-grid/src/plugins/table-view.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-view.test.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { setupConsole } from '@devexpress/dx-testing';
-import {
-  Getter,
-  Template,
-  TemplatePlaceholder,
-  PluginHost,
-} from '@devexpress/dx-react-core';
+import { PluginHost } from '@devexpress/dx-react-core';
 import {
   tableColumnsWithDataRows,
   tableRowsWithDataRows,
@@ -15,6 +10,7 @@ import {
   isHeaderStubTableCell,
 } from '@devexpress/dx-grid-core';
 import { TableView } from './table-view';
+import { pluginDepsToComponents } from './test-utils';
 
 jest.mock('@devexpress/dx-grid-core', () => ({
   tableColumnsWithDataRows: jest.fn(),
@@ -24,7 +20,21 @@ jest.mock('@devexpress/dx-grid-core', () => ({
   isHeaderStubTableCell: jest.fn(),
 }));
 
-const defaultPluginProps = {
+const defaultDeps = {
+  getter: {
+    columns: [{ name: 'field' }],
+    rows: [{ field: 1 }],
+    getRowId: () => {},
+  },
+  action: {
+    setColumnOrder: jest.fn(),
+  },
+  template: {
+    body: undefined,
+  },
+};
+
+const defaultProps = {
   tableTemplate: () => null,
   tableCellTemplate: () => null,
   tableStubCellTemplate: () => null,
@@ -54,66 +64,58 @@ describe('TableView', () => {
 
   describe('table layout getters', () => {
     it('should provide tableBodyRows', () => {
-      let tableBodyRows = null;
+      const deps = {
+        checkGetter: (getter) => {
+          expect(getter('tableBodyRows'))
+            .toBe('tableRowsWithDataRows');
+        },
+      };
+
       mount(
         <PluginHost>
-          <Getter name="rows" value="rows" />
-          <Getter name="getRowId" value="getRowId" />
+          {pluginDepsToComponents(defaultDeps, deps)}
           <TableView
-            {...defaultPluginProps}
+            {...defaultProps}
           />
-          <Template
-            name="root"
-            connectGetters={getter => (tableBodyRows = getter('tableBodyRows'))}
-          >
-            {() => <div />}
-          </Template>
         </PluginHost>,
       );
 
       expect(tableRowsWithDataRows)
-        .toBeCalledWith('rows', 'getRowId');
-      expect(tableBodyRows)
-        .toBe('tableRowsWithDataRows');
+        .toBeCalledWith(defaultDeps.getter.rows, defaultDeps.getter.getRowId);
     });
 
     it('should extend tableColumns', () => {
-      let tableColumns = null;
+      const deps = {
+        checkGetter: (getter) => {
+          expect(getter('tableColumns'))
+            .toBe('tableColumnsWithDataRows');
+        },
+      };
+
       mount(
         <PluginHost>
-          <Getter name="columns" value="columns" />
+          {pluginDepsToComponents(defaultDeps, deps)}
           <TableView
-            {...defaultPluginProps}
+            {...defaultProps}
           />
-          <Template
-            name="root"
-            connectGetters={getter => (tableColumns = getter('tableColumns'))}
-          >
-            {() => <div />}
-          </Template>
         </PluginHost>,
       );
 
       expect(tableColumnsWithDataRows)
-        .toBeCalledWith('columns');
-      expect(tableColumns)
-        .toBe('tableColumnsWithDataRows');
+        .toBeCalledWith(defaultDeps.getter.columns);
     });
   });
 
   it('should render data cell on user-defined column and row intersection', () => {
     isDataTableCell.mockImplementation(() => true);
-
     const tableCellTemplate = jest.fn(() => null);
     const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
 
     mount(
       <PluginHost>
-        <Template name="root">
-          <TemplatePlaceholder name="body" />
-        </Template>
+        {pluginDepsToComponents(defaultDeps)}
         <TableView
-          {...defaultPluginProps}
+          {...defaultProps}
           tableTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableCellTemplate={tableCellTemplate}
         />
@@ -136,11 +138,9 @@ describe('TableView', () => {
 
     mount(
       <PluginHost>
-        <Template name="root">
-          <TemplatePlaceholder name="body" />
-        </Template>
+        {pluginDepsToComponents(defaultDeps)}
         <TableView
-          {...defaultPluginProps}
+          {...defaultProps}
           tableTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableStubCellTemplate={tableStubCellTemplate}
         />
@@ -153,43 +153,42 @@ describe('TableView', () => {
 
   it('should render stub header cell on plugin-defined column and row intersection', () => {
     isHeaderStubTableCell.mockImplementation(() => true);
-
     const tableStubHeaderCellTemplate = jest.fn(() => null);
     const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {} };
+    let tableHeaderRows;
+    const deps = {
+      checkGetter: (getter) => {
+        tableHeaderRows = getter('tableHeaderRows');
+      },
+    };
 
     mount(
       <PluginHost>
-        <Template name="root">
-          <TemplatePlaceholder name="body" />
-        </Template>
+        {pluginDepsToComponents(defaultDeps, deps)}
         <TableView
-          {...defaultPluginProps}
+          {...defaultProps}
           tableTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableStubHeaderCellTemplate={tableStubHeaderCellTemplate}
         />
-        <Getter name="tableHeaderRows" value="tableHeaderRows" />
       </PluginHost>,
     );
 
     expect(isHeaderStubTableCell)
-      .toBeCalledWith(tableCellArgs.tableRow, 'tableHeaderRows');
+      .toBeCalledWith(tableCellArgs.tableRow, tableHeaderRows);
     expect(tableStubHeaderCellTemplate)
       .toBeCalledWith(tableCellArgs);
   });
 
   it('should render no data cell if rows are empty', () => {
     isNoDataTableRow.mockImplementation(() => true);
-
     const tableNoDataCellTemplate = jest.fn(() => null);
     const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {}, colspan: 4 };
 
     mount(
       <PluginHost>
-        <Template name="root">
-          <TemplatePlaceholder name="body" />
-        </Template>
+        {pluginDepsToComponents(defaultDeps)}
         <TableView
-          {...defaultPluginProps}
+          {...defaultProps}
           tableTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableNoDataCellTemplate={tableNoDataCellTemplate}
         />

--- a/packages/dx-react-grid/src/plugins/table-view.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-view.test.jsx
@@ -1,15 +1,36 @@
 import React from 'react';
 import { mount } from 'enzyme';
-
 import { setupConsole } from '@devexpress/dx-testing';
 import {
-  Getter, Template, TemplatePlaceholder, PluginHost,
+  Getter,
+  Template,
+  TemplatePlaceholder,
+  PluginHost,
 } from '@devexpress/dx-react-core';
 import {
-  getTableCellInfo,
+  tableColumnsWithDataRows,
+  tableRowsWithDataRows,
+  isNoDataTableRow,
+  isDataTableCell,
+  isHeaderStubTableCell,
 } from '@devexpress/dx-grid-core';
-
 import { TableView } from './table-view';
+
+jest.mock('@devexpress/dx-grid-core', () => ({
+  tableColumnsWithDataRows: jest.fn(),
+  tableRowsWithDataRows: jest.fn(),
+  isNoDataTableRow: jest.fn(),
+  isDataTableCell: jest.fn(),
+  isHeaderStubTableCell: jest.fn(),
+}));
+
+const defaultPluginProps = {
+  tableTemplate: () => null,
+  tableCellTemplate: () => null,
+  tableStubCellTemplate: () => null,
+  tableStubHeaderCellTemplate: () => null,
+  tableNoDataCellTemplate: () => null,
+};
 
 describe('TableView', () => {
   let resetConsole;
@@ -20,198 +41,167 @@ describe('TableView', () => {
     resetConsole();
   });
 
+  beforeEach(() => {
+    tableColumnsWithDataRows.mockImplementation(() => 'tableColumnsWithDataRows');
+    tableRowsWithDataRows.mockImplementation(() => 'tableRowsWithDataRows');
+    isNoDataTableRow.mockImplementation(() => false);
+    isDataTableCell.mockImplementation(() => false);
+    isHeaderStubTableCell.mockImplementation(() => false);
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('table layout getters', () => {
+    it('should provide tableBodyRows', () => {
+      let tableBodyRows = null;
+      mount(
+        <PluginHost>
+          <Getter name="rows" value="rows" />
+          <Getter name="getRowId" value="getRowId" />
+          <TableView
+            {...defaultPluginProps}
+          />
+          <Template
+            name="root"
+            connectGetters={getter => (tableBodyRows = getter('tableBodyRows'))}
+          >
+            {() => <div />}
+          </Template>
+        </PluginHost>,
+      );
+
+      expect(tableRowsWithDataRows)
+        .toBeCalledWith('rows', 'getRowId');
+      expect(tableBodyRows)
+        .toBe('tableRowsWithDataRows');
+    });
+
+    it('should extend tableColumns', () => {
+      let tableColumns = null;
+      mount(
+        <PluginHost>
+          <Getter name="columns" value="columns" />
+          <TableView
+            {...defaultPluginProps}
+          />
+          <Template
+            name="root"
+            connectGetters={getter => (tableColumns = getter('tableColumns'))}
+          >
+            {() => <div />}
+          </Template>
+        </PluginHost>,
+      );
+
+      expect(tableColumnsWithDataRows)
+        .toBeCalledWith('columns');
+      expect(tableColumns)
+        .toBe('tableColumnsWithDataRows');
+    });
+  });
+
   it('should render data cell on user-defined column and row intersection', () => {
-    const tree = mount(
+    isDataTableCell.mockImplementation(() => true);
+
+    const tableCellTemplate = jest.fn(() => null);
+
+    mount(
       <PluginHost>
-        <Getter
-          name="columns"
-          value={[{ name: 'a' }, { name: 'b' }]}
-        />
-        <Getter
-          name="rows"
-          value={[{ id: 1 }, { id: 2 }]}
-        />
         <Template name="root">
           <TemplatePlaceholder name="body" />
         </Template>
         <TableView
-          tableTemplate={({ bodyRows, columns, cellTemplate }) => (
-            <table>
-              <tbody>
-                {bodyRows.map(row => (
-                  <tr key={row.id}>
-                    {columns.map(column => React.cloneElement(
-                      cellTemplate({ row, column }),
-                      { key: column.name },
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-          tableCellTemplate={({ row, column }) => <td className="data">{row.id + column.name}</td>}
-          tableStubCellTemplate={() => null}
-          tableStubHeaderCellTemplate={() => null}
-          tableNoDataCellTemplate={() => null}
+          {...defaultPluginProps}
+          tableTemplate={({ cellTemplate }) => cellTemplate({ row: { original: 'row' }, column: { original: 'column' }, style: {} })}
+          tableCellTemplate={tableCellTemplate}
         />
       </PluginHost>,
     );
 
-    const dataCells = tree.find('td.data');
-    expect(dataCells)
-      .toHaveLength(4);
-    expect(dataCells.map(dataCell => dataCell.text()))
-      .toEqual(['1a', '1b', '2a', '2b']);
+    expect(isDataTableCell)
+      .toBeCalledWith({ original: 'row' }, { original: 'column' });
+    expect(tableCellTemplate)
+      .toBeCalledWith({ row: 'row', column: 'column', style: {} });
   });
 
-  it('should render empty cell on plugin-defined column and row intersection', () => {
-    const tree = mount(
+  it('should render stub cell on plugin-defined column and row intersection', () => {
+    const tableStubCellTemplate = jest.fn(() => null);
+
+    mount(
       <PluginHost>
-        <Getter
-          name="columns"
-          value={[{ name: 'a' }, { name: 'b' }]}
-        />
-        <Getter
-          name="rows"
-          value={[{ id: 1 }, { id: 2 }]}
-        />
         <Template name="root">
           <TemplatePlaceholder name="body" />
         </Template>
         <TableView
-          tableTemplate={({ bodyRows, columns, cellTemplate }) => (
-            <table>
-              <tbody>
-                {bodyRows.map(row => (
-                  <tr key={row.id || row.type}>
-                    {columns.map(column => React.cloneElement(
-                      cellTemplate({ row, column }),
-                      { key: column.name || column.type },
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-          tableCellTemplate={() => <td className="data" />}
-          tableStubCellTemplate={() => <td className="empty" />}
-          tableStubHeaderCellTemplate={() => null}
-          tableNoDataCellTemplate={() => null}
-        />
-        <Getter
-          name="tableColumns"
-          pureComputed={tableColumns => [{ type: 'columnPlugin' }, ...tableColumns]}
-          connectArgs={getter => [getter('tableColumns')]}
-        />
-        <Getter
-          name="tableBodyRows"
-          pureComputed={tableBodyRows => [{ type: 'rowPlugin' }, ...tableBodyRows]}
-          connectArgs={getter => [getter('tableBodyRows')]}
+          {...defaultPluginProps}
+          tableTemplate={({ cellTemplate }) =>
+            cellTemplate({ row: { original: 'row' }, column: { original: 'column' }, style: {} })}
+          tableStubCellTemplate={tableStubCellTemplate}
         />
       </PluginHost>,
     );
 
-    expect(tree.find('td.empty'))
-      .toHaveLength(5);
+    expect(tableStubCellTemplate)
+      .not.toBeCalledWith({ row: 'row', column: 'column' });
+    expect(tableStubCellTemplate)
+      .toBeCalledWith({ style: {} });
   });
 
-  it('should render empty header cell on plugin-defined column and row intersection', () => {
-    const tree = mount(
+  it('should render stub header cell on plugin-defined column and row intersection', () => {
+    isHeaderStubTableCell.mockImplementation(() => true);
+
+    const tableStubHeaderCellTemplate = jest.fn(() => null);
+
+    mount(
       <PluginHost>
-        <Getter
-          name="columns"
-          value={[{ name: 'a' }, { name: 'b' }]}
-        />
-        <Getter
-          name="rows"
-          value={[{ id: 1 }, { id: 2 }]}
-        />
         <Template name="root">
           <TemplatePlaceholder name="body" />
         </Template>
         <TableView
-          tableTemplate={({ headerRows, bodyRows, columns, cellTemplate }) => (
-            <table>
-              <tbody>
-                {[...headerRows, ...bodyRows].map(row => (
-                  <tr key={row.id || row.type}>
-                    {columns.map(column => React.cloneElement(
-                      cellTemplate({ row, column }),
-                      { key: column.name || column.type },
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-          tableCellTemplate={() => <td className="data" />}
-          tableStubCellTemplate={() => <td className="empty" />}
-          tableStubHeaderCellTemplate={() => <td className="empty-header" />}
-          tableNoDataCellTemplate={() => null}
+          {...defaultPluginProps}
+          tableTemplate={({ cellTemplate }) =>
+            cellTemplate({ row: { original: 'row' }, column: { original: 'column' }, style: {} })}
+          tableStubHeaderCellTemplate={tableStubHeaderCellTemplate}
         />
-        <Getter
-          name="tableColumns"
-          pureComputed={tableColumns => [{ type: 'columnPlugin' }, ...tableColumns]}
-          connectArgs={getter => [getter('tableColumns')]}
-        />
-        <Getter
-          name="tableHeaderRows"
-          pureComputed={tableHeaderRows => [{ type: 'rowPlugin' }, ...tableHeaderRows]}
-          connectArgs={getter => [getter('tableHeaderRows')]}
-        />
+        <Getter name="tableHeaderRows" value="tableHeaderRows" />
       </PluginHost>,
     );
 
-    expect(tree.find('td.empty-header'))
-      .toHaveLength(3);
+    expect(isHeaderStubTableCell)
+      .toBeCalledWith({ original: 'row' }, 'tableHeaderRows');
+    expect(tableStubHeaderCellTemplate)
+      .not.toBeCalledWith({ row: 'row', column: 'column' });
+    expect(tableStubHeaderCellTemplate)
+      .toBeCalledWith({ style: {} });
   });
 
   it('should render no data cell if rows are empty', () => {
-    const tree = mount(
+    isNoDataTableRow.mockImplementation(() => true);
+
+    const tableNoDataCellTemplate = jest.fn(() => null);
+
+    mount(
       <PluginHost>
-        <Getter
-          name="columns"
-          value={[{ name: 'a' }, { name: 'b' }]}
-        />
-        <Getter
-          name="rows"
-          value={[]}
-        />
         <Template name="root">
           <TemplatePlaceholder name="body" />
         </Template>
         <TableView
-          tableTemplate={({ bodyRows, columns, cellTemplate }) => (
-            <table>
-              <tbody>
-                {bodyRows.map(row => (
-                  <tr key={row.id || row.type}>
-                    {columns.map((column, columnIndex) => {
-                      const info = getTableCellInfo({ row, column, columnIndex, columns });
-                      if (info.skip) return null;
-
-                      return React.cloneElement(
-                        cellTemplate({ row, column, colspan: info.colspan }),
-                        { key: column.name || column.type },
-                      );
-                    })}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-          tableCellTemplate={() => null}
-          tableStubCellTemplate={() => null}
-          tableStubHeaderCellTemplate={() => null}
-          tableNoDataCellTemplate={({ colspan }) => <td className="no-data" colSpan={colspan} />}
+          {...defaultPluginProps}
+          tableTemplate={({ cellTemplate }) =>
+            cellTemplate({ row: { original: 'row' }, column: { original: 'column' }, style: {}, colspan: 3 })}
+          tableNoDataCellTemplate={tableNoDataCellTemplate}
         />
+        <Getter name="tableHeaderRows" value="tableHeaderRows" />
       </PluginHost>,
     );
 
-    const noDataCell = tree.find('td.no-data');
-    expect(noDataCell)
-      .toHaveLength(1);
-    expect(noDataCell.prop('colSpan'))
-      .toBe(2);
+    expect(isNoDataTableRow)
+      .toBeCalledWith({ original: 'row' });
+
+    expect(tableNoDataCellTemplate)
+      .not.toBeCalledWith(expect.objectContaining({ row: 'row', column: 'column' }));
+    expect(tableNoDataCellTemplate)
+      .toBeCalledWith(expect.objectContaining({ style: {}, colspan: 3 }));
   });
 });

--- a/packages/dx-react-grid/src/plugins/test-utils.jsx
+++ b/packages/dx-react-grid/src/plugins/test-utils.jsx
@@ -7,16 +7,21 @@ import {
   PluginContainer,
 } from '@devexpress/dx-react-core';
 
+// remove when switch to node 8
+const entries = object =>
+  Object.keys(object)
+    .reduce((acc, key) => [...acc, [key, object[key]]], []);
+
 export const pluginDepsToComponents = (
   deps,
   depsOverrides = {},
 ) => (
   <PluginContainer>
-    {Object.entries({ ...deps.getter, ...depsOverrides.getter })
+    {entries({ ...deps.getter, ...depsOverrides.getter })
       .map(([name, value]) => <Getter key={`getter_${name}`} name={name} value={value} />)}
-    {Object.entries({ ...deps.action, ...depsOverrides.action })
+    {entries({ ...deps.action, ...depsOverrides.action })
       .map(([name, action]) => <Action key={`getter_${name}`} name={name} action={action} />)}
-    {Object.entries({ ...deps.template, ...depsOverrides.template })
+    {entries({ ...deps.template, ...depsOverrides.template })
       .map(([name, templateParams]) => (
         <Template key={`getter_${name}`} name="root">
           <div>

--- a/packages/dx-react-grid/src/plugins/test-utils.jsx
+++ b/packages/dx-react-grid/src/plugins/test-utils.jsx
@@ -20,10 +20,10 @@ export const pluginDepsToComponents = (
     {entries({ ...deps.getter, ...depsOverrides.getter })
       .map(([name, value]) => <Getter key={`getter_${name}`} name={name} value={value} />)}
     {entries({ ...deps.action, ...depsOverrides.action })
-      .map(([name, action]) => <Action key={`getter_${name}`} name={name} action={action} />)}
+      .map(([name, action]) => <Action key={`action_${name}`} name={name} action={action} />)}
     {entries({ ...deps.template, ...depsOverrides.template })
       .map(([name, templateParams]) => (
-        <Template key={`getter_${name}`} name="root">
+        <Template key={`template_${name}`} name="root">
           <div>
             <TemplatePlaceholder name={name} params={templateParams} />
             <TemplatePlaceholder />

--- a/packages/dx-react-grid/src/plugins/test-utils.jsx
+++ b/packages/dx-react-grid/src/plugins/test-utils.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  Getter,
+  Action,
+  Template,
+  TemplatePlaceholder,
+  PluginContainer,
+} from '@devexpress/dx-react-core';
+
+export const pluginDepsToComponents = (
+  deps,
+  depsOverrides = {},
+) => (
+  <PluginContainer>
+    {Object.entries({ ...deps.getter, ...depsOverrides.getter })
+      .map(([name, value]) => <Getter key={`getter_${name}`} name={name} value={value} />)}
+    {Object.entries({ ...deps.action, ...depsOverrides.action })
+      .map(([name, action]) => <Action key={`getter_${name}`} name={name} action={action} />)}
+    {Object.entries({ ...deps.template, ...depsOverrides.template })
+      .map(([name, templateParams]) => (
+        <Template key={`getter_${name}`} name="root">
+          <div>
+            <TemplatePlaceholder name={name} params={templateParams} />
+            <TemplatePlaceholder />
+          </div>
+        </Template>
+      ))}
+    <Template
+      key="check"
+      name="root"
+      connectGetters={getter => depsOverrides.checkGetter && depsOverrides.checkGetter(getter)}
+      connectActions={action => depsOverrides.checkAction && depsOverrides.checkAction(action)}
+    >
+      {() => <TemplatePlaceholder />}
+    </Template>
+  </PluginContainer>
+);

--- a/packages/dx-react-grid/src/plugins/test-utils.jsx
+++ b/packages/dx-react-grid/src/plugins/test-utils.jsx
@@ -28,8 +28,10 @@ export const pluginDepsToComponents = (
     <Template
       key="check"
       name="root"
-      connectGetters={getter => depsOverrides.checkGetter && depsOverrides.checkGetter(getter)}
-      connectActions={action => depsOverrides.checkAction && depsOverrides.checkAction(action)}
+      // eslint-disable-next-line no-param-reassign
+      connectGetters={getter => (depsOverrides.computedGetter = getter)}
+      // eslint-disable-next-line no-param-reassign
+      connectActions={getter => (depsOverrides.computedAction = getter)}
     >
       {() => <TemplatePlaceholder />}
     </Template>

--- a/packages/dx-react-grid/src/plugins/test-utils.jsx
+++ b/packages/dx-react-grid/src/plugins/test-utils.jsx
@@ -34,9 +34,9 @@ export const pluginDepsToComponents = (
       key="check"
       name="root"
       // eslint-disable-next-line no-param-reassign
-      connectGetters={getter => (depsOverrides.computedGetter = getter)}
+      connectGetters={(getter) => { depsOverrides.computedGetter = getter; }}
       // eslint-disable-next-line no-param-reassign
-      connectActions={getter => (depsOverrides.computedAction = getter)}
+      connectActions={(action) => { depsOverrides.computedAction = action; }}
     >
       {() => <TemplatePlaceholder />}
     </Template>


### PR DESCRIPTION
BREAKING CHANGES:
 
`TableRow` and `TableColumn` interfaces structure has been changed. Now, it wraps original rows and columns of the Grid component instead of patching it.

Before:

```ts
interface TableRow extends Row {
  type?: string;
}
interface TableColumn extends Column {
  type?: string;
}
```

After:

```ts
interface TableRow {
  key: string;
  type: string;
  rowId?: number | string;
  row?: Row;
  height?: number;
}
interface TableColumn {
  key: string;
  type: string;
  column?: Column;
  width?: number;
}
```
 
The `CommandHeadingCellArgs` interface related to the TableEditColumn plugin no longer has `column` and `row` fields.