### PR TITLE
refactor(react-grid): rename colspan to colSpan

### DIFF
--- a/packages/dx-grid-core/src/utils/table.js
+++ b/packages/dx-grid-core/src/utils/table.js
@@ -12,7 +12,7 @@ export const getTableRowColumnsWithColSpan = (tableColumns, colSpanStart) => {
       if (span) return acc;
       if (columnIndex === colSpanStart || tableColumn.key === colSpanStart) {
         span = true;
-        return [...acc, { ...tableColumn, colspan: tableColumns.length - columnIndex }];
+        return [...acc, { ...tableColumn, colSpan: tableColumns.length - columnIndex }];
       }
       return [...acc, tableColumn];
     }, []);

--- a/packages/dx-grid-core/src/utils/table.test.js
+++ b/packages/dx-grid-core/src/utils/table.test.js
@@ -6,31 +6,31 @@ import {
 
 describe('table utils', () => {
   describe('#getTableRowColumnsWithColSpan', () => {
-    it('should return correct columns without colspan', () => {
+    it('should return correct columns without colSpan', () => {
       const columns = [{ type: 'a', id: 1 }, { type: 'b', id: 2 }];
 
       expect(getTableRowColumnsWithColSpan(columns, null))
         .toEqual(columns);
     });
 
-    it('should return correct columns with numeric colspan', () => {
+    it('should return correct columns with numeric colSpan', () => {
       const columns = [{ type: 'a', id: 1 }, { type: 'b', id: 2 }, { type: 'c', id: 3 }];
 
       expect(getTableRowColumnsWithColSpan(columns, 0))
-        .toEqual([{ ...columns[0], colspan: 3 }]);
+        .toEqual([{ ...columns[0], colSpan: 3 }]);
 
       expect(getTableRowColumnsWithColSpan(columns, 1))
-        .toEqual([columns[0], { ...columns[1], colspan: 2 }]);
+        .toEqual([columns[0], { ...columns[1], colSpan: 2 }]);
     });
 
-    it('should return correct columns with string colspan', () => {
+    it('should return correct columns with string colSpan', () => {
       const columns = [{ key: 'a_1' }, { key: 'b_2' }, { key: 'c_3' }];
 
       expect(getTableRowColumnsWithColSpan(columns, 'a_1'))
-        .toEqual([{ ...columns[0], colspan: 3 }]);
+        .toEqual([{ ...columns[0], colSpan: 3 }]);
 
       expect(getTableRowColumnsWithColSpan(columns, 'b_2'))
-        .toEqual([columns[0], { ...columns[1], colspan: 2 }]);
+        .toEqual([columns[0], { ...columns[1], colSpan: 2 }]);
     });
   });
 

--- a/packages/dx-react-demos/src/bootstrap3/featured-remote-data/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-remote-data/demo.jsx
@@ -135,13 +135,13 @@ export default class Demo extends React.PureComponent {
               }
               return undefined;
             }}
-            tableNoDataCellTemplate={({ colspan }) => (
+            tableNoDataCellTemplate={({ colSpan }) => (
               <td
                 style={{
                   textAlign: 'center',
                   padding: '40px 0',
                 }}
-                colSpan={colspan}
+                colSpan={colSpan}
               >
                 <big className="text-muted">{loading ? '' : 'No data'}</big>
               </td>

--- a/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
@@ -41,10 +41,10 @@ SaleAmountCellBase.propTypes = {
 
 const SaleAmountCell = withStyles(styleSheet)(SaleAmountCellBase);
 
-const NoDataCellBase = ({ loading, colspan, classes }) => (
+const NoDataCellBase = ({ loading, colSpan, classes }) => (
   <TableCell
     className={classes.noDataCell}
-    colSpan={colspan}
+    colSpan={colSpan}
   >
     <big>{loading ? '' : 'No data'}</big>
   </TableCell>
@@ -52,7 +52,7 @@ const NoDataCellBase = ({ loading, colspan, classes }) => (
 
 NoDataCellBase.propTypes = {
   loading: PropTypes.bool.isRequired,
-  colspan: PropTypes.number.isRequired,
+  colSpan: PropTypes.number.isRequired,
   classes: PropTypes.object.isRequired,
 };
 
@@ -178,8 +178,8 @@ export default class Demo extends React.PureComponent {
               }
               return undefined;
             }}
-            tableNoDataCellTemplate={({ colspan }) => (
-              <NoDataCell loading={loading} colspan={colspan} />
+            tableNoDataCellTemplate={({ colSpan }) => (
+              <NoDataCell loading={loading} colSpan={colSpan} />
             )}
           />
           <TableHeaderRow allowSorting />

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-detail-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-detail-cell.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const TableDetailCell = ({ colspan, style, template }) =>
-  <td style={style} colSpan={colspan} className="active">{template()}</td>;
+export const TableDetailCell = ({ colSpan, style, template }) =>
+  <td style={style} colSpan={colSpan} className="active">{template()}</td>;
 
 TableDetailCell.propTypes = {
   style: PropTypes.shape(),
-  colspan: PropTypes.number,
+  colSpan: PropTypes.number,
   template: PropTypes.func.isRequired,
 };
 
 TableDetailCell.defaultProps = {
   style: null,
-  colspan: 1,
+  colSpan: 1,
 };

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-group-row-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-group-row-cell.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const TableGroupCell = ({ style, colspan, row, isExpanded, toggleGroupExpanded }) => (
+export const TableGroupCell = ({ style, colSpan, row, isExpanded, toggleGroupExpanded }) => (
   <td
-    colSpan={colspan}
+    colSpan={colSpan}
     style={{
       cursor: 'pointer',
       ...style,
@@ -24,7 +24,7 @@ export const TableGroupCell = ({ style, colspan, row, isExpanded, toggleGroupExp
 
 TableGroupCell.propTypes = {
   style: PropTypes.shape(),
-  colspan: PropTypes.number,
+  colSpan: PropTypes.number,
   row: PropTypes.shape(),
   isExpanded: PropTypes.bool,
   toggleGroupExpanded: PropTypes.func,
@@ -32,7 +32,7 @@ TableGroupCell.propTypes = {
 
 TableGroupCell.defaultProps = {
   style: null,
-  colspan: 1,
+  colSpan: 1,
   row: {},
   isExpanded: false,
   toggleGroupExpanded: () => {},

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-no-data-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-no-data-cell.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const TableNoDataCell = ({ style, colspan }) => (
+export const TableNoDataCell = ({ style, colSpan }) => (
   <td
     style={{
       textAlign: 'center',
       padding: '40px 0',
       ...style,
     }}
-    colSpan={colspan}
+    colSpan={colSpan}
   >
     <big className="text-muted">No data</big>
   </td>
@@ -16,10 +16,10 @@ export const TableNoDataCell = ({ style, colspan }) => (
 
 TableNoDataCell.propTypes = {
   style: PropTypes.shape(),
-  colspan: PropTypes.number,
+  colSpan: PropTypes.number,
 };
 
 TableNoDataCell.defaultProps = {
   style: null,
-  colspan: 1,
+  colSpan: 1,
 };

--- a/packages/dx-react-grid-bootstrap3/src/templates/virtual-table.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/virtual-table.jsx
@@ -61,7 +61,7 @@ export class VirtualTable extends React.Component {
           itemCount={columnsWithColSpan.length}
           itemInfo={(columnIndex) => {
             const columnWithColSpan = columnsWithColSpan[columnIndex];
-            const size = !columnWithColSpan.colspan
+            const size = !columnWithColSpan.colSpan
               ? columnWidths[columnIndex]
               : columns.slice(columnIndex).reduce(
                 (accum, column) => accum + columnWidths[columns.indexOf(column)],

--- a/packages/dx-react-grid-material-ui/src/templates/table-detail-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-detail-cell.jsx
@@ -9,10 +9,10 @@ const styleSheet = createStyleSheet('TableDetailCell', theme => ({
   },
 }));
 
-const TableDetailCellBase = ({ colspan, style, template, classes }) => (
+const TableDetailCellBase = ({ colSpan, style, template, classes }) => (
   <TableCell
     style={style}
-    colSpan={colspan}
+    colSpan={colSpan}
     className={classes.active}
   >
     {template()}
@@ -21,14 +21,14 @@ const TableDetailCellBase = ({ colspan, style, template, classes }) => (
 
 TableDetailCellBase.propTypes = {
   style: PropTypes.shape(),
-  colspan: PropTypes.number,
+  colSpan: PropTypes.number,
   template: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,
 };
 
 TableDetailCellBase.defaultProps = {
   style: null,
-  colspan: 1,
+  colSpan: 1,
 };
 
 export const TableDetailCell = withStyles(styleSheet)(TableDetailCellBase);

--- a/packages/dx-react-grid-material-ui/src/templates/table-group-row-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-group-row-cell.jsx
@@ -32,14 +32,14 @@ const styleSheet = createStyleSheet('TableGroupCell', theme => ({
 
 const TableGroupCellBase = ({
   style,
-  colspan,
+  colSpan,
   row,
   isExpanded,
   toggleGroupExpanded,
   classes,
 }) => (
   <TableCell
-    colSpan={colspan}
+    colSpan={colSpan}
     style={style}
     className={classes.cell}
     onClick={toggleGroupExpanded}
@@ -59,7 +59,7 @@ const TableGroupCellBase = ({
 
 TableGroupCellBase.propTypes = {
   style: PropTypes.shape(),
-  colspan: PropTypes.number,
+  colSpan: PropTypes.number,
   row: PropTypes.shape(),
   isExpanded: PropTypes.bool,
   toggleGroupExpanded: PropTypes.func,
@@ -68,7 +68,7 @@ TableGroupCellBase.propTypes = {
 
 TableGroupCellBase.defaultProps = {
   style: null,
-  colspan: 1,
+  colSpan: 1,
   row: {},
   isExpanded: false,
   toggleGroupExpanded: () => {},

--- a/packages/dx-react-grid-material-ui/src/templates/table-no-data-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-no-data-cell.jsx
@@ -14,11 +14,11 @@ const styleSheet = createStyleSheet('TableNoDataCell', theme => ({
   },
 }));
 
-export const TableNoDataCellBase = ({ style, colspan, classes }) => (
+export const TableNoDataCellBase = ({ style, colSpan, classes }) => (
   <TableCell
     style={style}
     className={classes.cell}
-    colSpan={colspan}
+    colSpan={colSpan}
   >
     <big className="text-muted">No data</big>
   </TableCell>
@@ -26,13 +26,13 @@ export const TableNoDataCellBase = ({ style, colspan, classes }) => (
 
 TableNoDataCellBase.propTypes = {
   style: PropTypes.shape(),
-  colspan: PropTypes.number,
+  colSpan: PropTypes.number,
   classes: PropTypes.object.isRequired,
 };
 
 TableNoDataCellBase.defaultProps = {
   style: null,
-  colspan: 1,
+  colSpan: 1,
 };
 
 export const TableNoDataCell = withStyles(styleSheet)(TableNoDataCellBase);

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -79,7 +79,7 @@ Field | Type | Description
 tableRow | [TableRow](#table-row) | Specifies a table row
 tableColumn | [TableColumn](#table-column) | Specifies a table column
 style? | Object | Styles that should be applied to the root cell element
-colspan? | number | Specifies the number of columns the cell spans
+colSpan? | number | Specifies the number of columns the cell spans
 
 ### <a name="table-data-cell-args"></a>TableDataCellArgs
 

--- a/packages/dx-react-grid/src/components/table-layout.test.jsx
+++ b/packages/dx-react-grid/src/components/table-layout.test.jsx
@@ -157,12 +157,12 @@ describe('TableLayout', () => {
 
     let rowColumn = rowWrappers.at(0).find('td');
     expect(rowColumn.length).toBe(1);
-    expect(rowColumn.at(0).children(PropsContainer).props().colspan).toBe(4);
+    expect(rowColumn.at(0).children(PropsContainer).props().colSpan).toBe(4);
 
     rowColumn = rowWrappers.at(1).find('td');
     expect(rowColumn.length).toBe(2);
-    expect(rowColumn.at(0).children(PropsContainer).props()).not.toHaveProperty('colspan');
-    expect(rowColumn.at(1).children(PropsContainer).props().colspan).toBe(3);
+    expect(rowColumn.at(0).children(PropsContainer).props()).not.toHaveProperty('colSpan');
+    expect(rowColumn.at(1).children(PropsContainer).props().colSpan).toBe(3);
   });
 
   it('should have correct styles', () => {

--- a/packages/dx-react-grid/src/components/table-layout/row-layout.jsx
+++ b/packages/dx-react-grid/src/components/table-layout/row-layout.jsx
@@ -42,7 +42,7 @@ export class RowLayout extends React.PureComponent {
                 tableRow={row}
                 tableColumn={column}
                 style={getColumnStyle({ column })}
-                {...column.colspan ? { colspan: column.colspan } : null}
+                {...column.colSpan ? { colSpan: column.colSpan } : null}
               />
             ))
         }

--- a/packages/dx-react-grid/src/plugins/table-view.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-view.test.jsx
@@ -174,7 +174,7 @@ describe('TableView', () => {
   it('should render no data cell if rows are empty', () => {
     isNoDataTableRow.mockImplementation(() => true);
     const tableNoDataCellTemplate = jest.fn(() => null);
-    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {}, colspan: 4 };
+    const tableCellArgs = { tableRow: { row: 'row' }, tableColumn: { column: 'column' }, style: {}, colSpan: 4 };
 
     mount(
       <PluginHost>


### PR DESCRIPTION
BREAKING CHANGES:

The `colspan` field passed to tableNoDataCellTemplate (the TableView plugin), detailCellTemplate (the TableRowDetail plugin) and groupCellTemplate (the TableGroupRow plugin) has been renamed to `colSpan`.