### PR TITLE
refactor(react-core): rename Getter to Property

### DIFF
--- a/packages/dx-core/src/plugin-host.js
+++ b/packages/dx-core/src/plugin-host.js
@@ -7,7 +7,7 @@ export class PluginHost {
   constructor() {
     this.plugins = [];
     this.subscriptions = [];
-    this.gettersCache = {};
+    this.propertiesCache = {};
   }
   ensureDependencies() {
     const defined = new Set();
@@ -44,7 +44,7 @@ export class PluginHost {
   }
   cleanPluginsCache() {
     this.validationRequired = true;
-    this.gettersCache = {};
+    this.propertiesCache = {};
     this.knownKeysCache = {};
   }
   knownKeys(postfix) {
@@ -64,14 +64,16 @@ export class PluginHost {
       this.validationRequired = false;
     }
 
-    if (!this.gettersCache[key]) {
-      this.gettersCache[key] = this.plugins.map(plugin => plugin[key]).filter(plugin => !!plugin);
+    if (!this.propertiesCache[key]) {
+      this.propertiesCache[key] = this.plugins
+        .map(plugin => plugin[key])
+        .filter(plugin => !!plugin);
     }
-    if (!upTo) return this.gettersCache[key];
+    if (!upTo) return this.propertiesCache[key];
 
     const upToIndex = this.plugins.indexOf(upTo);
-    return this.gettersCache[key].filter((getter) => {
-      const pluginIndex = this.plugins.findIndex(plugin => plugin[key] === getter);
+    return this.propertiesCache[key].filter((property) => {
+      const pluginIndex = this.plugins.findIndex(plugin => plugin[key] === property);
       return pluginIndex < upToIndex;
     });
   }

--- a/packages/dx-react-core/src/index.js
+++ b/packages/dx-react-core/src/index.js
@@ -1,7 +1,7 @@
 export { PluginHost } from './plugged/host';
 export { PluginContainer } from './plugged/container';
+export { Property } from './plugged/property';
 export { Action } from './plugged/action';
-export { Getter } from './plugged/getter';
 export { Watcher } from './plugged/watcher';
 export { Template } from './plugged/template';
 export { TemplatePlaceholder } from './plugged/template-placeholder';

--- a/packages/dx-react-core/src/plugged/indexer.jsx
+++ b/packages/dx-react-core/src/plugged/indexer.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter } from './getter';
+import { Property } from './property';
 import { Action } from './action';
 import { Template } from './template';
 
@@ -19,7 +19,7 @@ export const PluginIndexer = (
           return [...calculatedPosition, index];
         };
 
-        if (child.type === Getter ||
+        if (child.type === Property ||
             child.type === Action ||
             child.type === Template) {
           return React.cloneElement(child, { position: childPosition });

--- a/packages/dx-react-core/src/plugged/indexer.test.jsx
+++ b/packages/dx-react-core/src/plugged/indexer.test.jsx
@@ -5,7 +5,7 @@ import { setupConsole } from '@devexpress/dx-testing';
 
 import { PluginHost } from './host';
 import { PluginIndexer } from './indexer';
-import { Getter } from './getter';
+import { Property } from './property';
 import { Template } from './template';
 
 describe('PluginIndexer', () => {
@@ -18,16 +18,16 @@ describe('PluginIndexer', () => {
   });
 
   it('should correctly determine plugin position', () => {
-    const Test = ({ enableGetter }) => (
+    const Test = ({ enableProperty }) => (
       <PluginHost>
-        <Getter name="test" value={1} />
-        {enableGetter && <Getter name="test" value={2} />}
-        <Getter name="test" computed={({ test }) => `text${test}`} />
+        <Property name="test" value={1} />
+        {enableProperty && <Property name="test" value={2} />}
+        <Property name="test" computed={({ test }) => `text${test}`} />
 
         <Template
           name="root"
-          connectGetters={getter => ({
-            text: getter('test'),
+          connectProperties={property => ({
+            text: property('test'),
           })}
         >
           {({ text }) => <span>{text}</span>}
@@ -35,32 +35,32 @@ describe('PluginIndexer', () => {
       </PluginHost>
     );
     Test.propTypes = {
-      enableGetter: PropTypes.bool.isRequired,
+      enableProperty: PropTypes.bool.isRequired,
     };
 
     const tree = mount(
-      <Test enableGetter={false} />,
+      <Test enableProperty={false} />,
     );
 
-    tree.setProps({ enableGetter: true });
+    tree.setProps({ enableProperty: true });
     expect(tree.find('span').text()).toBe('text2');
   });
 
   it('should correctly determine plugin position within another component', () => {
-    const Test = ({ enableGetter }) => (
+    const Test = ({ enableProperty }) => (
       <PluginHost>
         <div>
           <PluginIndexer>
-            <Getter name="test" value={1} />
-            {enableGetter && <Getter name="test" value={2} />}
-            <Getter name="test" computed={({ test }) => `text${test}`} />
+            <Property name="test" value={1} />
+            {enableProperty && <Property name="test" value={2} />}
+            <Property name="test" computed={({ test }) => `text${test}`} />
           </PluginIndexer>
         </div>
 
         <Template
           name="root"
-          connectGetters={getter => ({
-            text: getter('test'),
+          connectProperties={property => ({
+            text: property('test'),
           })}
         >
           {({ text }) => <span>{text}</span>}
@@ -68,14 +68,14 @@ describe('PluginIndexer', () => {
       </PluginHost>
     );
     Test.propTypes = {
-      enableGetter: PropTypes.bool.isRequired,
+      enableProperty: PropTypes.bool.isRequired,
     };
 
     const tree = mount(
-      <Test enableGetter={false} />,
+      <Test enableProperty={false} />,
     );
 
-    tree.setProps({ enableGetter: true });
+    tree.setProps({ enableProperty: true });
     expect(tree.find('span').text()).toBe('text2');
   });
 });

--- a/packages/dx-react-core/src/plugged/property.jsx
+++ b/packages/dx-react-core/src/plugged/property.jsx
@@ -5,44 +5,44 @@ import { getAction } from '../utils/plugin-helpers';
 
 export const UPDATE_CONNECTION = 'updateConnection';
 
-export class Getter extends React.PureComponent {
+export class Property extends React.PureComponent {
   componentWillMount() {
     const { pluginHost } = this.context;
     const { name } = this.props;
 
     let lastComputed;
-    let lastGetterDependencies = {};
+    let lastPropertyDependencies = {};
     let lastResult;
 
     this.plugin = {
       position: () => this.props.position(),
-      [`${name}Getter`]: (original) => {
+      [`${name}Property`]: (original) => {
         const { value, computed } = this.props;
         if (value !== undefined) return value;
 
-        const getGetterValue = getterName => ((getterName === name)
+        const getPropertyValue = propertyName => ((propertyName === name)
           ? original
-          : pluginHost.get(`${getterName}Getter`, this.plugin));
+          : pluginHost.get(`${propertyName}Property`, this.plugin));
 
-        const currentGetterDependencies = Object.keys(lastGetterDependencies)
-          .reduce((acc, getterName) => Object.assign(acc, {
-            [getterName]: getGetterValue(getterName),
+        const currentPropertyDependencies = Object.keys(lastPropertyDependencies)
+          .reduce((acc, propertyName) => Object.assign(acc, {
+            [propertyName]: getPropertyValue(propertyName),
           }), {});
 
         if (computed === lastComputed &&
-          shallowEqual(lastGetterDependencies, currentGetterDependencies)) {
+          shallowEqual(lastPropertyDependencies, currentPropertyDependencies)) {
           return lastResult;
         }
 
         lastComputed = computed;
-        lastGetterDependencies = {};
+        lastPropertyDependencies = {};
 
-        const getters = pluginHost.knownKeys('Getter')
-          .reduce((acc, getterName) => {
-            Object.defineProperty(acc, getterName, {
+        const properties = pluginHost.knownKeys('Property')
+          .reduce((acc, propertyName) => {
+            Object.defineProperty(acc, propertyName, {
               get: () => {
-                const result = getGetterValue(getterName);
-                lastGetterDependencies[getterName] = result;
+                const result = getPropertyValue(propertyName);
+                lastPropertyDependencies[propertyName] = result;
                 return result;
               },
             });
@@ -56,7 +56,7 @@ export class Getter extends React.PureComponent {
             return acc;
           }, {});
 
-        lastResult = computed(getters, actions);
+        lastResult = computed(properties, actions);
         return lastResult;
       },
     };
@@ -78,19 +78,19 @@ export class Getter extends React.PureComponent {
   }
 }
 
-Getter.propTypes = {
+Property.propTypes = {
   position: PropTypes.func,
   name: PropTypes.string.isRequired,
   value: PropTypes.any, // eslint-disable-line react/forbid-prop-types
   computed: PropTypes.func,
 };
 
-Getter.defaultProps = {
+Property.defaultProps = {
   value: undefined,
   computed: null,
   position: null,
 };
 
-Getter.contextTypes = {
+Property.contextTypes = {
   pluginHost: PropTypes.object.isRequired,
 };

--- a/packages/dx-react-core/src/plugged/property.test.jsx
+++ b/packages/dx-react-core/src/plugged/property.test.jsx
@@ -5,18 +5,18 @@ import { mount } from 'enzyme';
 import { PluginHost } from './host';
 import { PluginContainer } from './container';
 import { Template } from './template';
-import { Getter } from './getter';
+import { Property } from './property';
 
-describe('Getter', () => {
+describe('Property', () => {
   it('should return value', () => {
     const tree = mount(
       <PluginHost>
-        <Getter name="test" value={'arg'} />
+        <Property name="test" value={'arg'} />
 
         <Template
           name="root"
-          connectGetters={getter => ({
-            prop: getter('test'),
+          connectProperties={property => ({
+            prop: property('test'),
           })}
         >
           {({ prop }) => <h1>{prop}</h1>}
@@ -27,19 +27,19 @@ describe('Getter', () => {
     expect(tree.find('h1').text()).toBe('arg');
   });
 
-  it('can use other getters', () => {
+  it('can use other properties', () => {
     const tree = mount(
       <PluginHost>
-        <Getter name="dep" value={'dep'} />
-        <Getter
+        <Property name="dep" value={'dep'} />
+        <Property
           name="test"
-          computed={getters => getters.dep}
+          computed={properties => properties.dep}
         />
 
         <Template
           name="root"
-          connectGetters={getter => ({
-            prop: getter('test'),
+          connectProperties={property => ({
+            prop: property('test'),
           })}
         >
           {({ prop }) => <h1>{prop}</h1>}
@@ -50,21 +50,21 @@ describe('Getter', () => {
     expect(tree.find('h1').text()).toBe('dep');
   });
 
-  it('should preserve the order if used after another getter', () => {
+  it('should preserve the order if used after another property', () => {
     const tree = mount(
       <PluginHost>
-        <Getter name="dep" value={'base'} />
-        <Getter
+        <Property name="dep" value={'base'} />
+        <Property
           name="test"
-          computed={getters => getters.dep}
+          computed={properties => properties.dep}
         />
 
-        <Getter name="dep" value={'overriden'} />
+        <Property name="dep" value={'overriden'} />
 
         <Template
           name="root"
-          connectGetters={getter => ({
-            prop: getter('test'),
+          connectProperties={property => ({
+            prop: property('test'),
           })}
         >
           {({ prop }) => <h1>{prop}</h1>}
@@ -78,37 +78,37 @@ describe('Getter', () => {
   it('should pass the latest result to the template', () => {
     const tree = mount(
       <PluginHost>
-        <Getter name="dep" value={'base'} />
+        <Property name="dep" value={'base'} />
 
         <Template
           name="root"
-          connectGetters={getter => ({
-            prop: getter('dep'),
+          connectProperties={property => ({
+            prop: property('dep'),
           })}
         >
           {({ prop }) => <h1>{prop}</h1>}
         </Template>
 
-        <Getter name="dep" value={'overriden'} />
+        <Property name="dep" value={'overriden'} />
       </PluginHost>,
     );
 
     expect(tree.find('h1').text()).toBe('overriden');
   });
 
-  it('can extend getter with same name', () => {
+  it('can extend property with same name', () => {
     const tree = mount(
       <PluginHost>
-        <Getter name="test" value={'base'} />
-        <Getter
+        <Property name="test" value={'base'} />
+        <Property
           name="test"
-          computed={getters => `${getters.test}_extended`}
+          computed={properties => `${properties.test}_extended`}
         />
 
         <Template
           name="root"
-          connectGetters={getter => ({
-            prop: getter('test'),
+          connectProperties={property => ({
+            prop: property('test'),
           })}
         >
           {({ prop }) => <h1>{prop}</h1>}
@@ -127,8 +127,8 @@ describe('Getter', () => {
           <PluginContainer>
             <Template
               name="root"
-              connectGetters={getter => ({
-                prop: getter('test'),
+              connectProperties={property => ({
+                prop: property('test'),
               })}
             >
               {({ prop }) => <h1>{prop}</h1>}
@@ -142,7 +142,7 @@ describe('Getter', () => {
       <PluginHost>
         <EncapsulatedPlugin />
 
-        <Getter name="test" value={text} />
+        <Property name="test" value={text} />
       </PluginHost>
     );
     Test.propTypes = {
@@ -167,15 +167,15 @@ describe('Getter', () => {
       render() {
         return (
           <PluginContainer>
-            <Getter
+            <Property
               name="test"
               computed={staticComputed}
             />
 
             <Template
               name="root"
-              connectGetters={(getter) => {
-                log.push(getter('test'));
+              connectProperties={(property) => {
+                log.push(property('test'));
               }}
             >
               <div />
@@ -186,7 +186,7 @@ describe('Getter', () => {
     }
     const Test = ({ value }) => (
       <PluginHost>
-        <Getter name="test" value={value} force={{}} />
+        <Property name="test" value={value} force={{}} />
         <EncapsulatedPlugin />
       </PluginHost>
     );

--- a/packages/dx-react-core/src/plugged/template-connector.jsx
+++ b/packages/dx-react-core/src/plugged/template-connector.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { shallowEqual } from '@devexpress/dx-core';
-import { UPDATE_CONNECTION } from './getter';
+import { UPDATE_CONNECTION } from './property';
 import { getAction } from '../utils/plugin-helpers';
 
 export class TemplateConnector extends React.Component {
@@ -46,7 +46,7 @@ export class TemplateConnector extends React.Component {
 
     let mappedProps = {};
     if (mapProps) {
-      mappedProps = mapProps(name => pluginHost.get(`${name}Getter`), params);
+      mappedProps = mapProps(name => pluginHost.get(`${name}Property`), params);
     }
 
     let mappedActions = {};

--- a/packages/dx-react-core/src/plugged/template-placeholder.jsx
+++ b/packages/dx-react-core/src/plugged/template-placeholder.jsx
@@ -60,14 +60,14 @@ export class TemplatePlaceholder extends React.Component {
 
     this.setupSubscription();
 
-    const { children: template, connectGetters, connectActions } = this.template;
+    const { children: template, connectProperties, connectActions } = this.template;
     const { children: placeholder } = this.props;
 
     const renderedTemplate = template();
     const content = renderedTemplate ? (
       <TemplateConnector
         params={this.params}
-        mapProps={connectGetters}
+        mapProps={connectProperties}
         mapActions={connectActions}
         content={renderedTemplate}
       />

--- a/packages/dx-react-core/src/plugged/template-placeholder.test.jsx
+++ b/packages/dx-react-core/src/plugged/template-placeholder.test.jsx
@@ -6,7 +6,7 @@ import { PluginHost } from './host';
 import { PluginContainer } from './container';
 import { Template } from './template';
 import { TemplatePlaceholder } from './template-placeholder';
-import { Getter } from './getter';
+import { Property } from './property';
 
 describe('TemplatePlaceholder', () => {
   it('should be a place for template rendering', () => {
@@ -179,10 +179,10 @@ describe('TemplatePlaceholder', () => {
   });
 
   it('should supply correct element with connected properties when templates are chained', () => {
-    const getterValue = 'test value';
+    const propertyValue = 'test value';
     const tree = mount(
       <PluginHost>
-        <Getter name="testGetter" value={getterValue} />
+        <Property name="testProperty" value={propertyValue} />
 
         <Template name="root">
           <TemplatePlaceholder name="test">
@@ -192,8 +192,8 @@ describe('TemplatePlaceholder', () => {
 
         <Template
           name="test"
-          connectGetters={getter => ({
-            value: getter('testGetter'),
+          connectProperties={property => ({
+            value: property('testProperty'),
           })}
         >
           {({ value }) => (<div className="test" >{value}</div>)}
@@ -202,6 +202,6 @@ describe('TemplatePlaceholder', () => {
     );
 
     expect(tree.find('.test').text())
-      .toBe(getterValue);
+      .toBe(propertyValue);
   });
 });

--- a/packages/dx-react-core/src/plugged/template.jsx
+++ b/packages/dx-react-core/src/plugged/template.jsx
@@ -13,13 +13,13 @@ export class Template extends React.PureComponent {
   }
   componentWillMount() {
     const { pluginHost } = this.context;
-    const { name, predicate, connectGetters, connectActions } = this.props;
+    const { name, predicate, connectProperties, connectActions } = this.props;
 
     this.plugin = {
       position: () => this.props.position(),
       [`${name}Template`]: {
         predicate,
-        connectGetters,
+        connectProperties,
         connectActions,
         children: () => this.props.children,
         id: this.id,
@@ -44,7 +44,7 @@ Template.propTypes = {
   position: PropTypes.func,
   name: PropTypes.string.isRequired,
   predicate: PropTypes.func,
-  connectGetters: PropTypes.func,
+  connectProperties: PropTypes.func,
   connectActions: PropTypes.func,
   children: PropTypes.oneOfType([
     PropTypes.func,
@@ -55,7 +55,7 @@ Template.propTypes = {
 
 Template.defaultProps = {
   predicate: null,
-  connectGetters: null,
+  connectProperties: null,
   connectActions: null,
   children: null,
   position: null,

--- a/packages/dx-react-core/src/plugged/watcher.jsx
+++ b/packages/dx-react-core/src/plugged/watcher.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { argumentsShallowEqual } from '@devexpress/dx-core';
-import { UPDATE_CONNECTION } from './getter';
+import { UPDATE_CONNECTION } from './property';
 import { getAction } from '../utils/plugin-helpers';
 
 function changeDetector(watch, onChange) {
@@ -22,12 +22,12 @@ export class Watcher extends React.PureComponent {
   constructor(props, context) {
     super(props, context);
     const { pluginHost } = context;
-    const getter = getterName => pluginHost.get(`${getterName}Getter`);
+    const property = propertyName => pluginHost.get(`${propertyName}Property`);
     const action = actionName => getAction(pluginHost, actionName);
     const { watch, onChange } = this.props;
 
     this.detectChanges = changeDetector(
-      () => watch(getter),
+      () => watch(property),
       args => onChange.apply(null, [action, ...args]),
     );
 

--- a/packages/dx-react-core/src/plugged/watcher.test.jsx
+++ b/packages/dx-react-core/src/plugged/watcher.test.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { mount } from 'enzyme';
 
 import { PluginHost } from './host';
-import { Getter } from './getter';
+import { Property } from './property';
 import { Action } from './action';
 import { Watcher } from './watcher';
 
@@ -13,9 +13,9 @@ describe('Watcher', () => {
     const actionLogger = jest.fn();
     mount(
       <PluginHost>
-        <Getter name="test" value={'arg'} />
+        <Property name="test" value={'arg'} />
         <Action name="test" action={actionLogger} />
-        <Watcher watch={getter => ([getter('test')])} onChange={changeLogger} />
+        <Watcher watch={property => ([property('test')])} onChange={changeLogger} />
       </PluginHost>,
     );
 
@@ -36,8 +36,8 @@ describe('Watcher', () => {
 
     const Test = ({ dependency }) => (
       <PluginHost>
-        <Getter name="test" computed={() => dependency} />
-        <Watcher watch={getter => ([getter('test')])} onChange={changeLogger} />
+        <Property name="test" computed={() => dependency} />
+        <Watcher watch={property => ([property('test')])} onChange={changeLogger} />
       </PluginHost>
     );
     Test.propTypes = {

--- a/packages/dx-react-grid/docs/reference/column-order-state.md
+++ b/packages/dx-react-grid/docs/reference/column-order-state.md
@@ -22,12 +22,12 @@ onOrderChange | (nextOrder: Array&lt;string&gt;) => void | | Handles column orde
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-columns | Getter | Array&lt;[Column](grid.md#column)&gt; | Columns to be ordered
+columns | Property | Array&lt;[Column](grid.md#column)&gt; | Columns to be ordered
 
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-columns | Getter | Array&lt;[Column](grid.md#column)&gt; | Ordered columns
+columns | Property | Array&lt;[Column](grid.md#column)&gt; | Ordered columns
 setColumnOrder | Action | ({ sourceColumnName, targetColumnName }) => void | Moves a column to another column's position.  `sourceColumnName` specifies the column to be moved and `targetColumnName` specifies the target column.

--- a/packages/dx-react-grid/docs/reference/drag-drop-context.md
+++ b/packages/dx-react-grid/docs/reference/drag-drop-context.md
@@ -45,7 +45,7 @@ column | [Column](grid.md#column) | Specifies a table column
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-columns | Getter | Array&lt;[Column](grid.md#column)&gt; | Columns available for dragging
+columns | Property | Array&lt;[Column](grid.md#column)&gt; | Columns available for dragging
 root | Template | Object? | A template that renders the grid's root layout
 
 ### Exports

--- a/packages/dx-react-grid/docs/reference/editing-state.md
+++ b/packages/dx-react-grid/docs/reference/editing-state.md
@@ -47,25 +47,25 @@ deleted? | Array&lt;number &#124; string&gt; | An array of IDs representing rows
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-columns | Getter | Array&lt;[Column](grid.md#column)&gt; | The grid columns
+columns | Property | Array&lt;[Column](grid.md#column)&gt; | The grid columns
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-editingRows | Getter | Array&lt;number &#124; string&gt; | Rows being edited
+editingRows | Property | Array&lt;number &#124; string&gt; | Rows being edited
 startEditRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Switches rows specified by the ID to the edit mode
 stopEditRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Switches rows specified by the ID to the read-only mode
-addedRows | Getter | Array&lt;Object&gt; | Created rows
+addedRows | Property | Array&lt;Object&gt; | Created rows
 addRow | Action | () => void | Creates a row
 changeAddedRow | Action | ({ rowId: number, change: Object }) => void | Applies a change to a new row. Note: `rowId` is a row index within the `addedRows` array
 cancelAddedRows | Action | ({ rowIds: Array&lt;number&gt; }) => void | Removes new rows specified by index from the `addedRows` array
 commitAddedRows | Action | ({ rowIds: Array&lt;number&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](#change-set) and removes the specified rows from the `addedRows` array
-changedRows | Getter | { [key: string]: Object } | Uncommitted changed rows
+changedRows | Property | { [key: string]: Object } | Uncommitted changed rows
 changeRow | Action | ({ rowId: number &#124; string, change: Object }) => void | Applies a change to an existing row
 cancelChangedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Cancels rows' uncommitted changes specified by the ID
 commitChangedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](#change-set) and removes the specified rows from the `changedRows` array
-deletedRows | Getter | Array&lt;number &#124; string&gt; | Rows prepared for deletion
+deletedRows | Property | Array&lt;number &#124; string&gt; | Rows prepared for deletion
 deleteRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Adds rows specified by the ID to the `deletedRows` array
 cancelDeletedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Cancels rows' deletion specified by the ID removing them from the `deletedRows` array
 commitDeletedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](#change-set) and removes the specified rows from the `deletedRows` array

--- a/packages/dx-react-grid/docs/reference/filtering-state.md
+++ b/packages/dx-react-grid/docs/reference/filtering-state.md
@@ -39,5 +39,5 @@ none
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-filters | Getter | Array&lt;[Filter](#filter)&gt; | Applied column filters
+filters | Property | Array&lt;[Filter](#filter)&gt; | Applied column filters
 setColumnFilter | Action | ({ columnName: string, config: Object }) => void | Changes a column filter. Removes the filter if config is `null`

--- a/packages/dx-react-grid/docs/reference/grid.md
+++ b/packages/dx-react-grid/docs/reference/grid.md
@@ -70,8 +70,8 @@ children? | ReactElement | A markup to be placed into the footer
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-rows | Getter | Array&lt;[Row](#row)&gt; | Grid rows
-columns | Getter | Array&lt;[Column](#column)&gt; | Grid columns
+rows | Property | Array&lt;[Row](#row)&gt; | Grid rows
+columns | Property | Array&lt;[Column](#column)&gt; | Grid columns
 root | Template | Object? | A template that renders the grid root layout
 header | Template | Object? | A template that renders the grid header
 body | Template | Object? | A template that renders the grid body

--- a/packages/dx-react-grid/docs/reference/grouping-panel.md
+++ b/packages/dx-react-grid/docs/reference/grouping-panel.md
@@ -77,9 +77,9 @@ allowUngroupingByClick | boolean | Specifies whether to display the button that 
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-columns | Getter | Array&lt;[Column](grid.md#column)&gt; | Grid columns
-draftGrouping | Getter | Array&lt;[DraftGrouping](grouping-state.md#draft-grouping)&gt; | Grouping options used for preview
-sorting | Getter | Array&lt;[Sorting](sorting-state.md#sorting)&gt; | The current sorting state
+columns | Property | Array&lt;[Column](grid.md#column)&gt; | Grid columns
+draftGrouping | Property | Array&lt;[DraftGrouping](grouping-state.md#draft-grouping)&gt; | Grouping options used for preview
+sorting | Property | Array&lt;[Sorting](sorting-state.md#sorting)&gt; | The current sorting state
 groupByColumn | Action | ({ columnName: string }) => void | Toggles a column's grouping state
 setColumnSorting | Action | ({ columnName: string, direction: 'asc' &#124; 'desc', keepOther: boolean, cancel: boolean }) => void | Changes column sorting
 draftGroupingChange | Action | ({ columnName: string, groupIndex?: number }) => void | Sets the groupingChange state to the specified value

--- a/packages/dx-react-grid/docs/reference/grouping-state.md
+++ b/packages/dx-react-grid/docs/reference/grouping-state.md
@@ -54,15 +54,15 @@ A string value that consists of values by which rows are grouped, separated by t
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-columns | Getter | Array&lt;[Column](grid.md#column)&gt; | The grid columns
+columns | Property | Array&lt;[Column](grid.md#column)&gt; | The grid columns
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-grouping | Getter | Array&lt;[Grouping](#grouping)&gt; | The current grouping state
-draftGrouping | Getter | Array&lt;[DraftGrouping](#draft-grouping)&gt; | Grouping options used for preview
-expandedGroups | Getter | Set&lt;[GroupKey](#group-key)&gt; | Expanded groups
+grouping | Property | Array&lt;[Grouping](#grouping)&gt; | The current grouping state
+draftGrouping | Property | Array&lt;[DraftGrouping](#draft-grouping)&gt; | Grouping options used for preview
+expandedGroups | Property | Set&lt;[GroupKey](#group-key)&gt; | Expanded groups
 groupByColumn | Action | ({ columnName: string, groupIndex?: number }) => void | Groups by the specified column or cancels grouping. If `groupIndex` is omitted, the group is added to the last position.
 toggleGroupExpanded | Action | ({ groupKey: [GroupKey](#group-key) }) => void | Toggles the expanded group state
 draftGroupingChange | Action | ({ columnName: string, groupIndex?: number }) => void | Sets the groupingChange state to the specified value

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -20,13 +20,13 @@ filterFn | (row: [Row](grid.md#row), filter: [Filter](filtering-state.md#filter)
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be filtered
-filters | Getter | Array&lt;[Filter](filtering-state.md#filter)&gt; | Column filters to be applied
-getCellData | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get cell data
+rows | Property | Array&lt;[Row](grid.md#row)&gt; | Rows to be filtered
+filters | Property | Array&lt;[Filter](filtering-state.md#filter)&gt; | Column filters to be applied
+getCellData | Property | (row: [Row](grid.md#row), columnName: string) => any | The function used to get cell data
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows with the applied filtering
+rows | Property | Array&lt;[Row](grid.md#row)&gt; | Rows with the applied filtering
 

--- a/packages/dx-react-grid/docs/reference/local-grouping.md
+++ b/packages/dx-react-grid/docs/reference/local-grouping.md
@@ -18,13 +18,13 @@ none
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be grouped
-grouping | Getter | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | The current grouping state
-expandedGroups | Getter | Set&lt;[GroupKey](grouping-state.md#group-key)&gt; | Groups to be expanded
-getCellData | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get cell data
+rows | Property | Array&lt;[Row](grid.md#row)&gt; | Rows to be grouped
+grouping | Property | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | The current grouping state
+expandedGroups | Property | Set&lt;[GroupKey](grouping-state.md#group-key)&gt; | Groups to be expanded
+getCellData | Property | (row: [Row](grid.md#row), columnName: string) => any | The function used to get cell data
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows with the applied grouping and expanded groups
+rows | Property | Array&lt;[Row](grid.md#row)&gt; | Rows with the applied grouping and expanded groups

--- a/packages/dx-react-grid/docs/reference/local-paging.md
+++ b/packages/dx-react-grid/docs/reference/local-paging.md
@@ -18,14 +18,14 @@ none
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be paged
-pageSize | Getter | number | Provides the page size
-currentPage | Getter | number | Provides the current page
+rows | Property | Array&lt;[Row](grid.md#row)&gt; | Rows to be paged
+pageSize | Property | number | Provides the page size
+currentPage | Property | number | Provides the current page
 setCurrentPage | Action | (page: number) => void | Changes the current page
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows with the applied paging
-totalCount | Getter | number | The total row count
+rows | Property | Array&lt;[Row](grid.md#row)&gt; | Rows with the applied paging
+totalCount | Property | number | The total row count

--- a/packages/dx-react-grid/docs/reference/local-sorting.md
+++ b/packages/dx-react-grid/docs/reference/local-sorting.md
@@ -18,13 +18,13 @@ none
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be sorted
-sorting | Getter | Array&lt;[Sorting](sorting-state.md#sorting)&gt; | Column sorting to be applied
-getCellData | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell data
+rows | Property | Array&lt;[Row](grid.md#row)&gt; | Rows to be sorted
+sorting | Property | Array&lt;[Sorting](sorting-state.md#sorting)&gt; | Column sorting to be applied
+getCellData | Property | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell data
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows with the applied sorting
+rows | Property | Array&lt;[Row](grid.md#row)&gt; | Rows with the applied sorting
 

--- a/packages/dx-react-grid/docs/reference/paging-panel.md
+++ b/packages/dx-react-grid/docs/reference/paging-panel.md
@@ -40,9 +40,9 @@ showAllText | string | Specifies a page size selector's 'All' item text. Availab
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-currentPage | Getter | number | The current page
-pageSize | Getter | number | The count of rows to be shown on a single page
-totalCount | Getter | number | The total row count
+currentPage | Property | number | The current page
+pageSize | Property | number | The count of rows to be shown on a single page
+totalCount | Property | number | The total row count
 setCurrentPage | Action | (page: number) => void | Changes the current page
 setPageSize | Action | (size: number) => void | Changes the page size
 footer | Template | Object? | A template that renders the grid footer

--- a/packages/dx-react-grid/docs/reference/paging-state.md
+++ b/packages/dx-react-grid/docs/reference/paging-state.md
@@ -30,8 +30,8 @@ none
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-pageSize | Getter | number | The page size
+pageSize | Property | number | The page size
 setPageSize | Action | (size: number) => void | Changes the page size
-currentPage | Getter | number | The current page number
+currentPage | Property | number | The current page number
 setCurrentPage | Action | (page: number) => void | Changes the current page number
-totalCount | Getter | number | The total row count
+totalCount | Property | number | The total row count

--- a/packages/dx-react-grid/docs/reference/row-detail-state.md
+++ b/packages/dx-react-grid/docs/reference/row-detail-state.md
@@ -27,4 +27,4 @@ none
 Name | Plugin | Type | Description
 -----|--------|------|------------
 setDetailRowExpanded | Action | ({ rowId }) => void | Expands the specified row
-expandedRows | Getter | Array&lt;number &#124; string&gt; | Currently expanded rows
+expandedRows | Property | Array&lt;number &#124; string&gt; | Currently expanded rows

--- a/packages/dx-react-grid/docs/reference/selection-state.md
+++ b/packages/dx-react-grid/docs/reference/selection-state.md
@@ -22,13 +22,13 @@ onSelectionChange | (selection: Array&lt;number &#124; string&gt;) => void | | H
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be rendered
-getRowId | Getter | (row: [Row](grid.md#row)) => number &#124; string | A function used to get a unique row identifier
+rows | Property | Array&lt;[Row](grid.md#row)&gt; | Rows to be rendered
+getRowId | Property | (row: [Row](grid.md#row)) => number &#124; string | A function used to get a unique row identifier
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
 setRowsSelection | Action | ({ rowIds: Array&lt;number &#124; string&gt;, selected?: boolean  }) => void | A function that selects/deselects rows. The `selected` argument specifies whether the rows should be selected (true), deselected (false), or their selection status should be set to the opposite value (undefined). In the last case, the function selects unselected rows and deselects selected ones. To select/deselect a single row, pass an array with a single item to the `rowIds` argument.
-availableToSelect | Getter | Array&lt;number &#124; string&gt; | Rows to be rendered, which are available for selection
-selection | Getter | Array&lt;number &#124; string&gt; | Selected rows
+availableToSelect | Property | Array&lt;number &#124; string&gt; | Rows to be rendered, which are available for selection
+selection | Property | Array&lt;number &#124; string&gt; | Selected rows

--- a/packages/dx-react-grid/docs/reference/sorting-state.md
+++ b/packages/dx-react-grid/docs/reference/sorting-state.md
@@ -39,6 +39,6 @@ none
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-sorting | Getter | Array&lt;[Sorting](#sorting)&gt; | Applied column sorting
+sorting | Property | Array&lt;[Sorting](#sorting)&gt; | Applied column sorting
 setColumnSorting | Action | ({ columnName: string, direction: 'asc' &#124; 'desc', keepOther: boolean, cancel: boolean }) => void | Changes column sorting
 

--- a/packages/dx-react-grid/docs/reference/table-edit-column.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-column.md
@@ -70,7 +70,7 @@ text | string | Specifies the text to be rendered within the command control
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
+tableColumns | Property | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
 addRow | Action | () => void | Creates a row
 cancelAddedRows | Action | ({ rowIds: Array&lt;number&gt; }) => void | Removes uncommitted new rows from the `addedRows` array
 commitAddedRows | Action | ({ rowIds: Array&lt;number&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](editing-state.md#change-set) and removes the specified rows from the `addedRows` array
@@ -86,4 +86,4 @@ tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A te
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns including the edit column
+tableColumns | Property | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns including the edit column

--- a/packages/dx-react-grid/docs/reference/table-edit-row.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-row.md
@@ -37,12 +37,12 @@ onValueChange | (newValue: any) => void | Handles value changes
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Rows to be rendered inside the table body
-editingRows | Getter | Array&lt;number &#124; string&gt; | IDs of the rows being edited
-addedRows | Getter | Array&lt;Object&gt; | The created rows
-changedRows | Getter | { [key: string]: Object } | Uncommitted changed rows
-getCellData | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell data
-createRowChange | Getter | (row: [Row](grid.md#row), columnName: string, value: string &#124; string) => Object | The function used to set a cell data
+tableBodyRows | Property | Array&lt;[TableRow](table-view.md#table-row)&gt; | Rows to be rendered inside the table body
+editingRows | Property | Array&lt;number &#124; string&gt; | IDs of the rows being edited
+addedRows | Property | Array&lt;Object&gt; | The created rows
+changedRows | Property | { [key: string]: Object } | Uncommitted changed rows
+getCellData | Property | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell data
+createRowChange | Property | (row: [Row](grid.md#row), columnName: string, value: string &#124; string) => Object | The function used to set a cell data
 changeRow | Action | ({ rowId: number &#124; string, change: Object }) => void | Applies a change to an existing row
 changeAddedRow | Action | ({ rowId: number, change: Object }) => void | Applies a change to a new row. Note: `rowId` is a row index within the `addedRows` array
 tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
@@ -51,4 +51,4 @@ tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A te
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Table data rows including editing rows
+tableBodyRows | Property | Array&lt;[TableRow](table-view.md#table-row)&gt; | Table data rows including editing rows

--- a/packages/dx-react-grid/docs/reference/table-filter-row.md
+++ b/packages/dx-react-grid/docs/reference/table-filter-row.md
@@ -36,8 +36,8 @@ column | [Column](grid.md#column) | Specifies a column
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableHeaderRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Header rows to be rendered
-filters | Getter | Array&lt;[Filter](filtering-state.md#filter)&gt; | Applied column filters
+tableHeaderRows | Property | Array&lt;[TableRow](table-view.md#table-row)&gt; | Header rows to be rendered
+filters | Property | Array&lt;[Filter](filtering-state.md#filter)&gt; | Applied column filters
 setColumnFilter | Action | ({ columnName: string, config: Object }) => void | Changes a column filter. Removes the filter if config is `null`
 tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
 
@@ -45,4 +45,4 @@ tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A te
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableHeaderRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Header rows with filters to be rendered
+tableHeaderRows | Property | Array&lt;[TableRow](table-view.md#table-row)&gt; | Header rows with filters to be rendered

--- a/packages/dx-react-grid/docs/reference/table-group-row.md
+++ b/packages/dx-react-grid/docs/reference/table-group-row.md
@@ -58,11 +58,11 @@ value | any | The current group key value
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
-tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Table body rows
-grouping | Getter | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | Columns used for grouping
-draftGrouping | Getter | Array&lt;[DraftGrouping](grouping-state.md#draft-grouping)&gt; | Grouping options used for preview
-expandedGroups | Getter | Set&lt;[GroupKey](grouping-state.md#group-key)&gt; | Expanded groups
+tableColumns | Property | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
+tableBodyRows | Property | Array&lt;[TableRow](table-view.md#table-row)&gt; | Table body rows
+grouping | Property | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | Columns used for grouping
+draftGrouping | Property | Array&lt;[DraftGrouping](grouping-state.md#draft-grouping)&gt; | Grouping options used for preview
+expandedGroups | Property | Set&lt;[GroupKey](grouping-state.md#group-key)&gt; | Expanded groups
 toggleGroupExpanded | Action | ({ groupKey: [GroupKey](grouping-state.md#group-key) }) => void | Toggles the expanded group state
 tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
 
@@ -70,5 +70,5 @@ tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A te
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns, including the ones by which the table is grouped
-tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-column)&gt; | Table body rows with modified group rows
+tableColumns | Property | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns, including the ones by which the table is grouped
+tableBodyRows | Property | Array&lt;[TableRow](table-view.md#table-column)&gt; | Table body rows with modified group rows

--- a/packages/dx-react-grid/docs/reference/table-header-row.md
+++ b/packages/dx-react-grid/docs/reference/table-header-row.md
@@ -55,10 +55,10 @@ dragPayload | any | A data object that identifies the corresponding column in th
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableHeaderRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Header rows to be rendered
-sorting | Getter | Array&lt;[Sorting](sorting-state.md#sorting)&gt; | Column sorting
-columns | Getter | Array&lt;[Column](#column)&gt; | Table columns
-grouping | Getter | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | Columns used for grouping
+tableHeaderRows | Property | Array&lt;[TableRow](table-view.md#table-row)&gt; | Header rows to be rendered
+sorting | Property | Array&lt;[Sorting](sorting-state.md#sorting)&gt; | Column sorting
+columns | Property | Array&lt;[Column](#column)&gt; | Table columns
+grouping | Property | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | Columns used for grouping
 setColumnSorting | Action | ({ columnName: string, direction: 'asc' &#124; 'desc', keepOther: boolean, cancel: boolean }) => void | Changes column sorting
 groupByColumn | Action | ({ columnName: string, groupIndex?: number }) => void | Groups a table by the specified column or cancels grouping. If `groupIndex` is omitted, the group is added to the end of the group list.
 tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
@@ -67,4 +67,4 @@ tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A te
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableHeaderRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Table rows including header rows
+tableHeaderRows | Property | Array&lt;[TableRow](table-view.md#table-row)&gt; | Table rows including header rows

--- a/packages/dx-react-grid/docs/reference/table-row-detail.md
+++ b/packages/dx-react-grid/docs/reference/table-row-detail.md
@@ -60,9 +60,9 @@ toggleExpanded | () => void | Toggles a row's expanded state
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
-tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Body rows to be rendered
-expandedRows | Getter | Array&lt;number &#124; string&gt; | Expanded rows
+tableColumns | Property | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
+tableBodyRows | Property | Array&lt;[TableRow](table-view.md#table-row)&gt; | Body rows to be rendered
+expandedRows | Property | Array&lt;number &#124; string&gt; | Expanded rows
 setDetailRowExpanded | Action | ({ rowId }) => void | Expands the specified row
 tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
 
@@ -70,5 +70,5 @@ tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A te
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns including the detail cell
-tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Body rows to be rendered, including detailed rows
+tableColumns | Property | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns including the detail cell
+tableBodyRows | Property | Array&lt;[TableRow](table-view.md#table-row)&gt; | Body rows to be rendered, including detailed rows

--- a/packages/dx-react-grid/docs/reference/table-selection.md
+++ b/packages/dx-react-grid/docs/reference/table-selection.md
@@ -62,11 +62,11 @@ changeSelected | () => void | Selects or deselects a row
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
-tableBodyRows | Getter | Array&lt;[TableRow](#table-row)&gt; | Body rows to be rendered
-tableExtraProps | Getter | { [key: string]: any } | Additional table properties that can be provided by other plugins
-selection | Getter | Array&lt;number &#124; string&gt; | Selected rows
-availableToSelect | Getter | Array&lt;number &#124; string&gt; | Rows to be rendered, which are available for selection
+tableColumns | Property | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns
+tableBodyRows | Property | Array&lt;[TableRow](#table-row)&gt; | Body rows to be rendered
+tableExtraProps | Property | { [key: string]: any } | Additional table properties that can be provided by other plugins
+selection | Property | Array&lt;number &#124; string&gt; | Selected rows
+availableToSelect | Property | Array&lt;number &#124; string&gt; | Rows to be rendered, which are available for selection
 setRowsSelection | Action | ({ rowIds: Array&lt;number &#124; string&gt;, selected?: boolean }) => void | Selects/deselects rows. The `selected` argument specifies whether the rows should be selected (true), deselected (false), or their selection status should be set to the opposite value (undefined). In the last case, the function selects unselected rows and deselects selected ones. To select/deselect a single row, pass an array with a single item to the `rowIds` argument.
 tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell
 
@@ -74,6 +74,6 @@ tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A te
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns including the selection column
-tableBodyRows | Getter | Array&lt;[TableRow](#table-row)&gt; | Body rows to be rendered including the selected ones
-tableExtraProps | Getter | { [key: string]: any } | Additional table properties extended with the row onClick event listener
+tableColumns | Property | Array&lt;[TableColumn](table-view.md#table-column)&gt; | Table columns including the selection column
+tableBodyRows | Property | Array&lt;[TableRow](#table-row)&gt; | Body rows to be rendered including the selected ones
+tableExtraProps | Property | { [key: string]: any } | Additional table properties extended with the row onClick event listener

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -99,17 +99,17 @@ column | [Column](#column) | Specifies a table column
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be rendered by the table view
-columns | Getter | Array&lt;[Column](#column)&gt; | Columns to be rendered by the table view
-getRowId | Getter | (row: [Row](grid.md#row)) => number &#124; string | The function used to get a unique row identifier
-getCellData | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell data
+rows | Property | Array&lt;[Row](grid.md#row)&gt; | Rows to be rendered by the table view
+columns | Property | Array&lt;[Column](#column)&gt; | Columns to be rendered by the table view
+getRowId | Property | (row: [Row](grid.md#row)) => number &#124; string | The function used to get a unique row identifier
+getCellData | Property | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell data
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableHeaderRows | Getter | Array&lt;[TableRow](#table-row)&gt; | Header rows to be rendered
-tableBodyRows | Getter | Array&lt;[TableRow](#table-row)&gt; | Body rows to be rendered
-tableColumns | Getter | Array&lt;[TableColumn](#table-column)&gt; | Columns to be rendered
-tableExtraProps | Getter | { [key: string]: any } | Additional table properties that other plugins can provide
+tableHeaderRows | Property | Array&lt;[TableRow](#table-row)&gt; | Header rows to be rendered
+tableBodyRows | Property | Array&lt;[TableRow](#table-row)&gt; | Body rows to be rendered
+tableColumns | Property | Array&lt;[TableColumn](#table-column)&gt; | Columns to be rendered
+tableExtraProps | Property | { [key: string]: any } | Additional table properties that other plugins can provide
 tableViewCell | Template | [TableCellArgs](#table-cell-args) | A template that renders a table cell

--- a/packages/dx-react-grid/src/grid.jsx
+++ b/packages/dx-react-grid/src/grid.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { memoize } from '@devexpress/dx-core';
-import { PluginHost, Getter, Template, TemplatePlaceholder } from '@devexpress/dx-react-core';
+import { PluginHost, Property, Template, TemplatePlaceholder } from '@devexpress/dx-react-core';
 
 const rowIdGetter = (getRowId, rows) => {
   let rowsMap;
@@ -42,10 +42,10 @@ export class Grid extends React.PureComponent {
     } = this.props;
     return (
       <PluginHost>
-        <Getter name="rows" value={rows} />
-        <Getter name="columns" value={columns} />
-        <Getter name="getRowId" value={this.memoizedRowIdGetter(getRowId, rows)} />
-        <Getter name="getCellData" value={getCellData || this.memoizedGetCellDataGetter(columns)} />
+        <Property name="rows" value={rows} />
+        <Property name="columns" value={columns} />
+        <Property name="getRowId" value={this.memoizedRowIdGetter(getRowId, rows)} />
+        <Property name="getCellData" value={getCellData || this.memoizedGetCellDataGetter(columns)} />
         <Template name="header" />
         <Template name="body" />
         <Template name="footer" />

--- a/packages/dx-react-grid/src/grid.test.jsx
+++ b/packages/dx-react-grid/src/grid.test.jsx
@@ -140,8 +140,8 @@ describe('Grid', () => {
     >
       <Template
         name="root"
-        connectGetters={(getter) => {
-          cellData = getter('getCellData')(rows[1], columns[1].name);
+        connectProperties={(property) => {
+          cellData = property('getCellData')(rows[1], columns[1].name);
         }}
       >
         {() => <div />}
@@ -164,8 +164,8 @@ describe('Grid', () => {
     >
       <Template
         name="root"
-        connectGetters={(getter) => {
-          getter('getCellData')(rows[0], columns[0].name);
+        connectProperties={(property) => {
+          property('getCellData')(rows[0], columns[0].name);
         }}
       >
         {() => <div />}
@@ -187,8 +187,8 @@ describe('Grid', () => {
     >
       <Template
         name="root"
-        connectGetters={(getter) => {
-          getter('getCellData')(rows[0], columns[0].name);
+        connectProperties={(property) => {
+          property('getCellData')(rows[0], columns[0].name);
         }}
       >
         {() => <div />}

--- a/packages/dx-react-grid/src/plugins/column-order-state.jsx
+++ b/packages/dx-react-grid/src/plugins/column-order-state.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Action, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Action, PluginContainer } from '@devexpress/dx-react-core';
 import { orderedColumns, setColumnOrder } from '@devexpress/dx-grid-core';
 
 export class ColumnOrderState extends React.PureComponent {
@@ -31,7 +31,7 @@ export class ColumnOrderState extends React.PureComponent {
       <PluginContainer
         pluginName="ColumnOrderState"
       >
-        <Getter name="columns" computed={columnsComputed} />
+        <Property name="columns" computed={columnsComputed} />
         <Action
           name="setColumnOrder"
           action={({ sourceColumnName, targetColumnName }) =>

--- a/packages/dx-react-grid/src/plugins/column-order-state.test.jsx
+++ b/packages/dx-react-grid/src/plugins/column-order-state.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import { setupConsole } from '@devexpress/dx-testing';
-import { Template, Getter, PluginHost } from '@devexpress/dx-react-core';
+import { Template, Property, PluginHost } from '@devexpress/dx-react-core';
 
 import { ColumnOrderState } from './column-order-state';
 
@@ -19,7 +19,7 @@ describe('ColumnOrderState', () => {
     let orderedColumns;
     mount(
       <PluginHost>
-        <Getter
+        <Property
           name="columns"
           value={[{ name: 'a' }, { name: 'b' }]}
         />
@@ -28,7 +28,7 @@ describe('ColumnOrderState', () => {
         />
         <Template
           name="root"
-          connectGetters={(getter) => { orderedColumns = getter('columns'); }}
+          connectProperties={(property) => { orderedColumns = property('columns'); }}
         >
           {() => <div />}
         </Template>
@@ -43,7 +43,7 @@ describe('ColumnOrderState', () => {
     let orderedColumns;
     mount(
       <PluginHost>
-        <Getter
+        <Property
           name="columns"
           value={[{ name: 'a' }, { name: 'b' }]}
         />
@@ -52,7 +52,7 @@ describe('ColumnOrderState', () => {
         />
         <Template
           name="root"
-          connectGetters={(getter) => { orderedColumns = getter('columns'); }}
+          connectProperties={(property) => { orderedColumns = property('columns'); }}
         >
           {() => <div />}
         </Template>
@@ -69,7 +69,7 @@ describe('ColumnOrderState', () => {
     let setColumnOrder;
     mount(
       <PluginHost>
-        <Getter
+        <Property
           name="columns"
           value={[{ name: 'a' }, { name: 'b' }]}
         />
@@ -79,7 +79,7 @@ describe('ColumnOrderState', () => {
         />
         <Template
           name="root"
-          connectGetters={(getter) => { orderedColumns = getter('columns'); }}
+          connectProperties={(property) => { orderedColumns = property('columns'); }}
           connectActions={(action) => { setColumnOrder = action('setColumnOrder'); }}
         >
           {() => <div />}
@@ -104,7 +104,7 @@ describe('ColumnOrderState', () => {
     let setColumnOrder;
     mount(
       <PluginHost>
-        <Getter
+        <Property
           name="columns"
           value={[{ name: 'a' }, { name: 'b' }]}
         />
@@ -114,7 +114,7 @@ describe('ColumnOrderState', () => {
         />
         <Template
           name="root"
-          connectGetters={(getter) => { orderedColumns = getter('columns'); }}
+          connectProperties={(property) => { orderedColumns = property('columns'); }}
           connectActions={(action) => { setColumnOrder = action('setColumnOrder'); }}
         >
           {() => <div />}

--- a/packages/dx-react-grid/src/plugins/drag-drop-context.jsx
+++ b/packages/dx-react-grid/src/plugins/drag-drop-context.jsx
@@ -32,8 +32,8 @@ export class DragDropContext extends React.PureComponent {
       >
         <Template
           name="root"
-          connectGetters={getter => ({
-            columns: getter('columns'),
+          connectProperties={property => ({
+            columns: property('columns'),
           })}
         >
           {({ columns }) => (

--- a/packages/dx-react-grid/src/plugins/drag-drop-context.test.jsx
+++ b/packages/dx-react-grid/src/plugins/drag-drop-context.test.jsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 
 import { setupConsole } from '@devexpress/dx-testing';
 import {
-  Getter, PluginHost,
+  Property, PluginHost,
   DragDropContext as DragDropContextCore,
 } from '@devexpress/dx-react-core';
 
@@ -21,7 +21,7 @@ describe('DragDropContext', () => {
   it('should not render container if dragging is not started', () => {
     const tree = mount(
       <PluginHost>
-        <Getter
+        <Property
           name="columns"
           value={[{ name: 'a' }, { name: 'b' }]}
         />
@@ -39,7 +39,7 @@ describe('DragDropContext', () => {
   it('should render container while dragging', () => {
     const tree = mount(
       <PluginHost>
-        <Getter
+        <Property
           name="columns"
           value={[{ name: 'a', title: 'A' }, { name: 'b', title: 'B' }]}
         />

--- a/packages/dx-react-grid/src/plugins/editing-state.jsx
+++ b/packages/dx-react-grid/src/plugins/editing-state.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Action, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Action, PluginContainer } from '@devexpress/dx-react-core';
 import {
   startEditRows,
   stopEditRows,
@@ -166,11 +166,11 @@ export class EditingState extends React.PureComponent {
           action={({ rowIds }) => this._commitDeletedRows(deletedRows, { rowIds })}
         />
 
-        <Getter name="editingRows" value={editingRows} />
-        <Getter name="changedRows" value={changedRows} />
-        <Getter name="addedRows" value={addedRows} />
-        <Getter name="deletedRows" value={deletedRows} />
-        <Getter
+        <Property name="editingRows" value={editingRows} />
+        <Property name="changedRows" value={changedRows} />
+        <Property name="addedRows" value={addedRows} />
+        <Property name="deletedRows" value={deletedRows} />
+        <Property
           name="createRowChange"
           computed={createRowChange ?
           () => createRowChange :

--- a/packages/dx-react-grid/src/plugins/editing-state.test.jsx
+++ b/packages/dx-react-grid/src/plugins/editing-state.test.jsx
@@ -42,7 +42,7 @@ describe('EditingState', () => {
         createRowChange: createRowChangeMock,
         onCommitChanges: () => {},
       }, {
-        connectGetters: (getter) => { createRowChange = getter('createRowChange'); },
+        connectProperties: (property) => { createRowChange = property('createRowChange'); },
       });
 
       createRowChange(rows[0], columns[0].name, 3);

--- a/packages/dx-react-grid/src/plugins/filtering-state.jsx
+++ b/packages/dx-react-grid/src/plugins/filtering-state.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Action, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Action, PluginContainer } from '@devexpress/dx-react-core';
 import { setColumnFilter } from '@devexpress/dx-grid-core';
 
 export class FilteringState extends React.PureComponent {
@@ -34,7 +34,7 @@ export class FilteringState extends React.PureComponent {
           }
         />
 
-        <Getter name="filters" value={filters} />
+        <Property name="filters" value={filters} />
       </PluginContainer>
     );
   }

--- a/packages/dx-react-grid/src/plugins/grouping-panel.jsx
+++ b/packages/dx-react-grid/src/plugins/grouping-panel.jsx
@@ -23,10 +23,10 @@ export class GroupingPanel extends React.PureComponent {
       >
         <Template
           name="header"
-          connectGetters={getter => ({
-            columns: getter('columns'),
-            grouping: getter('draftGrouping'),
-            sorting: getter('sorting'),
+          connectProperties={property => ({
+            columns: property('columns'),
+            grouping: property('draftGrouping'),
+            sorting: property('sorting'),
           })}
           connectActions={action => ({
             groupByColumn: action('groupByColumn'),

--- a/packages/dx-react-grid/src/plugins/grouping-state.jsx
+++ b/packages/dx-react-grid/src/plugins/grouping-state.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Action, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Action, PluginContainer } from '@devexpress/dx-react-core';
 import {
   groupByColumn,
   toggleExpandedGroups,
@@ -101,9 +101,9 @@ export class GroupingState extends React.PureComponent {
           action={() => { this.cancelGroupingChange(); }}
         />
 
-        <Getter name="grouping" value={grouping} />
-        <Getter name="draftGrouping" value={draftGrouping} />
-        <Getter name="expandedGroups" value={expandedGroupsSet} />
+        <Property name="grouping" value={grouping} />
+        <Property name="draftGrouping" value={draftGrouping} />
+        <Property name="expandedGroups" value={expandedGroupsSet} />
       </PluginContainer>
     );
   }

--- a/packages/dx-react-grid/src/plugins/grouping-state.test.jsx
+++ b/packages/dx-react-grid/src/plugins/grouping-state.test.jsx
@@ -41,7 +41,7 @@ describe('GroupingState', () => {
         defaultGrouping: grouping,
         onGroupingChange,
       }, {
-        connectGetters: (getter) => { grouping = Array.from(getter('grouping')); },
+        connectProperties: (property) => { grouping = Array.from(property('grouping')); },
         connectActions: (action) => { groupByColumn = action('groupByColumn'); },
       });
 
@@ -62,7 +62,7 @@ describe('GroupingState', () => {
         grouping: [{ columnName: 'b' }],
         onGroupingChange,
       }, {
-        connectGetters: (getter) => { grouping = Array.from(getter('grouping')); },
+        connectProperties: (property) => { grouping = Array.from(property('grouping')); },
         connectActions: (action) => { groupByColumn = action('groupByColumn'); },
       });
 
@@ -83,7 +83,7 @@ describe('GroupingState', () => {
         defaultGrouping: grouping,
         onGroupingChange: groupingChange,
       }, {
-        connectGetters: (getter) => { grouping = Array.from(getter('grouping')); },
+        connectProperties: (property) => { grouping = Array.from(property('grouping')); },
         connectActions: (action) => { groupByColumn = action('groupByColumn'); },
       });
 
@@ -105,7 +105,7 @@ describe('GroupingState', () => {
       mountPlugin({
         onExpandedGroupsChange: expandedGroupsChangeMock,
       }, {
-        connectGetters: (getter) => { expandedGroups = Array.from(getter('expandedGroups')); },
+        connectProperties: (property) => { expandedGroups = Array.from(property('expandedGroups')); },
         connectActions: (action) => { toggleGroupExpanded = action('toggleGroupExpanded'); },
       });
 
@@ -126,7 +126,7 @@ describe('GroupingState', () => {
         expandedGroups: [],
         onExpandedGroupsChange: expandedGroupsChangeMock,
       }, {
-        connectGetters: (getter) => { expandedGroups = Array.from(getter('expandedGroups')); },
+        connectProperties: (property) => { expandedGroups = Array.from(property('expandedGroups')); },
         connectActions: (action) => { toggleGroupExpanded = action('toggleGroupExpanded'); },
       });
 
@@ -147,7 +147,7 @@ describe('GroupingState', () => {
         defaultExpandedGroups: ['a'],
         onExpandedGroupsChange: expandedGroupsChangeMock,
       }, {
-        connectGetters: (getter) => { expandedGroups = Array.from(getter('expandedGroups')); },
+        connectProperties: (property) => { expandedGroups = Array.from(property('expandedGroups')); },
         connectActions: (action) => { toggleGroupExpanded = action('toggleGroupExpanded'); },
       });
 
@@ -171,7 +171,7 @@ describe('GroupingState', () => {
         defaultExpandedGroups: ['John'],
         onExpandedGroupsChange: expandedGroupsChangeMock,
       }, {
-        connectGetters: (getter) => { expandedGroups = Array.from(getter('expandedGroups')); },
+        connectProperties: (property) => { expandedGroups = Array.from(property('expandedGroups')); },
         connectActions: (action) => { groupByColumn = action('groupByColumn'); },
       });
 
@@ -193,7 +193,7 @@ describe('GroupingState', () => {
         defaultExpandedGroups: ['John', 'John|30', 'Mike'],
         onExpandedGroupsChange: expandedGroupsChangeMock,
       }, {
-        connectGetters: (getter) => { expandedGroups = Array.from(getter('expandedGroups')); },
+        connectProperties: (property) => { expandedGroups = Array.from(property('expandedGroups')); },
         connectActions: (action) => { groupByColumn = action('groupByColumn'); },
       });
 
@@ -215,7 +215,7 @@ describe('GroupingState', () => {
         defaultExpandedGroups: ['John', 'Mike'],
         onExpandedGroupsChange: expandedGroupsChangeMock,
       }, {
-        connectGetters: (getter) => { expandedGroups = Array.from(getter('expandedGroups')); },
+        connectProperties: (property) => { expandedGroups = Array.from(property('expandedGroups')); },
         connectActions: (action) => { groupByColumn = action('groupByColumn'); },
       });
 
@@ -270,7 +270,7 @@ describe('GroupingState', () => {
       mountPlugin(
         { grouping: [] },
         {
-          connectGetters: (getter) => { draftGrouping = getter('draftGrouping'); },
+          connectProperties: (property) => { draftGrouping = property('draftGrouping'); },
           connectActions: (action) => { draftGroupingChange = action('draftGroupingChange'); },
         },
       );
@@ -290,7 +290,7 @@ describe('GroupingState', () => {
       mountPlugin(
         { grouping: [{ columnName: 'a' }] },
         {
-          connectGetters: (getter) => { draftGrouping = getter('draftGrouping'); },
+          connectProperties: (property) => { draftGrouping = property('draftGrouping'); },
           connectActions: (action) => {
             draftGroupingChange = action('draftGroupingChange');
             cancelGroupingChange = action('cancelGroupingChange');

--- a/packages/dx-react-grid/src/plugins/local-filtering.jsx
+++ b/packages/dx-react-grid/src/plugins/local-filtering.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, PluginContainer } from '@devexpress/dx-react-core';
 import { filteredRows } from '@devexpress/dx-grid-core';
 
 const pluginDependencies = [
@@ -19,7 +19,7 @@ export class LocalFiltering extends React.PureComponent {
         pluginName="LocalFiltering"
         dependencies={pluginDependencies}
       >
-        <Getter name="rows" computed={rowsComputed} />
+        <Property name="rows" computed={rowsComputed} />
       </PluginContainer>
     );
   }

--- a/packages/dx-react-grid/src/plugins/local-grouping.jsx
+++ b/packages/dx-react-grid/src/plugins/local-grouping.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Getter, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, PluginContainer } from '@devexpress/dx-react-core';
 import { groupedRows, expandedGroupRows } from '@devexpress/dx-grid-core';
 
 const pluginDependencies = [
@@ -19,8 +19,8 @@ export class LocalGrouping extends React.PureComponent {
         pluginName="LocalGrouping"
         dependencies={pluginDependencies}
       >
-        <Getter name="rows" computed={groupedRowsComputed} />
-        <Getter name="rows" computed={expandedGroupedRowsComputed} />
+        <Property name="rows" computed={groupedRowsComputed} />
+        <Property name="rows" computed={expandedGroupedRowsComputed} />
       </PluginContainer>
     );
   }

--- a/packages/dx-react-grid/src/plugins/local-paging.jsx
+++ b/packages/dx-react-grid/src/plugins/local-paging.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Getter, Watcher, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Watcher, PluginContainer } from '@devexpress/dx-react-core';
 import { paginate, ensurePageHeaders, pageCount, rowCount } from '@devexpress/dx-grid-core';
 
 const pluginDependencies = [
@@ -20,13 +20,13 @@ export class LocalPaging extends React.PureComponent {
         pluginName="LocalPaging"
         dependencies={pluginDependencies}
       >
-        <Getter name="rows" computed={rowsWithHeadersComputed} />
-        <Getter name="totalCount" computed={totalCountComputed} />
+        <Property name="rows" computed={rowsWithHeadersComputed} />
+        <Property name="totalCount" computed={totalCountComputed} />
         <Watcher
-          watch={getter => [
-            getter('totalCount'),
-            getter('currentPage'),
-            getter('pageSize'),
+          watch={property => [
+            property('totalCount'),
+            property('currentPage'),
+            property('pageSize'),
           ]}
           onChange={(action, totalCount, currentPage, pageSize) => {
             const totalPages = pageCount(totalCount, pageSize);
@@ -35,7 +35,7 @@ export class LocalPaging extends React.PureComponent {
             }
           }}
         />
-        <Getter name="rows" computed={paginatedRowsComputed} />
+        <Property name="rows" computed={paginatedRowsComputed} />
       </PluginContainer>
     );
   }

--- a/packages/dx-react-grid/src/plugins/local-paging.test.jsx
+++ b/packages/dx-react-grid/src/plugins/local-paging.test.jsx
@@ -14,7 +14,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 }));
 
 const defaultDeps = {
-  getter: {
+  property: {
     rows: [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
     currentPage: 1,
     pageSize: 2,
@@ -52,11 +52,11 @@ describe('LocalPaging', () => {
       </PluginHost>,
     );
 
-    expect(deps.computedGetter('totalCount'))
+    expect(deps.computedProperty('totalCount'))
       .toBe(6);
   });
 
-  it('should paginate rows passed into based on the "currentPage" and "pageSize" getters', () => {
+  it('should paginate rows passed into based on the "currentPage" and "pageSize" properties', () => {
     const deps = {};
     mount(
       <PluginHost>
@@ -65,13 +65,13 @@ describe('LocalPaging', () => {
       </PluginHost>,
     );
 
-    expect(deps.computedGetter('rows'))
+    expect(deps.computedProperty('rows'))
       .toEqual([{ id: 2 }, { id: 3 }]);
   });
 
   it('should change the "currentPage" if starting row index exceeds the rows count', () => {
     const deps = {
-      getter: {
+      property: {
         currentPage: 4,
       },
     };
@@ -96,6 +96,6 @@ describe('LocalPaging', () => {
     );
 
     expect(ensurePageHeaders)
-      .toHaveBeenCalledWith(defaultDeps.getter.rows, defaultDeps.getter.pageSize);
+      .toHaveBeenCalledWith(defaultDeps.property.rows, defaultDeps.property.pageSize);
   });
 });

--- a/packages/dx-react-grid/src/plugins/local-sorting.jsx
+++ b/packages/dx-react-grid/src/plugins/local-sorting.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Getter, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, PluginContainer } from '@devexpress/dx-react-core';
 import { sortedRows } from '@devexpress/dx-grid-core';
 
 const pluginDependencies = [
@@ -16,7 +16,7 @@ export class LocalSorting extends React.PureComponent {
         pluginName="LocalSorting"
         dependencies={pluginDependencies}
       >
-        <Getter name="rows" computed={rowsComputed} />
+        <Property name="rows" computed={rowsComputed} />
       </PluginContainer>
     );
   }

--- a/packages/dx-react-grid/src/plugins/paging-panel.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-panel.jsx
@@ -18,11 +18,11 @@ export class PagingPanel extends React.PureComponent {
       >
         <Template
           name="footer"
-          connectGetters={(getter) => {
-            const pageSize = getter('pageSize');
-            const totalCount = getter('totalCount');
+          connectProperties={(property) => {
+            const pageSize = property('pageSize');
+            const totalCount = property('totalCount');
             return {
-              currentPage: getter('currentPage'),
+              currentPage: property('currentPage'),
               totalPages: pageCount(totalCount, pageSize),
               pageSize,
               totalCount,

--- a/packages/dx-react-grid/src/plugins/paging-panel.test.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-panel.test.jsx
@@ -11,7 +11,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 }));
 
 const defaultDeps = {
-  getter: {
+  property: {
     currentPage: 1,
     pageSize: 2,
     totalCount: 21,

--- a/packages/dx-react-grid/src/plugins/paging-state.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-state.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Action, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Action, PluginContainer } from '@devexpress/dx-react-core';
 import { setCurrentPage, setPageSize } from '@devexpress/dx-grid-core';
 
 export class PagingState extends React.PureComponent {
@@ -44,9 +44,9 @@ export class PagingState extends React.PureComponent {
         <Action name="setCurrentPage" action={page => this._setCurrentPage(page)} />
         <Action name="setPageSize" action={size => this._setPageSize(size)} />
 
-        <Getter name="currentPage" value={currentPage} />
-        <Getter name="pageSize" value={pageSize} />
-        <Getter name="totalCount" value={totalCount} />
+        <Property name="currentPage" value={currentPage} />
+        <Property name="pageSize" value={pageSize} />
+        <Property name="totalCount" value={totalCount} />
       </PluginContainer>
     );
   }

--- a/packages/dx-react-grid/src/plugins/paging-state.test.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-state.test.jsx
@@ -25,7 +25,7 @@ describe('PagingState', () => {
           />
           <Template
             name="root"
-            connectGetters={(getter) => { currentPage = getter('currentPage'); }}
+            connectProperties={(property) => { currentPage = property('currentPage'); }}
           >
             {() => <div />}
           </Template>
@@ -45,7 +45,7 @@ describe('PagingState', () => {
           />
           <Template
             name="root"
-            connectGetters={(getter) => { currentPage = getter('currentPage'); }}
+            connectProperties={(property) => { currentPage = property('currentPage'); }}
           >
             {() => <div />}
           </Template>
@@ -68,7 +68,7 @@ describe('PagingState', () => {
           />
           <Template
             name="root"
-            connectGetters={(getter) => { currentPage = getter('currentPage'); }}
+            connectProperties={(property) => { currentPage = property('currentPage'); }}
             connectActions={(action) => { setCurrentPage = action('setCurrentPage'); }}
           >
             {() => <div />}
@@ -96,7 +96,7 @@ describe('PagingState', () => {
           />
           <Template
             name="root"
-            connectGetters={(getter) => { currentPage = getter('currentPage'); }}
+            connectProperties={(property) => { currentPage = property('currentPage'); }}
             connectActions={(action) => { setCurrentPage = action('setCurrentPage'); }}
           >
             {() => <div />}
@@ -123,7 +123,7 @@ describe('PagingState', () => {
           />
           <Template
             name="root"
-            connectGetters={(getter) => { pageSize = getter('pageSize'); }}
+            connectProperties={(property) => { pageSize = property('pageSize'); }}
           >
             {() => <div />}
           </Template>
@@ -143,7 +143,7 @@ describe('PagingState', () => {
           />
           <Template
             name="root"
-            connectGetters={(getter) => { pageSize = getter('pageSize'); }}
+            connectProperties={(property) => { pageSize = property('pageSize'); }}
           >
             {() => <div />}
           </Template>
@@ -166,7 +166,7 @@ describe('PagingState', () => {
           />
           <Template
             name="root"
-            connectGetters={(getter) => { pageSize = getter('pageSize'); }}
+            connectProperties={(property) => { pageSize = property('pageSize'); }}
             connectActions={(action) => { setPageSize = action('setPageSize'); }}
           >
             {() => <div />}
@@ -194,7 +194,7 @@ describe('PagingState', () => {
           />
           <Template
             name="root"
-            connectGetters={(getter) => { pageSize = getter('pageSize'); }}
+            connectProperties={(property) => { pageSize = property('pageSize'); }}
             connectActions={(action) => { setPageSize = action('setPageSize'); }}
           >
             {() => <div />}
@@ -221,7 +221,7 @@ describe('PagingState', () => {
           />
           <Template
             name="root"
-            connectGetters={(getter) => { totalCount = getter('totalCount'); }}
+            connectProperties={(property) => { totalCount = property('totalCount'); }}
           >
             {() => <div />}
           </Template>
@@ -239,7 +239,7 @@ describe('PagingState', () => {
           <PagingState />
           <Template
             name="root"
-            connectGetters={(getter) => { totalCount = getter('totalCount'); }}
+            connectProperties={(property) => { totalCount = property('totalCount'); }}
           >
             {() => <div />}
           </Template>

--- a/packages/dx-react-grid/src/plugins/row-detail-state.jsx
+++ b/packages/dx-react-grid/src/plugins/row-detail-state.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Action, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Action, PluginContainer } from '@devexpress/dx-react-core';
 import { setDetailRowExpanded } from '@devexpress/dx-grid-core';
 
 export class RowDetailState extends React.PureComponent {
@@ -33,7 +33,7 @@ export class RowDetailState extends React.PureComponent {
           action={({ rowId }) => this._setDetailRowExpanded({ rowId })}
         />
 
-        <Getter name="expandedRows" value={expandedRows} />
+        <Property name="expandedRows" value={expandedRows} />
       </PluginContainer>
     );
   }

--- a/packages/dx-react-grid/src/plugins/selection-state.jsx
+++ b/packages/dx-react-grid/src/plugins/selection-state.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Action, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Action, PluginContainer } from '@devexpress/dx-react-core';
 import { setRowsSelection, getAvailableSelection, getAvailableToSelect } from '@devexpress/dx-grid-core';
 
 const availableToSelectComputed = ({ rows, getRowId }) => getAvailableToSelect(rows, getRowId);
@@ -38,8 +38,8 @@ export class SelectionState extends React.PureComponent {
           }}
         />
 
-        <Getter name="availableToSelect" computed={availableToSelectComputed} />
-        <Getter name="selection" computed={selectionComputed} />
+        <Property name="availableToSelect" computed={availableToSelectComputed} />
+        <Property name="selection" computed={selectionComputed} />
       </PluginContainer>
     );
   }

--- a/packages/dx-react-grid/src/plugins/sorting-state.jsx
+++ b/packages/dx-react-grid/src/plugins/sorting-state.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Action, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Action, PluginContainer } from '@devexpress/dx-react-core';
 import { setColumnSorting } from '@devexpress/dx-grid-core';
 
 export class SortingState extends React.PureComponent {
@@ -34,7 +34,7 @@ export class SortingState extends React.PureComponent {
           }}
         />
 
-        <Getter name="sorting" value={sorting} />
+        <Property name="sorting" value={sorting} />
       </PluginContainer>
     );
   }

--- a/packages/dx-react-grid/src/plugins/table-edit-column.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Template, PluginContainer } from '@devexpress/dx-react-core';
 import {
   tableColumnsWithEditing,
   isHeadingEditCommandsTableCell,
@@ -33,7 +33,7 @@ export class TableEditColumn extends React.PureComponent {
         pluginName="TableEditColumn"
         dependencies={pluginDependencies}
       >
-        <Getter name="tableColumns" computed={tableColumnsComputed} />
+        <Property name="tableColumns" computed={tableColumnsComputed} />
         <Template
           name="tableViewCell"
           predicate={({ tableRow, tableColumn }) =>

--- a/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
@@ -21,7 +21,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 }));
 
 const defaultDeps = {
-  getter: {
+  property: {
     tableColumns: [{ type: 'undefined' }],
   },
   action: {
@@ -71,7 +71,7 @@ describe('TableHeaderRow', () => {
     jest.resetAllMocks();
   });
 
-  describe('table layout getters', () => {
+  describe('table layout properties', () => {
     it('should extend tableColumns', () => {
       const deps = {};
       mount(
@@ -84,10 +84,10 @@ describe('TableHeaderRow', () => {
         </PluginHost>,
       );
 
-      expect(deps.computedGetter('tableColumns'))
+      expect(deps.computedProperty('tableColumns'))
         .toBe('tableColumnsWithEditing');
       expect(tableColumnsWithEditing)
-        .toBeCalledWith(defaultDeps.getter.tableColumns, 120);
+        .toBeCalledWith(defaultDeps.property.tableColumns, 120);
     });
   });
 

--- a/packages/dx-react-grid/src/plugins/table-edit-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Template, PluginContainer } from '@devexpress/dx-react-core';
 import {
   getRowChange,
   tableRowsWithEditing,
@@ -25,18 +25,18 @@ export class TableEditRow extends React.PureComponent {
         pluginName="TableEditRow"
         dependencies={pluginDependencies}
       >
-        <Getter name="tableBodyRows" computed={tableBodyRowsComputed} />
+        <Property name="tableBodyRows" computed={tableBodyRowsComputed} />
         <Template
           name="tableViewCell"
           predicate={({ tableRow, tableColumn }) => isEditExistingTableCell(tableRow, tableColumn)}
-          connectGetters={(getter, { tableColumn: { column }, tableRow: { rowId, row } }) => {
-            const change = getRowChange(getter('changedRows'), rowId);
+          connectProperties={(property, { tableColumn: { column }, tableRow: { rowId, row } }) => {
+            const change = getRowChange(property('changedRows'), rowId);
             const changedRow = { ...row, ...change };
-            const getCellData = getter('getCellData');
+            const getCellData = property('getCellData');
             const value = getCellData(changedRow, column.name);
 
             return {
-              createRowChange: getter('createRowChange'),
+              createRowChange: property('createRowChange'),
               value,
               changedRow,
             };
@@ -71,9 +71,9 @@ export class TableEditRow extends React.PureComponent {
         <Template
           name="tableViewCell"
           predicate={({ tableRow, tableColumn }) => isEditNewTableCell(tableRow, tableColumn)}
-          connectGetters={getter => ({
-            getCellData: getter('getCellData'),
-            createRowChange: getter('createRowChange'),
+          connectProperties={property => ({
+            getCellData: property('getCellData'),
+            createRowChange: property('createRowChange'),
           })}
           connectActions={action => ({
             changeAddedRow: ({ rowId, change }) => action('changeAddedRow')({ rowId, change }),

--- a/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
@@ -19,7 +19,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 }));
 
 const defaultDeps = {
-  getter: {
+  property: {
     tableBodyRows: [{ type: 'undefined', rowId: 1 }],
     editingRows: [1, 2],
     addedRows: [{ a: 'text' }, {}],
@@ -64,7 +64,7 @@ describe('TableHeaderRow', () => {
     jest.resetAllMocks();
   });
 
-  describe('table layout getters', () => {
+  describe('table layout properties', () => {
     it('should extend tableBodyRows', () => {
       const deps = {};
       mount(
@@ -77,13 +77,13 @@ describe('TableHeaderRow', () => {
         </PluginHost>,
       );
 
-      expect(deps.computedGetter('tableBodyRows'))
+      expect(deps.computedProperty('tableBodyRows'))
         .toBe('tableRowsWithEditing');
       expect(tableRowsWithEditing)
         .toBeCalledWith(
-          defaultDeps.getter.tableBodyRows,
-          defaultDeps.getter.editingRows,
-          defaultDeps.getter.addedRows,
+          defaultDeps.property.tableBodyRows,
+          defaultDeps.property.editingRows,
+          defaultDeps.property.addedRows,
           120,
         );
     });
@@ -103,7 +103,7 @@ describe('TableHeaderRow', () => {
       </PluginHost>,
     );
 
-    expect(defaultDeps.getter.getCellData).toBeCalledWith(
+    expect(defaultDeps.property.getCellData).toBeCalledWith(
       defaultDeps.template.tableViewCell.tableRow.row,
       defaultDeps.template.tableViewCell.tableColumn.column.name,
     );
@@ -134,7 +134,7 @@ describe('TableHeaderRow', () => {
       </PluginHost>,
     );
 
-    expect(defaultDeps.getter.getCellData).toBeCalledWith(
+    expect(defaultDeps.property.getCellData).toBeCalledWith(
       { ...defaultDeps.template.tableViewCell.tableRow.row },
       defaultDeps.template.tableViewCell.tableColumn.column.name,
     );
@@ -170,7 +170,7 @@ describe('TableHeaderRow', () => {
     const onValueChange = editCellTemplate.mock.calls[0][0].onValueChange;
     onValueChange('test');
 
-    const createRowChangeArgs = defaultDeps.getter.createRowChange.mock.calls[0];
+    const createRowChangeArgs = defaultDeps.property.createRowChange.mock.calls[0];
 
     expect(createRowChangeArgs[0]).toEqual({
       a: undefined,

--- a/packages/dx-react-grid/src/plugins/table-filter-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-filter-row.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Template, PluginContainer } from '@devexpress/dx-react-core';
 import {
   getColumnFilterConfig,
   tableHeaderRowsWithFilter,
@@ -24,12 +24,12 @@ export class TableFilterRow extends React.PureComponent {
         pluginName="TableFilterRow"
         dependencies={pluginDependencies}
       >
-        <Getter name="tableHeaderRows" computed={tableHeaderRowsComputed} />
+        <Property name="tableHeaderRows" computed={tableHeaderRowsComputed} />
         <Template
           name="tableViewCell"
           predicate={({ tableRow, tableColumn }) => isFilterTableCell(tableRow, tableColumn)}
-          connectGetters={(getter, { tableColumn: { column } }) => ({
-            filter: getColumnFilterConfig(getter('filters'), column.name),
+          connectProperties={(property, { tableColumn: { column } }) => ({
+            filter: getColumnFilterConfig(property('filters'), column.name),
           })}
           connectActions={(action, { tableColumn: { column } }) => ({
             setFilter: config => action('setColumnFilter')({ columnName: column.name, config }),

--- a/packages/dx-react-grid/src/plugins/table-filter-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-filter-row.test.jsx
@@ -16,7 +16,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 }));
 
 const defaultDeps = {
-  getter: {
+  property: {
     tableHeaderRows: [{ type: 'undefined', rowId: 1 }],
     filters: [{ columnName: 'a', value: 'b' }],
   },
@@ -54,7 +54,7 @@ describe('TableHeaderRow', () => {
     jest.resetAllMocks();
   });
 
-  describe('table layout getters', () => {
+  describe('table layout properties', () => {
     it('should extend tableHeaderRows', () => {
       const deps = {};
       mount(
@@ -67,10 +67,10 @@ describe('TableHeaderRow', () => {
         </PluginHost>,
       );
 
-      expect(deps.computedGetter('tableHeaderRows'))
+      expect(deps.computedProperty('tableHeaderRows'))
         .toBe('tableHeaderRowsWithFilter');
       expect(tableHeaderRowsWithFilter)
-        .toBeCalledWith(defaultDeps.getter.tableHeaderRows, 120);
+        .toBeCalledWith(defaultDeps.property.tableHeaderRows, 120);
     });
   });
 

--- a/packages/dx-react-grid/src/plugins/table-group-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-group-row.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Template, PluginContainer } from '@devexpress/dx-react-core';
 import {
   tableColumnsWithGrouping,
   tableRowsWithGrouping,
@@ -31,13 +31,13 @@ export class TableGroupRow extends React.PureComponent {
         pluginName="TableGroupRow"
         dependencies={pluginDependencies}
       >
-        <Getter name="tableColumns" computed={tableColumnsComputed} />
-        <Getter name="tableBodyRows" computed={tableBodyRowsComputed} />
+        <Property name="tableColumns" computed={tableColumnsComputed} />
+        <Property name="tableBodyRows" computed={tableBodyRowsComputed} />
 
         <Template
           name="tableViewCell"
           predicate={({ tableRow, tableColumn }) => isGroupTableCell(tableRow, tableColumn)}
-          connectGetters={getter => ({ expandedGroups: getter('expandedGroups') })}
+          connectProperties={property => ({ expandedGroups: property('expandedGroups') })}
           connectActions={action => ({ toggleGroupExpanded: action('toggleGroupExpanded') })}
         >
           {({ expandedGroups, toggleGroupExpanded, ...params }) => groupCellTemplate({

--- a/packages/dx-react-grid/src/plugins/table-group-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-group-row.test.jsx
@@ -19,7 +19,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 }));
 
 const defaultDeps = {
-  getter: {
+  property: {
     tableColumns: [{ type: 'undefined', id: 1, column: 'column' }],
     tableBodyRows: [{ type: 'undefined', id: 1, row: 'row' }],
     grouping: [{ columnName: 'a' }],
@@ -66,7 +66,7 @@ describe('TableGroupRow', () => {
     jest.resetAllMocks();
   });
 
-  describe('table layout getters extending', () => {
+  describe('table layout properties extending', () => {
     it('should extend tableBodyRows', () => {
       const deps = {};
 
@@ -79,10 +79,10 @@ describe('TableGroupRow', () => {
         </PluginHost>,
       );
 
-      expect(deps.computedGetter('tableBodyRows'))
+      expect(deps.computedProperty('tableBodyRows'))
         .toBe('tableRowsWithGrouping');
       expect(tableRowsWithGrouping)
-        .toBeCalledWith(defaultDeps.getter.tableBodyRows);
+        .toBeCalledWith(defaultDeps.property.tableBodyRows);
     });
 
     it('should extend tableColumns', () => {
@@ -97,13 +97,13 @@ describe('TableGroupRow', () => {
         </PluginHost>,
       );
 
-      expect(deps.computedGetter('tableColumns'))
+      expect(deps.computedProperty('tableColumns'))
         .toBe('tableColumnsWithGrouping');
       expect(tableColumnsWithGrouping)
         .toBeCalledWith(
-          defaultDeps.getter.tableColumns,
-          defaultDeps.getter.grouping,
-          defaultDeps.getter.draftGrouping,
+          defaultDeps.property.tableColumns,
+          defaultDeps.property.grouping,
+          defaultDeps.property.draftGrouping,
           defaultProps.groupIndentColumnWidth,
         );
     });

--- a/packages/dx-react-grid/src/plugins/table-header-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-header-row.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Template, PluginContainer } from '@devexpress/dx-react-core';
 import {
   getColumnSortingDirection,
   tableRowsWithHeading,
@@ -23,15 +23,15 @@ export class TableHeaderRow extends React.PureComponent {
           { pluginName: 'DragDropContext', optional: !allowDragging },
         ]}
       >
-        <Getter name="tableHeaderRows" computed={tableHeaderRowsComputed} />
+        <Property name="tableHeaderRows" computed={tableHeaderRowsComputed} />
 
         <Template
           name="tableViewCell"
           predicate={({ tableRow, tableColumn }) => isHeadingTableCell(tableRow, tableColumn)}
-          connectGetters={(getter, { tableColumn: { column } }) => {
-            const sorting = getter('sorting');
-            const columns = getter('columns');
-            const grouping = getter('grouping');
+          connectProperties={(property, { tableColumn: { column } }) => {
+            const sorting = property('sorting');
+            const columns = property('columns');
+            const grouping = property('grouping');
 
             const groupingSupported = grouping !== undefined &&
                 grouping.length < columns.length - 1;

--- a/packages/dx-react-grid/src/plugins/table-header-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-header-row.test.jsx
@@ -15,7 +15,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 }));
 
 const defaultDeps = {
-  getter: {
+  property: {
     columns: [{ name: 'a' }],
     tableHeaderRows: [{ type: 'undefined', rowId: 1 }],
   },
@@ -50,7 +50,7 @@ describe('TableHeaderRow', () => {
     jest.resetAllMocks();
   });
 
-  describe('table layout getters', () => {
+  describe('table layout properties', () => {
     it('should extend tableHeaderRows', () => {
       const deps = {};
       mount(
@@ -62,10 +62,10 @@ describe('TableHeaderRow', () => {
         </PluginHost>,
       );
 
-      expect(deps.computedGetter('tableHeaderRows'))
+      expect(deps.computedProperty('tableHeaderRows'))
         .toBe('tableRowsWithHeading');
       expect(tableRowsWithHeading)
-        .toBeCalledWith(defaultDeps.getter.tableHeaderRows);
+        .toBeCalledWith(defaultDeps.property.tableHeaderRows);
     });
   });
 

--- a/packages/dx-react-grid/src/plugins/table-row-detail.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Template, PluginContainer } from '@devexpress/dx-react-core';
 import {
   tableRowsWithExpandedDetail,
   isDetailRowExpanded,
@@ -33,12 +33,12 @@ export class TableRowDetail extends React.PureComponent {
         pluginName="TableRowDetail"
         dependencies={pluginDependencies}
       >
-        <Getter name="tableColumns" computed={tableColumnsComputed} />
+        <Property name="tableColumns" computed={tableColumnsComputed} />
         <Template
           name="tableViewCell"
           predicate={({ tableRow, tableColumn }) => isDetailToggleTableCell(tableRow, tableColumn)}
-          connectGetters={getter => ({
-            expandedRows: getter('expandedRows'),
+          connectProperties={property => ({
+            expandedRows: property('expandedRows'),
           })}
           connectActions={action => ({
             setDetailRowExpanded: action('setDetailRowExpanded'),
@@ -56,7 +56,7 @@ export class TableRowDetail extends React.PureComponent {
           })}
         </Template>
 
-        <Getter name="tableBodyRows" computed={tableBodyRowsComputed} />
+        <Property name="tableBodyRows" computed={tableBodyRowsComputed} />
         <Template name="tableViewCell" predicate={({ tableRow }) => isDetailTableRow(tableRow)}>
           {params => detailCellTemplate({
             ...params,

--- a/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-row-detail.test.jsx
@@ -21,7 +21,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 }));
 
 const defaultDeps = {
-  getter: {
+  property: {
     tableColumns: [{ type: 'undefined', column: 'column' }],
     tableBodyRows: [{ type: 'undefined', rowId: 1, row: 'row' }],
     expandedRows: { onClick: () => {} },
@@ -65,7 +65,7 @@ describe('TableRowDetail', () => {
     jest.resetAllMocks();
   });
 
-  describe('table layout getters', () => {
+  describe('table layout properties', () => {
     it('should extend tableBodyRows', () => {
       const deps = {};
       mount(
@@ -78,10 +78,10 @@ describe('TableRowDetail', () => {
         </PluginHost>,
       );
 
-      expect(deps.computedGetter('tableBodyRows'))
+      expect(deps.computedProperty('tableBodyRows'))
         .toBe('tableRowsWithExpandedDetail');
       expect(tableRowsWithExpandedDetail)
-        .toBeCalledWith(defaultDeps.getter.tableBodyRows, defaultDeps.getter.expandedRows, 120);
+        .toBeCalledWith(defaultDeps.property.tableBodyRows, defaultDeps.property.expandedRows, 120);
     });
 
     it('should extend tableColumns', () => {
@@ -96,10 +96,10 @@ describe('TableRowDetail', () => {
         </PluginHost>,
       );
 
-      expect(deps.computedGetter('tableColumns'))
+      expect(deps.computedProperty('tableColumns'))
         .toBe('tableColumnsWithDetail');
       expect(tableColumnsWithDetail)
-        .toBeCalledWith(defaultDeps.getter.tableColumns, 120);
+        .toBeCalledWith(defaultDeps.property.tableColumns, 120);
     });
   });
 

--- a/packages/dx-react-grid/src/plugins/table-selection.jsx
+++ b/packages/dx-react-grid/src/plugins/table-selection.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Template, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Template, PluginContainer } from '@devexpress/dx-react-core';
 import {
   tableColumnsWithSelection,
   tableRowsWithSelection,
@@ -40,22 +40,22 @@ export class TableSelection extends React.PureComponent {
         dependencies={pluginDependencies}
       >
         {showSelectionColumn && (
-          <Getter name="tableColumns" computed={tableColumnsComputed} />
+          <Property name="tableColumns" computed={tableColumnsComputed} />
         )}
         {highlightSelected && (
-          <Getter name="tableBodyRows" computed={tableBodyRowsComputed} />
+          <Property name="tableBodyRows" computed={tableBodyRowsComputed} />
         )}
         {selectByRowClick && (
-          <Getter name="tableExtraProps" computed={tableExtraPropsComputed} />
+          <Property name="tableExtraProps" computed={tableExtraPropsComputed} />
         )}
 
         {(showSelectionColumn && showSelectAll) && (
           <Template
             name="tableViewCell"
             predicate={({ tableRow, tableColumn }) => isSelectAllTableCell(tableRow, tableColumn)}
-            connectGetters={(getter) => {
-              const availableToSelect = getter('availableToSelect');
-              const selection = getter('selection');
+            connectProperties={(property) => {
+              const availableToSelect = property('availableToSelect');
+              const selection = property('selection');
               const selectionExists = selection.length !== 0;
               return {
                 availableToSelect,
@@ -82,8 +82,8 @@ export class TableSelection extends React.PureComponent {
           <Template
             name="tableViewCell"
             predicate={({ tableRow, tableColumn }) => isSelectTableCell(tableRow, tableColumn)}
-            connectGetters={getter => ({
-              selection: getter('selection'),
+            connectProperties={property => ({
+              selection: property('selection'),
             })}
             connectActions={action => ({
               toggleSelected: ({ rowId }) => action('setRowsSelection')({ rowIds: [rowId] }),

--- a/packages/dx-react-grid/src/plugins/table-selection.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-selection.test.jsx
@@ -21,7 +21,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 }));
 
 const defaultDeps = {
-  getter: {
+  property: {
     tableColumns: [{ type: 'undefined', column: 'column' }],
     tableBodyRows: [{ type: 'undefined', rowId: 1, row: 'row' }],
     tableExtraProps: { onClick: () => {} },
@@ -67,7 +67,7 @@ describe('TableHeaderRow', () => {
     jest.resetAllMocks();
   });
 
-  describe('table layout getters', () => {
+  describe('table layout properties', () => {
     it('should extend tableBodyRows', () => {
       const deps = {};
 
@@ -81,10 +81,10 @@ describe('TableHeaderRow', () => {
         </PluginHost>,
       );
 
-      expect(deps.computedGetter('tableBodyRows'))
+      expect(deps.computedProperty('tableBodyRows'))
         .toBe('tableRowsWithSelection');
       expect(tableRowsWithSelection)
-        .toHaveBeenCalledWith(defaultDeps.getter.tableBodyRows, defaultDeps.getter.selection);
+        .toHaveBeenCalledWith(defaultDeps.property.tableBodyRows, defaultDeps.property.selection);
     });
 
     it('should extend tableColumns', () => {
@@ -100,10 +100,10 @@ describe('TableHeaderRow', () => {
         </PluginHost>,
       );
 
-      expect(deps.computedGetter('tableColumns'))
+      expect(deps.computedProperty('tableColumns'))
         .toBe('tableColumnsWithSelection');
       expect(tableColumnsWithSelection)
-        .toBeCalledWith(defaultDeps.getter.tableColumns, 120);
+        .toBeCalledWith(defaultDeps.property.tableColumns, 120);
     });
 
     it('should extend tableExtraProps', () => {
@@ -119,10 +119,10 @@ describe('TableHeaderRow', () => {
         </PluginHost>,
       );
 
-      expect(deps.computedGetter('tableExtraProps'))
+      expect(deps.computedProperty('tableExtraProps'))
         .toBe('tableExtraPropsWithSelection');
       expect(tableExtraPropsWithSelection)
-        .toBeCalledWith(defaultDeps.getter.tableExtraProps, expect.any(Function));
+        .toBeCalledWith(defaultDeps.property.tableExtraProps, expect.any(Function));
     });
   });
 

--- a/packages/dx-react-grid/src/plugins/table-view.jsx
+++ b/packages/dx-react-grid/src/plugins/table-view.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Getter, Template, TemplatePlaceholder, PluginContainer } from '@devexpress/dx-react-core';
+import { Property, Template, TemplatePlaceholder, PluginContainer } from '@devexpress/dx-react-core';
 import {
   tableColumnsWithDataRows,
   tableRowsWithDataRows,
@@ -35,21 +35,21 @@ export class TableView extends React.PureComponent {
           { pluginName: 'DragDropContext', optional: !allowColumnReordering },
         ]}
       >
-        <Getter name="tableHeaderRows" value={tableHeaderRows} />
-        <Getter name="tableBodyRows" computed={tableBodyRowsComputed} />
-        <Getter name="tableColumns" computed={tableColumnsComputed} />
-        <Getter name="tableExtraProps" value={tableExtraProps} />
+        <Property name="tableHeaderRows" value={tableHeaderRows} />
+        <Property name="tableBodyRows" computed={tableBodyRowsComputed} />
+        <Property name="tableColumns" computed={tableColumnsComputed} />
+        <Property name="tableExtraProps" value={tableExtraProps} />
 
         <Template
           name="body"
-          connectGetters={getter => ({
-            headerRows: getter('tableHeaderRows'),
-            bodyRows: getter('tableBodyRows'),
-            columns: getter('tableColumns'),
-            getRowId: getter('getRowId'),
+          connectProperties={property => ({
+            headerRows: property('tableHeaderRows'),
+            bodyRows: property('tableBodyRows'),
+            columns: property('tableColumns'),
+            getRowId: property('getRowId'),
             cellTemplate,
             allowColumnReordering,
-            ...getter('tableExtraProps'),
+            ...property('tableExtraProps'),
           })}
           connectActions={action => ({
             setColumnOrder: action('setColumnOrder'),
@@ -59,8 +59,8 @@ export class TableView extends React.PureComponent {
         </Template>
         <Template
           name="tableViewCell"
-          connectGetters={getter => ({
-            headerRows: getter('tableHeaderRows'),
+          connectProperties={property => ({
+            headerRows: property('tableHeaderRows'),
           })}
         >
           {({ headerRows, ...restParams }) => (
@@ -72,8 +72,8 @@ export class TableView extends React.PureComponent {
         <Template
           name="tableViewCell"
           predicate={({ tableRow, tableColumn }) => isDataTableCell(tableRow, tableColumn)}
-          connectGetters={getter => ({
-            getCellData: getter('getCellData'),
+          connectProperties={property => ({
+            getCellData: property('getCellData'),
           })}
         >
           {({ getCellData, ...params }) => tableCellTemplate({

--- a/packages/dx-react-grid/src/plugins/table-view.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-view.test.jsx
@@ -21,7 +21,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 }));
 
 const defaultDeps = {
-  getter: {
+  property: {
     columns: [{ name: 'field' }],
     rows: [{ field: 1 }],
     getRowId: () => {},
@@ -63,7 +63,7 @@ describe('TableView', () => {
     jest.resetAllMocks();
   });
 
-  describe('table layout getters', () => {
+  describe('table layout properties', () => {
     it('should provide tableBodyRows', () => {
       const deps = {};
 
@@ -77,15 +77,15 @@ describe('TableView', () => {
       );
 
       expect(tableRowsWithDataRows)
-        .toBeCalledWith(defaultDeps.getter.rows, defaultDeps.getter.getRowId);
-      expect(deps.computedGetter('tableBodyRows'))
+        .toBeCalledWith(defaultDeps.property.rows, defaultDeps.property.getRowId);
+      expect(deps.computedProperty('tableBodyRows'))
         .toBe('tableRowsWithDataRows');
     });
 
     it('should extend tableColumns', () => {
       const deps = {
-        checkGetter: (getter) => {
-          expect(getter('tableColumns'))
+        checkProperty: (property) => {
+          expect(property('tableColumns'))
             .toBe('tableColumnsWithDataRows');
         },
       };
@@ -100,7 +100,7 @@ describe('TableView', () => {
       );
 
       expect(tableColumnsWithDataRows)
-        .toBeCalledWith(defaultDeps.getter.columns);
+        .toBeCalledWith(defaultDeps.property.columns);
     });
   });
 
@@ -172,7 +172,7 @@ describe('TableView', () => {
     );
 
     expect(isHeaderStubTableCell)
-      .toBeCalledWith(tableCellArgs.tableRow, deps.computedGetter('tableHeaderRows'));
+      .toBeCalledWith(tableCellArgs.tableRow, deps.computedProperty('tableHeaderRows'));
     expect(tableStubHeaderCellTemplate)
       .toBeCalledWith(tableCellArgs);
   });

--- a/packages/dx-react-grid/src/plugins/test-utils.jsx
+++ b/packages/dx-react-grid/src/plugins/test-utils.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Getter,
+  Property,
   Action,
   Template,
   TemplatePlaceholder,
@@ -25,8 +25,8 @@ export const pluginDepsToComponents = (
         <div />
       </PluginContainer>
     ))}
-    {entries({ ...deps.getter, ...depsOverrides.getter })
-      .map(([name, value]) => <Getter key={`getter_${name}`} name={name} value={value} />)}
+    {entries({ ...deps.property, ...depsOverrides.property })
+      .map(([name, value]) => <Property key={`property_${name}`} name={name} value={value} />)}
     {entries({ ...deps.action, ...depsOverrides.action })
       .map(([name, action]) => <Action key={`action_${name}`} name={name} action={action} />)}
     {entries({ ...deps.template, ...depsOverrides.template })
@@ -42,7 +42,7 @@ export const pluginDepsToComponents = (
       key="check"
       name="root"
       // eslint-disable-next-line no-param-reassign
-      connectGetters={(getter) => { depsOverrides.computedGetter = getter; }}
+      connectProperties={(property) => { depsOverrides.computedProperty = property; }}
       // eslint-disable-next-line no-param-reassign
       connectActions={(action) => { depsOverrides.computedAction = action; }}
     >


### PR DESCRIPTION
BREAKING CHANGES:

The "Getter" plugin primitive has been renamed to "Property" to make its purpose clearer. It defines a shared property that returns a static value or computed value based on a component's properties or actions.