### PR TITLE
refactor(react-grid): add the most recently added row to the end

### DIFF
--- a/packages/dx-grid-core/src/plugins/editing-state/reducers.js
+++ b/packages/dx-grid-core/src/plugins/editing-state/reducers.js
@@ -6,7 +6,7 @@ export const stopEditRows = (prevEditingRows, { rowIds }) => {
   return prevEditingRows.filter(id => !rowIdSet.has(id));
 };
 
-export const addRow = (addedRows, { row }) => [row, ...addedRows];
+export const addRow = (addedRows, { row }) => [...addedRows, row];
 
 export const changeAddedRow = (addedRows, { rowId, change }) => {
   const result = addedRows.slice();

--- a/packages/dx-grid-core/src/plugins/editing-state/reducers.test.js
+++ b/packages/dx-grid-core/src/plugins/editing-state/reducers.test.js
@@ -35,7 +35,7 @@ describe('EditingState reducers', () => {
       const payload = { row: { a: 2 } };
 
       const nextAddedRows = addRow(addedRows, payload);
-      expect(nextAddedRows).toEqual([{ a: 2 }, { a: 1 }]);
+      expect(nextAddedRows).toEqual([{ a: 1 }, { a: 2 }]);
     });
   });
   describe('#changeAddedRow', () => {

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
@@ -19,7 +19,7 @@ export const rowsWithEditing = (rows, editingRows, addedRows, getRowId, rowHeigh
     height: rowHeight,
   }));
   return [
-    ...addedTableRows,
+    ...addedTableRows.reverse(),
     ...tableRows,
   ];
 };

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
@@ -7,10 +7,16 @@ describe('EditRow computeds', () => {
     it('should work', () => {
       const rows = [{ id: 1 }, { id: 2 }];
       const editingRows = [2];
-      const addedRows = [{ id: 3 }];
+      const addedRows = [{ id: 3 }, { id: 4 }];
 
       const computed = rowsWithEditing(rows, editingRows, addedRows, row => row.id);
       expect(computed).toEqual([
+        {
+          index: 1,
+          type: 'edit',
+          _originalRow: { id: 4 },
+          isNew: true,
+        },
         {
           index: 0,
           type: 'edit',


### PR DESCRIPTION
BREAKING CHANGE:

In order to improve API transparency, the most recently added row will be added to the end of the addedRows property of the EditingState plugin.