### PR TITLE
refactor(react-grid): simplify arguments of the setPageSize and setCurrentPage actions

### DIFF
--- a/packages/dx-grid-core/src/plugins/paging-state/reducers.js
+++ b/packages/dx-grid-core/src/plugins/paging-state/reducers.js
@@ -1,2 +1,2 @@
-export const setCurrentPage = (prevPage, { page }) => page;
+export const setCurrentPage = (prevPage, page) => page;
 export const setPageSize = (prevPageSize, size) => size;

--- a/packages/dx-grid-core/src/plugins/paging-state/reducers.js
+++ b/packages/dx-grid-core/src/plugins/paging-state/reducers.js
@@ -1,2 +1,2 @@
 export const setCurrentPage = (prevPage, { page }) => page;
-export const setPageSize = (prevPageSize, { size }) => size;
+export const setPageSize = (prevPageSize, size) => size;

--- a/packages/dx-grid-core/src/plugins/paging-state/reducers.test.js
+++ b/packages/dx-grid-core/src/plugins/paging-state/reducers.test.js
@@ -6,9 +6,8 @@ describe('PagingState reducers', () => {
   describe('#setCurrentPage', () => {
     it('should work', () => {
       const state = 0;
-      const payload = { page: 1 };
 
-      const nextState = setCurrentPage(state, payload);
+      const nextState = setCurrentPage(state, 1);
       expect(nextState).toBe(1);
     });
   });

--- a/packages/dx-react-grid/docs/reference/local-paging.md
+++ b/packages/dx-react-grid/docs/reference/local-paging.md
@@ -21,7 +21,7 @@ Name | Plugin | Type | Description
 rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be paged
 pageSize | Getter | number | Provides the page size
 currentPage | Getter | number | Provides the current page
-setCurrentPage | Action | ({ page: number }) => void | Changes the current page
+setCurrentPage | Action | (page: number) => void | Changes the current page
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/paging-panel.md
+++ b/packages/dx-react-grid/docs/reference/paging-panel.md
@@ -43,7 +43,7 @@ Name | Plugin | Type | Description
 currentPage | Getter | number | The current page
 pageSize | Getter | number | The count of rows to be shown on a single page
 totalCount | Getter | number | The total row count
-setCurrentPage | Action | ({ page: number }) => void | Changes the current page
+setCurrentPage | Action | (page: number) => void | Changes the current page
 setPageSize | Action | (size: number) => void | Changes the page size
 footer | Template | Object? | A template that renders the grid footer
 

--- a/packages/dx-react-grid/docs/reference/paging-panel.md
+++ b/packages/dx-react-grid/docs/reference/paging-panel.md
@@ -44,7 +44,7 @@ currentPage | Getter | number | The current page
 pageSize | Getter | number | The count of rows to be shown on a single page
 totalCount | Getter | number | The total row count
 setCurrentPage | Action | ({ page: number }) => void | Changes the current page
-setPageSize | Action | ({ size: number }) => void | Changes the page size
+setPageSize | Action | (size: number) => void | Changes the page size
 footer | Template | Object? | A template that renders the grid footer
 
 ### Exports

--- a/packages/dx-react-grid/docs/reference/paging-state.md
+++ b/packages/dx-react-grid/docs/reference/paging-state.md
@@ -33,5 +33,5 @@ Name | Plugin | Type | Description
 pageSize | Getter | number | The page size
 setPageSize | Action | (size: number) => void | Changes the page size
 currentPage | Getter | number | The current page number
-setCurrentPage | Action | ({ page: number }) => void | Changes the current page number
+setCurrentPage | Action | (page: number) => void | Changes the current page number
 totalCount | Getter | number | The total row count

--- a/packages/dx-react-grid/docs/reference/paging-state.md
+++ b/packages/dx-react-grid/docs/reference/paging-state.md
@@ -31,7 +31,7 @@ none
 Name | Plugin | Type | Description
 -----|--------|------|------------
 pageSize | Getter | number | The page size
-setPageSize | Action | ({ size: number }) => void | Changes the page size
+setPageSize | Action | (size: number) => void | Changes the page size
 currentPage | Getter | number | The current page number
 setCurrentPage | Action | ({ page: number }) => void | Changes the current page number
 totalCount | Getter | number | The total row count

--- a/packages/dx-react-grid/src/plugins/local-paging.jsx
+++ b/packages/dx-react-grid/src/plugins/local-paging.jsx
@@ -31,7 +31,7 @@ export class LocalPaging extends React.PureComponent {
           onChange={(action, totalCount, currentPage, pageSize) => {
             const totalPages = pageCount(totalCount, pageSize);
             if (totalPages - 1 < currentPage) {
-              action('setCurrentPage')({ page: Math.max(totalPages - 1, 0) });
+              action('setCurrentPage')(Math.max(totalPages - 1, 0));
             }
           }}
         />

--- a/packages/dx-react-grid/src/plugins/local-paging.test.jsx
+++ b/packages/dx-react-grid/src/plugins/local-paging.test.jsx
@@ -83,7 +83,7 @@ describe('LocalPaging', () => {
     );
 
     expect(setCurrentPageMock.mock.calls)
-      .toEqual([[{ page: 2 }]]);
+      .toEqual([[2]]);
   });
 
   it('should ensure page headers are present on each page', () => {

--- a/packages/dx-react-grid/src/plugins/paging-panel.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-panel.jsx
@@ -25,7 +25,7 @@ export class PagingPanel extends React.PureComponent {
           }}
           connectActions={action => ({
             onCurrentPageChange: page => action('setCurrentPage')({ page }),
-            onPageSizeChange: size => action('setPageSize')({ size }),
+            onPageSizeChange: size => action('setPageSize')(size),
           })}
         >
           {params => (

--- a/packages/dx-react-grid/src/plugins/paging-panel.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-panel.jsx
@@ -24,7 +24,7 @@ export class PagingPanel extends React.PureComponent {
             };
           }}
           connectActions={action => ({
-            onCurrentPageChange: page => action('setCurrentPage')({ page }),
+            onCurrentPageChange: page => action('setCurrentPage')(page),
             onPageSizeChange: size => action('setPageSize')(size),
           })}
         >

--- a/packages/dx-react-grid/src/plugins/paging-panel.test.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-panel.test.jsx
@@ -60,6 +60,6 @@ describe('PagingPanel', () => {
 
     pagerTemplateMock.mock.calls[0][0].onPageSizeChange(3);
     expect(setPageSizeMock.mock.calls)
-      .toEqual([[{ size: 3 }]]);
+      .toEqual([[3]]);
   });
 });

--- a/packages/dx-react-grid/src/plugins/paging-panel.test.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-panel.test.jsx
@@ -56,7 +56,7 @@ describe('PagingPanel', () => {
 
     pagerTemplateMock.mock.calls[0][0].onCurrentPageChange(3);
     expect(setCurrentPageMock.mock.calls)
-      .toEqual([[{ page: 3 }]]);
+      .toEqual([[3]]);
 
     pagerTemplateMock.mock.calls[0][0].onPageSizeChange(3);
     expect(setPageSizeMock.mock.calls)

--- a/packages/dx-react-grid/src/plugins/paging-state.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-state.jsx
@@ -21,9 +21,9 @@ export class PagingState extends React.PureComponent {
       }
     };
 
-    this._setPageSize = ({ size }) => {
+    this._setPageSize = (size) => {
       const { onPageSizeChange } = this.props;
-      const pageSize = setPageSize(this.state.pageSize, { size });
+      const pageSize = setPageSize(this.state.pageSize, size);
       this.setState({ pageSize });
       if (onPageSizeChange) {
         onPageSizeChange(pageSize);
@@ -40,7 +40,7 @@ export class PagingState extends React.PureComponent {
     return (
       <PluginContainer>
         <Action name="setCurrentPage" action={({ page }) => this._setCurrentPage({ page })} />
-        <Action name="setPageSize" action={({ size }) => this._setPageSize({ size })} />
+        <Action name="setPageSize" action={size => this._setPageSize(size)} />
 
         <Getter name="currentPage" value={currentPage} />
         <Getter name="pageSize" value={pageSize} />

--- a/packages/dx-react-grid/src/plugins/paging-state.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-state.jsx
@@ -12,9 +12,9 @@ export class PagingState extends React.PureComponent {
       pageSize: props.defaultPageSize,
     };
 
-    this._setCurrentPage = ({ page }) => {
+    this._setCurrentPage = (page) => {
       const { onCurrentPageChange } = this.props;
-      const currentPage = setCurrentPage(this.state.currentPage, { page });
+      const currentPage = setCurrentPage(this.state.currentPage, page);
       this.setState({ currentPage });
       if (onCurrentPageChange) {
         onCurrentPageChange(currentPage);
@@ -39,7 +39,7 @@ export class PagingState extends React.PureComponent {
 
     return (
       <PluginContainer>
-        <Action name="setCurrentPage" action={({ page }) => this._setCurrentPage({ page })} />
+        <Action name="setCurrentPage" action={page => this._setCurrentPage(page)} />
         <Action name="setPageSize" action={size => this._setPageSize(size)} />
 
         <Getter name="currentPage" value={currentPage} />

--- a/packages/dx-react-grid/src/plugins/paging-state.test.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-state.test.jsx
@@ -76,7 +76,7 @@ describe('PagingState', () => {
         </PluginHost>,
       );
 
-      setCurrentPage({ page: 3 });
+      setCurrentPage(3);
 
       expect(currentPage)
         .toEqual(3);
@@ -104,7 +104,7 @@ describe('PagingState', () => {
         </PluginHost>,
       );
 
-      setCurrentPage({ page: 3 });
+      setCurrentPage(3);
 
       expect(currentPage)
         .toEqual(2);

--- a/packages/dx-react-grid/src/plugins/paging-state.test.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-state.test.jsx
@@ -174,7 +174,7 @@ describe('PagingState', () => {
         </PluginHost>,
       );
 
-      setPageSize({ size: 3 });
+      setPageSize(3);
 
       expect(pageSize)
         .toEqual(3);
@@ -202,7 +202,7 @@ describe('PagingState', () => {
         </PluginHost>,
       );
 
-      setPageSize({ size: 3 });
+      setPageSize(3);
 
       expect(pageSize)
         .toEqual(2);


### PR DESCRIPTION
BREAKING CHANGES:

Arguments of the `setPageSize` and `setCurrentPage` actions were simpilified. 

Now, to call these actions, a user can use `numbers` instead of `objects`. See the following code:

    setPageSize(5); // instead of setPageSize({ size: 5 })

and

    setCurrentPage(1); // instead of setCurrentPage({ page: 1 })



