### PR TITLE
refactor(react-grid): rename tableTemplate to tableLayoutTemplate

### DIFF
--- a/packages/dx-react-grid-bootstrap3/src/plugins/table-view.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/plugins/table-view.jsx
@@ -8,7 +8,7 @@ import { TableStubCell } from '../templates/table-stub-cell';
 import { TableStubHeaderCell } from '../templates/table-stub-header-cell';
 import { TableNoDataCell } from '../templates/table-no-data-cell';
 
-const tableTemplate = props => <Table {...props} />;
+const tableLayoutTemplate = props => <Table {...props} />;
 const defaultCellTemplate = props => <TableCell {...props} />;
 const stubCellTemplate = props => <TableStubCell {...props} />;
 const stubHeaderCellTemplate = props => <TableStubHeaderCell {...props} />;
@@ -16,7 +16,7 @@ const noDataCellTemplate = props => <TableNoDataCell {...props} />;
 
 export const TableView = ({ tableCellTemplate, ...props }) => (
   <TableViewBase
-    tableTemplate={tableTemplate}
+    tableLayoutTemplate={tableLayoutTemplate}
     tableCellTemplate={combineTemplates(
       tableCellTemplate,
       defaultCellTemplate,

--- a/packages/dx-react-grid-bootstrap3/src/plugins/virtual-table-view.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/plugins/virtual-table-view.jsx
@@ -8,7 +8,7 @@ import { TableNoDataCell } from '../templates/table-no-data-cell';
 import { TableStubCell } from '../templates/table-stub-cell';
 import { TableStubHeaderCell } from '../templates/table-stub-header-cell';
 
-const tableTemplate = props => <VirtualTable {...props} />;
+const tableLayoutTemplate = props => <VirtualTable {...props} />;
 const defaultCellTemplate = props => <TableCell {...props} />;
 const noDataCellTemplate = props => <TableNoDataCell {...props} />;
 const stubCellTemplate = props => <TableStubCell {...props} />;
@@ -16,7 +16,7 @@ const stubHeaderCellTemplate = props => <TableStubHeaderCell {...props} />;
 
 export const VirtualTableView = ({ tableCellTemplate, ...props }) => (
   <TableViewBase
-    tableTemplate={tableTemplate}
+    tableLayoutTemplate={tableLayoutTemplate}
     tableCellTemplate={combineTemplates(
       tableCellTemplate,
       defaultCellTemplate,

--- a/packages/dx-react-grid-material-ui/src/plugins/table-view.jsx
+++ b/packages/dx-react-grid-material-ui/src/plugins/table-view.jsx
@@ -7,14 +7,14 @@ import { TableCell } from '../templates/table-cell';
 import { TableStubCell } from '../templates/table-stub-cell';
 import { TableNoDataCell } from '../templates/table-no-data-cell';
 
-const tableTemplate = props => <Table {...props} />;
+const tableLayoutTemplate = props => <Table {...props} />;
 const defaultCellTemplate = props => <TableCell {...props} />;
 const stubCellTemplate = props => <TableStubCell {...props} />;
 const noDataCellTemplate = props => <TableNoDataCell {...props} />;
 
 export const TableView = ({ tableCellTemplate, ...props }) => (
   <TableViewBase
-    tableTemplate={tableTemplate}
+    tableLayoutTemplate={tableLayoutTemplate}
     tableCellTemplate={combineTemplates(
       tableCellTemplate,
       defaultCellTemplate,

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -13,7 +13,7 @@ This plugin renders the Grid data as a table. It contains the Table View and Tab
 
 Name | Type | Default | Description
 -----|------|---------|------------
-tableTemplate | (args: [TableArgs](#table-args)) => ReactElement | | Renders a table using the specified parameters
+tableLayoutTemplate | (args: [TableArgs](#table-args)) => ReactElement | | Renders a table layout using the specified parameters
 tableCellTemplate | (args: [TableDataCellArgs](#table-data-cell-args)) => ReactElement | | Renders a table cell using the specified parameters
 tableNoDataCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a table cell using the specified parameters when the table is empty
 tableStubCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a stub table cell if the cell data is not provided

--- a/packages/dx-react-grid/src/plugins/table-group-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-group-row.test.jsx
@@ -40,7 +40,6 @@ const defaultDeps = {
 };
 
 const defaultProps = {
-  tableTemplate: () => null,
   groupCellTemplate: () => null,
   groupIndentCellTemplate: () => null,
   groupIndentColumnWidth: 100,

--- a/packages/dx-react-grid/src/plugins/table-view.jsx
+++ b/packages/dx-react-grid/src/plugins/table-view.jsx
@@ -19,7 +19,7 @@ const cellTemplate = params =>
 export class TableView extends React.PureComponent {
   render() {
     const {
-      tableTemplate,
+      tableLayoutTemplate,
       tableCellTemplate,
       tableNoDataCellTemplate,
       tableStubCellTemplate,
@@ -55,7 +55,7 @@ export class TableView extends React.PureComponent {
             setColumnOrder: action('setColumnOrder'),
           })}
         >
-          {tableTemplate}
+          {tableLayoutTemplate}
         </Template>
         <Template
           name="tableViewCell"
@@ -95,7 +95,7 @@ export class TableView extends React.PureComponent {
 }
 
 TableView.propTypes = {
-  tableTemplate: PropTypes.func.isRequired,
+  tableLayoutTemplate: PropTypes.func.isRequired,
   tableCellTemplate: PropTypes.func.isRequired,
   tableNoDataCellTemplate: PropTypes.func.isRequired,
   tableStubCellTemplate: PropTypes.func.isRequired,

--- a/packages/dx-react-grid/src/plugins/table-view.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-view.test.jsx
@@ -36,7 +36,7 @@ const defaultDeps = {
 };
 
 const defaultProps = {
-  tableTemplate: () => null,
+  tableLayoutTemplate: () => null,
   tableCellTemplate: () => null,
   tableStubCellTemplate: () => null,
   tableStubHeaderCellTemplate: () => null,
@@ -119,7 +119,7 @@ describe('TableView', () => {
         {pluginDepsToComponents(defaultDeps)}
         <TableView
           {...defaultProps}
-          tableTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
+          tableLayoutTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableCellTemplate={tableCellTemplate}
         />
       </PluginHost>,
@@ -144,7 +144,7 @@ describe('TableView', () => {
         {pluginDepsToComponents(defaultDeps)}
         <TableView
           {...defaultProps}
-          tableTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
+          tableLayoutTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableStubCellTemplate={tableStubCellTemplate}
         />
       </PluginHost>,
@@ -165,7 +165,7 @@ describe('TableView', () => {
         {pluginDepsToComponents(defaultDeps, deps)}
         <TableView
           {...defaultProps}
-          tableTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
+          tableLayoutTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableStubHeaderCellTemplate={tableStubHeaderCellTemplate}
         />
       </PluginHost>,
@@ -187,7 +187,7 @@ describe('TableView', () => {
         {pluginDepsToComponents(defaultDeps)}
         <TableView
           {...defaultProps}
-          tableTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
+          tableLayoutTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableNoDataCellTemplate={tableNoDataCellTemplate}
         />
       </PluginHost>,


### PR DESCRIPTION
BREAKING CHANGE:

The `tableTemplate` property has been renamed to `tableLayoutTemplate` to make the `TableView` plugin API more eloquent.