### PR TITLE
chore(react-grid-material-ui): swap UMD bundle with CJS one in package entry

### DIFF
--- a/packages/dx-react-grid-material-ui/package.json
+++ b/packages/dx-react-grid-material-ui/package.json
@@ -32,7 +32,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/dx-react-grid-material-ui.umd.js",
+  "main": "dist/dx-react-grid-material-ui.cjs.js",
   "module": "dist/dx-react-grid-material-ui.es.js",
   "globalName": "DevExpress.DXReactGridMaterialUI",
   "files": [

--- a/packages/dx-react-grid-material-ui/rollup.config.js
+++ b/packages/dx-react-grid-material-ui/rollup.config.js
@@ -1,23 +1,21 @@
 import babel from 'rollup-plugin-babel';
 import license from 'rollup-plugin-license';
 import resolve from 'rollup-plugin-node-resolve';
-import { banner, external, babelrc, moduleName, globals } from '../../tools/rollup-utils';
+import { banner, external, babelrc } from '../../tools/rollup-utils';
 
 export default {
   entry: 'src/index.js',
   sourceMap: true,
   targets: [
     {
-      format: 'umd',
-      dest: 'dist/dx-react-grid-material-ui.umd.js',
+      format: 'cjs',
+      dest: 'dist/dx-react-grid-material-ui.cjs.js',
     },
     {
       format: 'es',
       dest: 'dist/dx-react-grid-material-ui.es.js',
     },
   ],
-  moduleName: moduleName(__dirname),
-  globals: globals(__dirname),
   external: external(__dirname),
   plugins: [
     resolve({

--- a/tools/rollup-utils.js
+++ b/tools/rollup-utils.js
@@ -42,17 +42,6 @@ const knownGlobals = {
   'react-dom': 'ReactDOM',
   'prop-types': 'PropTypes',
   'react-bootstrap': 'ReactBootstrap',
-  'material-ui': 'material-ui',
-  'classnames': 'classNames',
-  'material-ui/styles': 'material-ui.styles',
-  'material-ui/styles/palette': 'material-ui.styles.palette',
-  'material-ui-icons': 'material-ui-icons',
-  'material-ui-icons/Close': 'material-ui-icons.Close',
-  'material-ui-icons/List': 'material-ui-icons.List',
-  'material-ui-icons/ChevronRight': 'material-ui-icons.ChevronRight',
-  'material-ui-icons/ChevronLeft': 'material-ui-icons.ChevronLeft',
-  'material-ui-icons/ExpandMore': 'material-ui-icons.ExpandMore',
-  'material-ui-icons/ExpandLess': 'material-ui-icons.ExpandLess',
 };
 
 export const globals = (packageDirectory) => {


### PR DESCRIPTION
BREAKING CHANGE:
UMD bundle for the `@devexpress/dx-react-grid-material-ui` package is no longer provided