### PR TITLE
refactor(react-grid): rename getCellData to getCellValue

### DIFF
--- a/packages/dx-grid-core/src/plugins/filtering-state/computeds.js
+++ b/packages/dx-grid-core/src/plugins/filtering-state/computeds.js
@@ -2,11 +2,11 @@ const toString = value => String(value).toLowerCase();
 
 const applyFilter = (filter, value) => (toString(value).indexOf(toString(filter.value)) > -1);
 
-export const filteredRows = (rows, filters, getCellData, userFilterFn) => {
+export const filteredRows = (rows, filters, getCellValue, userFilterFn) => {
   if (!filters.length) return rows;
 
   const filterFn = userFilterFn ||
-    ((row, filter) => applyFilter(filter, getCellData(row, filter.columnName)));
+    ((row, filter) => applyFilter(filter, getCellValue(row, filter.columnName)));
 
   return rows.filter(row => filters.reduce((accumulator, filter) =>
     accumulator && filterFn(row, filter), true));

--- a/packages/dx-grid-core/src/plugins/filtering-state/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/filtering-state/computeds.test.js
@@ -11,19 +11,19 @@ describe('FilteringState computeds', () => {
       { a: 2, b: 2 },
     ];
 
-    const getCellData = (row, columnName) => row[columnName];
+    const getCellValue = (row, columnName) => row[columnName];
 
     it('should not touch rows if no filters specified', () => {
       const filters = [];
 
-      const filtered = filteredRows(rows, filters, getCellData);
+      const filtered = filteredRows(rows, filters, getCellValue);
       expect(filtered).toBe(rows);
     });
 
     it('can filter by one field', () => {
       const filters = [{ columnName: 'a', value: 1 }];
 
-      const filtered = filteredRows(rows, filters, getCellData);
+      const filtered = filteredRows(rows, filters, getCellValue);
       expect(filtered).toEqual([
         { a: 1, b: 1 },
         { a: 1, b: 2 },
@@ -33,7 +33,7 @@ describe('FilteringState computeds', () => {
     it('can filter by several fields', () => {
       const filters = [{ columnName: 'a', value: 1 }, { columnName: 'b', value: 2 }];
 
-      const filtered = filteredRows(rows, filters, getCellData);
+      const filtered = filteredRows(rows, filters, getCellValue);
       expect(filtered).toEqual([
         { a: 1, b: 2 },
       ]);

--- a/packages/dx-grid-core/src/plugins/grouping-local/computeds.js
+++ b/packages/dx-grid-core/src/plugins/grouping-local/computeds.js
@@ -1,11 +1,11 @@
 import { GROUP_KEY_SEPARATOR } from '../grouping-state/constants';
 
-export const groupedRows = (rows, grouping, getCellData) => {
+export const groupedRows = (rows, grouping, getCellValue) => {
   if (!grouping.length) return rows;
 
   const groups = rows
     .reduce((acc, row) => {
-      const value = getCellData(row, grouping[0].columnName);
+      const value = getCellValue(row, grouping[0].columnName);
       const key = String(value);
       const sameKeyItems = acc.get(key);
       if (!sameKeyItems) {
@@ -20,7 +20,7 @@ export const groupedRows = (rows, grouping, getCellData) => {
   return [...groups.values()]
     .map(([value, items]) => ({
       value,
-      items: groupedRows(items, nestedGrouping, getCellData),
+      items: groupedRows(items, nestedGrouping, getCellValue),
     }));
 };
 

--- a/packages/dx-grid-core/src/plugins/grouping-local/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/grouping-local/computeds.test.js
@@ -10,7 +10,7 @@ describe('GroupingPlugin computeds', () => {
     { a: 2, b: 1 },
     { a: 2, b: 2 },
   ];
-  const getCellData = (row, columnName) => row[columnName];
+  const getCellValue = (row, columnName) => row[columnName];
 
   const firstLevelGroupings = [{ columnName: 'a' }];
   const firstLevelGroupedRows = [{
@@ -58,12 +58,12 @@ describe('GroupingPlugin computeds', () => {
 
   describe('#groupedRows', () => {
     it('can group by one column', () => {
-      expect(groupedRows(rowsSource, firstLevelGroupings, getCellData))
+      expect(groupedRows(rowsSource, firstLevelGroupings, getCellValue))
         .toEqual(firstLevelGroupedRows);
     });
 
     it('can group by several columns', () => {
-      expect(groupedRows(rowsSource, secondLevelGroupings, getCellData))
+      expect(groupedRows(rowsSource, secondLevelGroupings, getCellValue))
         .toEqual(secondLevelGroupedRows);
     });
   });

--- a/packages/dx-grid-core/src/plugins/sorting-state/computeds.js
+++ b/packages/dx-grid-core/src/plugins/sorting-state/computeds.js
@@ -1,10 +1,10 @@
 import mergeSort from '../../utils/merge-sort';
 
-const createSortingCompare = (sorting, compareEqual, getCellData) => (a, b) => {
+const createSortingCompare = (sorting, compareEqual, getCellValue) => (a, b) => {
   const inverse = sorting.direction === 'desc';
   const { columnName } = sorting;
-  const aValue = getCellData(a, columnName);
-  const bValue = getCellData(b, columnName);
+  const aValue = getCellValue(a, columnName);
+  const bValue = getCellValue(b, columnName);
 
   if (aValue === bValue) {
     return (compareEqual && compareEqual(a, b)) || 0;
@@ -13,13 +13,13 @@ const createSortingCompare = (sorting, compareEqual, getCellData) => (a, b) => {
   return (aValue < bValue) ^ inverse ? -1 : 1; // eslint-disable-line no-bitwise
 };
 
-export const sortedRows = (rows, sorting, getCellData) => {
+export const sortedRows = (rows, sorting, getCellValue) => {
   if (!sorting.length) return rows;
 
   const compare = Array.from(sorting)
     .reverse()
     .reduce((prevCompare, columnSorting) =>
-      createSortingCompare(columnSorting, prevCompare, getCellData), () => 0);
+      createSortingCompare(columnSorting, prevCompare, getCellValue), () => 0);
 
   return mergeSort(Array.from(rows), compare);
 };

--- a/packages/dx-grid-core/src/plugins/sorting-state/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/sorting-state/computeds.test.js
@@ -13,19 +13,19 @@ describe('SortingState computeds', () => {
       { a: 1, b: 2 },
     ];
 
-    const getCellData = (row, columnName) => row[columnName];
+    const getCellValue = (row, columnName) => row[columnName];
 
     it('does not mutate rows if no sorting specified', () => {
       const sorting = [];
 
-      const sorted = sortedRows(rows, sorting, getCellData);
+      const sorted = sortedRows(rows, sorting, getCellValue);
       expect(sorted).toBe(rows);
     });
 
     it('can sort ascending by one column', () => {
       const sorting = [{ columnName: 'a', direction: 'asc' }];
 
-      const sorted = sortedRows(rows, sorting, getCellData);
+      const sorted = sortedRows(rows, sorting, getCellValue);
       expect(sorted).toEqual([
         { a: 1, b: 1 },
         { a: 1, b: 2 },
@@ -37,7 +37,7 @@ describe('SortingState computeds', () => {
     it('can sort descending by one column', () => {
       const sorting = [{ columnName: 'a', direction: 'desc' }];
 
-      const sorted = sortedRows(rows, sorting, getCellData);
+      const sorted = sortedRows(rows, sorting, getCellValue);
       expect(sorted).toEqual([
         { a: 2, b: 2 },
         { a: 2, b: 1 },
@@ -49,7 +49,7 @@ describe('SortingState computeds', () => {
     it('can sort by several columns', () => {
       const sorting = [{ columnName: 'a', direction: 'asc' }, { columnName: 'b', direction: 'asc' }];
 
-      const sorted = sortedRows(rows, sorting, getCellData);
+      const sorted = sortedRows(rows, sorting, getCellValue);
       expect(sorted).toEqual([
         { a: 1, b: 1 },
         { a: 1, b: 2 },
@@ -61,7 +61,7 @@ describe('SortingState computeds', () => {
     it('can sort by several columns with different directions', () => {
       const sorting = [{ columnName: 'a', direction: 'asc' }, { columnName: 'b', direction: 'desc' }];
 
-      const sorted = sortedRows(rows, sorting, getCellData);
+      const sorted = sortedRows(rows, sorting, getCellValue);
       expect(sorted).toEqual([
         { a: 1, b: 2 },
         { a: 1, b: 1 },
@@ -74,7 +74,7 @@ describe('SortingState computeds', () => {
       const immutableRows = Immutable(rows);
       const immutableSorting = Immutable([{ columnName: 'a', direction: 'desc' }]);
 
-      const sorted = sortedRows(immutableRows, immutableSorting, getCellData);
+      const sorted = sortedRows(immutableRows, immutableSorting, getCellValue);
       expect(sorted).toEqual([
         { a: 2, b: 2 },
         { a: 2, b: 1 },

--- a/packages/dx-react-demos/src/bootstrap3/data-accessors/custom-data-accessors-in-columns.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/data-accessors/custom-data-accessors-in-columns.jsx
@@ -24,7 +24,7 @@ export default class Demo extends React.PureComponent {
         {
           name: 'firstName',
           title: 'First Name',
-          getCellData: row => (row.user ? row.user.firstName : undefined),
+          getCellValue: row => (row.user ? row.user.firstName : undefined),
           createRowChange: (row, value) => ({
             user: {
               ...row.user,
@@ -35,7 +35,7 @@ export default class Demo extends React.PureComponent {
         {
           name: 'lastName',
           title: 'Last Name',
-          getCellData: row => (row.user ? row.user.lastName : undefined),
+          getCellValue: row => (row.user ? row.user.lastName : undefined),
           createRowChange: (row, value) => ({
             user: {
               ...row.user,
@@ -46,7 +46,7 @@ export default class Demo extends React.PureComponent {
         {
           name: 'car',
           title: 'Car',
-          getCellData: row => (row.car ? row.car.model : undefined),
+          getCellValue: row => (row.car ? row.car.model : undefined),
           createRowChange: (row, value) => ({
             car: {
               model: value,
@@ -62,6 +62,7 @@ export default class Demo extends React.PureComponent {
       }),
     };
 
+    this.getRowId = row => row.id;
     this.commitChanges = ({ added, changed, deleted }) => {
       let rows = this.state.rows;
       if (added) {
@@ -91,7 +92,7 @@ export default class Demo extends React.PureComponent {
       <Grid
         rows={rows}
         columns={columns}
-        getRowId={row => row.id}
+        getRowId={this.getRowId}
       >
         <EditingState
           onCommitChanges={this.commitChanges}
@@ -99,11 +100,7 @@ export default class Demo extends React.PureComponent {
         <TableView />
         <TableHeaderRow />
         <TableEditRow />
-        <TableEditColumn
-          allowAdding
-          allowEditing
-          allowDeleting
-        />
+        <TableEditColumn allowAdding allowEditing allowDeleting />
       </Grid>
     );
   }

--- a/packages/dx-react-demos/src/bootstrap3/data-accessors/custom-data-accessors.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/data-accessors/custom-data-accessors.jsx
@@ -33,6 +33,27 @@ export default class Demo extends React.PureComponent {
       }),
     };
 
+    this.getRowId = row => row.id;
+    this.getCellValue = (row, columnName) => {
+      if (columnName.indexOf('.') > -1) {
+        const { rootField, nestedField } = this.splitColumnName(columnName);
+        return row[rootField] ? row[rootField][nestedField] : undefined;
+      }
+      return row[columnName];
+    };
+    this.createRowChange = (row, columnName, value) => {
+      if (columnName.indexOf('.') > -1) {
+        const { rootField, nestedField } = this.splitColumnName(columnName);
+
+        return {
+          [rootField]: {
+            ...row[rootField],
+            [nestedField]: value,
+          },
+        };
+      }
+      return { [columnName]: value };
+    };
     this.commitChanges = ({ added, changed, deleted }) => {
       let rows = this.state.rows;
       if (added) {
@@ -66,39 +87,17 @@ export default class Demo extends React.PureComponent {
       <Grid
         rows={rows}
         columns={columns}
-        getRowId={row => row.id}
-        getCellData={(row, columnName) => {
-          if (columnName.indexOf('.') > -1) {
-            const { rootField, nestedField } = this.splitColumnName(columnName);
-            return row[rootField] ? row[rootField][nestedField] : undefined;
-          }
-          return row[columnName];
-        }}
+        getRowId={this.getRowId}
+        getCellValue={this.getCellValue}
       >
         <EditingState
+          createRowChange={this.createRowChange}
           onCommitChanges={this.commitChanges}
-          createRowChange={(row, columnName, value) => {
-            if (columnName.indexOf('.') > -1) {
-              const { rootField, nestedField } = this.splitColumnName(columnName);
-
-              return {
-                [rootField]: {
-                  ...row[rootField],
-                  [nestedField]: value,
-                },
-              };
-            }
-            return { [columnName]: value };
-          }}
         />
         <TableView />
         <TableHeaderRow />
         <TableEditRow />
-        <TableEditColumn
-          allowAdding
-          allowEditing
-          allowDeleting
-        />
+        <TableEditColumn allowAdding allowEditing allowDeleting />
       </Grid>
     );
   }

--- a/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors-in-columns.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors-in-columns.jsx
@@ -24,7 +24,7 @@ export default class Demo extends React.PureComponent {
         {
           name: 'firstName',
           title: 'First Name',
-          getCellData: row => (row.user ? row.user.firstName : undefined),
+          getCellValue: row => (row.user ? row.user.firstName : undefined),
           createRowChange: (row, value) => ({
             user: {
               ...row.user,
@@ -35,7 +35,7 @@ export default class Demo extends React.PureComponent {
         {
           name: 'lastName',
           title: 'Last Name',
-          getCellData: row => (row.user ? row.user.lastName : undefined),
+          getCellValue: row => (row.user ? row.user.lastName : undefined),
           createRowChange: (row, value) => ({
             user: {
               ...row.user,
@@ -46,7 +46,7 @@ export default class Demo extends React.PureComponent {
         {
           name: 'car',
           title: 'Car',
-          getCellData: row => (row.car ? row.car.model : undefined),
+          getCellValue: row => (row.car ? row.car.model : undefined),
           createRowChange: (row, value) => ({
             car: {
               model: value,
@@ -62,6 +62,7 @@ export default class Demo extends React.PureComponent {
       }),
     };
 
+    this.getRowId = row => row.id;
     this.commitChanges = ({ added, changed, deleted }) => {
       let rows = this.state.rows;
       if (added) {
@@ -91,7 +92,7 @@ export default class Demo extends React.PureComponent {
       <Grid
         rows={rows}
         columns={columns}
-        getRowId={row => row.id}
+        getRowId={this.getRowId}
       >
         <EditingState
           onCommitChanges={this.commitChanges}
@@ -99,11 +100,7 @@ export default class Demo extends React.PureComponent {
         <TableView />
         <TableHeaderRow />
         <TableEditRow />
-        <TableEditColumn
-          allowAdding
-          allowEditing
-          allowDeleting
-        />
+        <TableEditColumn allowAdding allowEditing allowDeleting />
       </Grid>
     );
   }

--- a/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors.jsx
@@ -33,6 +33,27 @@ export default class Demo extends React.PureComponent {
       }),
     };
 
+    this.getRowId = row => row.id;
+    this.getCellValue = (row, columnName) => {
+      if (columnName.indexOf('.') > -1) {
+        const { rootField, nestedField } = this.splitColumnName(columnName);
+        return row[rootField] ? row[rootField][nestedField] : undefined;
+      }
+      return row[columnName];
+    };
+    this.createRowChange = (row, columnName, value) => {
+      if (columnName.indexOf('.') > -1) {
+        const { rootField, nestedField } = this.splitColumnName(columnName);
+
+        return {
+          [rootField]: {
+            ...row[rootField],
+            [nestedField]: value,
+          },
+        };
+      }
+      return { [columnName]: value };
+    };
     this.commitChanges = ({ added, changed, deleted }) => {
       let rows = this.state.rows;
       if (added) {
@@ -66,39 +87,17 @@ export default class Demo extends React.PureComponent {
       <Grid
         rows={rows}
         columns={columns}
-        getRowId={row => row.id}
-        getCellData={(row, columnName) => {
-          if (columnName.indexOf('.') > -1) {
-            const { rootField, nestedField } = this.splitColumnName(columnName);
-            return row[rootField] ? row[rootField][nestedField] : undefined;
-          }
-          return row[columnName];
-        }}
+        getRowId={this.getRowId}
+        getCellValue={this.getCellValue}
       >
         <EditingState
+          createRowChange={this.createRowChange}
           onCommitChanges={this.commitChanges}
-          createRowChange={(row, columnName, value) => {
-            if (columnName.indexOf('.') > -1) {
-              const { rootField, nestedField } = this.splitColumnName(columnName);
-
-              return {
-                [rootField]: {
-                  ...row[rootField],
-                  [nestedField]: value,
-                },
-              };
-            }
-            return { [columnName]: value };
-          }}
         />
         <TableView />
         <TableHeaderRow />
         <TableEditRow />
-        <TableEditColumn
-          allowAdding
-          allowEditing
-          allowDeleting
-        />
+        <TableEditColumn allowAdding allowEditing allowDeleting />
       </Grid>
     );
   }

--- a/packages/dx-react-grid/docs/guides/data-accessors.md
+++ b/packages/dx-react-grid/docs/guides/data-accessors.md
@@ -1,67 +1,72 @@
 # Data Accessors
 
-## Cell Data Access
+## Cell Value Access
 
 In a common scenario with a simple data structure, you can associate a column with a row field using the column's `name` field as shown in the following example:
 
 ```js
 const rows = [
   { firstName: 'John', lastName: 'Smith' },
-  ...
+  /* ... */
 ];
 const columns = [
   { name: 'firstName', title: 'First Name' },
   { name: 'lastName', title: 'Last Name' },
-  ...
+  /* ... */
 ];
+
 <Grid
-  rows={rows},
+  rows={rows}
   columns={columns}
 />
 ```
 
-In the case of nested data structure, use the `getCellData` function to calculate a column value as demonstrated below:
+In the case of nested data structure, use the `getCellValue` function to calculate a column value as demonstrated below:
 
 ```js
 const rows = [
   { user: { firstName: 'John', lastName: 'Smith' } },
-  ...
+  /* ... */
 ];
+const columns = [
+  {
+    name: 'firstName',
+    title: 'First Name',
+    getCellValue: row => (row.user ? row.user.firstName : undefined),
+  },
+  {
+    name: 'lastName',
+    title: 'Last Name',
+    getCellValue: row => (row.user ? row.user.lastName : undefined),
+  },
+  /* ... */
+];
+
 <Grid
-  rows={rows},
-  columns: [
-    {
-      name: 'firstName',
-      title: 'First Name',
-      getCellData: row => (row.user ? row.user.firstName : undefined),
-    },
-    {
-      name: 'lastName',
-      title: 'Last Name',
-      getCellData: row => (row.user ? row.user.lastName : undefined),
-    },
-    ...
-  ],
+  rows={rows}
+  columns={columns}
 />
 ```
 
 .embedded-demo(data-accessors/custom-data-accessors-in-columns)
 
-If you use a common data calculation algorithm for all columns, specify the `getCellData` function on the Grid's level.
+If you use a common value calculation algorithm for all columns, specify the `getCellValue` function on the Grid's level.
 
 For example, you can implement dot notation support for columns like `{ name: 'user.firstName' }`. In this case, the function code looks as follows:
 
 ```js
- <Grid
+const getCellValue = (row, columnName) => {
+  if (columnName.indexOf('.') > -1) {
+    const { rootField, nestedField } = this.splitColumnName(columnName);
+    return row[rootField] ? row[rootField][nestedField] : undefined;
+  }
+  return row[columnName];
+};
+
+<Grid
   rows={rows}
   columns={columns}
-  getCellData={(row, columnName) => {
-    if (columnName.indexOf('.') > -1) {
-      const { rootField, nestedField } = this.splitColumnName(columnName);
-      return row[rootField] ? row[rootField][nestedField] : undefined;
-    }
-    return row[columnName];
-  }}
+  getCellValue={getCellValue}
 >
 ```
 
@@ -69,23 +74,22 @@ The following demo shows this approach in action:
 
 .embedded-demo(data-accessors/custom-data-accessors)
 
-Note that the Grid's `getCellData` property has a higher priority than the column's property.
+Note that the Grid's `getCellValue` property has a higher priority than the column's property.
 
-The `getCellData` implementation presented in this demo is not optimized for frequent invocation. Avoid using it in production apps operating with large amounts of data.
+The `getCellValue` implementation presented in this demo is not optimized for frequent invocation. Avoid using it in production apps operating with large amounts of data.
 
-## Cell Data Editing
+## Cell Value Editing
 
 If editing features are enabled, you can use the column's `createRowChange` function to create a row changes object:
 
 ```js
 const rows = [
   { user: { firstName: 'John', lastName: 'Smith' } },
-  ...
+  /* ... */
 ];
-
-const columns: [
+const columns = [
   {
-    ...
+    /* ... */
     createRowChange: (row, value) => ({
       user: {
         ...row.user,
@@ -93,20 +97,22 @@ const columns: [
       },
     }),
   },
-  ...
-]
+  /* ... */
+];
 ```
 
 Specify the `EditingState` plugin's `createRowChange` property if you use a common algorithm for all columns.
 
 ```js
+const createRowChange = (row, columnName, value) => {
+  /* ... */
+};
+
 <Grid
-  ...
+  /* ... */
 >
   <EditingState
-    createRowChange={(row, columnName, value) => {
-      // ...
-    }}
+    createRowChange={createRowChange}
   />
 />
 ```

--- a/packages/dx-react-grid/docs/reference/grid.md
+++ b/packages/dx-react-grid/docs/reference/grid.md
@@ -11,7 +11,7 @@ Name | Type | Default | Description
 rows | Array&lt;[Row](#row)&gt; | | Specifies the data the Grid displays.
 columns | Array&lt;[Column](#column)&gt; | | Specifies for which row object fields columns are created.
 getRowId | (row: [Row](#row)) => number &#124; string | null | Specifies the function used to get a row ID.
-getCellData | (row: [Row](#row), columnName: string) => any | null | Specifies the function used to get a cell's data.
+getCellValue | (row: [Row](#row), columnName: string) => any | null | Specifies the function used to get a cell's value.
 rootTemplate | (args: [RootArgs](#root-args)) => ReactElement | | A template that renders the grid root layout.
 headerPlaceholderTemplate | (args: [HeaderPlaceholderArgs](#header-placeholder-args)) => ReactElement | null | A template that renders the header placeholder.
 footerPlaceholderTemplate | (args: [FooterPlaceholderArgs](#footer-placeholder-args)) => ReactElement | null | A template that renders the footer placeholder.
@@ -30,8 +30,8 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-name | string | Specifies the column name or the name of a row object field whose value the column displays. If the column name does not match any field name, specify the `getCellData` function.
-getCellData | (row: [Row](#row), columnName: string) => any | Specifies the function used to get the column data for a given row.
+name | string | Specifies the column name or the name of a row object field whose value the column displays. If the column name does not match any field name, specify the `getCellValue` function.
+getCellValue | (row: [Row](#row), columnName: string) => any | Specifies the function used to get the column data for a given row.
 
 ### <a name="root-args"></a>RootArgs
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -22,7 +22,7 @@ Name | Plugin | Type | Description
 -----|--------|------|------------
 rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be filtered
 filters | Getter | Array&lt;[Filter](filtering-state.md#filter)&gt; | Column filters to be applied
-getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell's value
+getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell value
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -22,7 +22,7 @@ Name | Plugin | Type | Description
 -----|--------|------|------------
 rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be filtered
 filters | Getter | Array&lt;[Filter](filtering-state.md#filter)&gt; | Column filters to be applied
-getCellData | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get cell data
+getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell's value
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/local-grouping.md
+++ b/packages/dx-react-grid/docs/reference/local-grouping.md
@@ -21,7 +21,7 @@ Name | Plugin | Type | Description
 rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be grouped
 grouping | Getter | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | The current grouping state
 expandedGroups | Getter | Set&lt;[GroupKey](grouping-state.md#group-key)&gt; | Groups to be expanded
-getCellData | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get cell data
+getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell's value
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/local-grouping.md
+++ b/packages/dx-react-grid/docs/reference/local-grouping.md
@@ -21,7 +21,7 @@ Name | Plugin | Type | Description
 rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be grouped
 grouping | Getter | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | The current grouping state
 expandedGroups | Getter | Set&lt;[GroupKey](grouping-state.md#group-key)&gt; | Groups to be expanded
-getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell's value
+getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell value
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/local-sorting.md
+++ b/packages/dx-react-grid/docs/reference/local-sorting.md
@@ -20,7 +20,7 @@ Name | Plugin | Type | Description
 -----|--------|------|------------
 rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be sorted
 sorting | Getter | Array&lt;[Sorting](sorting-state.md#sorting)&gt; | Column sorting to be applied
-getCellData | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell data
+getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell's value
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/local-sorting.md
+++ b/packages/dx-react-grid/docs/reference/local-sorting.md
@@ -20,7 +20,7 @@ Name | Plugin | Type | Description
 -----|--------|------|------------
 rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be sorted
 sorting | Getter | Array&lt;[Sorting](sorting-state.md#sorting)&gt; | Column sorting to be applied
-getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell's value
+getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell value
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/table-edit-row.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-row.md
@@ -52,7 +52,7 @@ tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Rows
 editingRows | Getter | Array&lt;number &#124; string&gt; | IDs of the rows being edited
 addedRows | Getter | Array&lt;Object&gt; | The created rows
 changedRows | Getter | { [key: string]: Object } | Uncommitted changed rows
-getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell's value
+getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell value
 createRowChange | Getter | (row: [Row](grid.md#row), columnName: string, value: string &#124; string) => Object | The function used to set a cell's value
 changeRow | Action | ({ rowId: number &#124; string, change: Object }) => void | Applies a change to an existing row
 changeAddedRow | Action | ({ rowId: number, change: Object }) => void | Applies a change to a new row. Note: `rowId` is a row index within the `addedRows` array

--- a/packages/dx-react-grid/docs/reference/table-edit-row.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-row.md
@@ -52,8 +52,8 @@ tableBodyRows | Getter | Array&lt;[TableRow](table-view.md#table-row)&gt; | Rows
 editingRows | Getter | Array&lt;number &#124; string&gt; | IDs of the rows being edited
 addedRows | Getter | Array&lt;Object&gt; | The created rows
 changedRows | Getter | { [key: string]: Object } | Uncommitted changed rows
-getCellData | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell's data
-createRowChange | Getter | (row: [Row](grid.md#row), columnName: string, value: string &#124; string) => Object | The function used to set a cell's data
+getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell's value
+createRowChange | Getter | (row: [Row](grid.md#row), columnName: string, value: string &#124; string) => Object | The function used to set a cell's value
 changeRow | Action | ({ rowId: number &#124; string, change: Object }) => void | Applies a change to an existing row
 changeAddedRow | Action | ({ rowId: number, change: Object }) => void | Applies a change to a new row. Note: `rowId` is a row index within the `addedRows` array
 tableViewCell | Template | [TableCellArgs](table-view.md#table-cell-args) | A template that renders a table cell

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -127,7 +127,7 @@ Name | Plugin | Type | Description
 rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be rendered by the table view
 columns | Getter | Array&lt;[Column](#column)&gt; | Columns to be rendered by the table view
 getRowId | Getter | (row: [Row](grid.md#row)) => number &#124; string | The function used to get a unique row identifier
-getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell's value
+getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell value
 
 ### Exports
 

--- a/packages/dx-react-grid/docs/reference/table-view.md
+++ b/packages/dx-react-grid/docs/reference/table-view.md
@@ -18,8 +18,8 @@ tableCellTemplate | (args: [TableDataCellArgs](#table-data-cell-args)) => ReactE
 tableRowTemplate | (args: [TableDataRowArgs](#table-data-row-args)) => ReactElement | | Renders a table row using the specified parameters
 tableNoDataCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a table cell using the specified parameters when the table is empty
 tableNoDataRowTemplate | (args: [TableRowArgs](#table-row-args)) => ReactElement | | Renders a table row using the specified parameters when the table is empty
-tableStubCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a stub table cell if the cell data is not provided
-tableStubHeaderCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a stub header cell if the cell data is not provided
+tableStubCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a stub table cell if the cell value is not provided
+tableStubHeaderCellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | | Renders a stub header cell if the cell value is not provided
 allowColumnReordering | boolean | false | If true, it allows end-users to change the column's order by dragging it. Requires the [ColumnOrderState](column-order-state.md) and the [DragDropContext](drag-drop-context.md) dependencies.
 
 ## Interfaces
@@ -127,7 +127,7 @@ Name | Plugin | Type | Description
 rows | Getter | Array&lt;[Row](grid.md#row)&gt; | Rows to be rendered by the table view
 columns | Getter | Array&lt;[Column](#column)&gt; | Columns to be rendered by the table view
 getRowId | Getter | (row: [Row](grid.md#row)) => number &#124; string | The function used to get a unique row identifier
-getCellData | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell's data
+getCellValue | Getter | (row: [Row](grid.md#row), columnName: string) => any | The function used to get a cell's value
 
 ### Exports
 

--- a/packages/dx-react-grid/src/grid.jsx
+++ b/packages/dx-react-grid/src/grid.jsx
@@ -12,13 +12,13 @@ const rowIdGetter = (getRowId, rows) => {
   };
 };
 
-const getCellDataGetter = (columns) => {
+const getCellValueGetter = (columns) => {
   let useFastAccessor = true;
 
   const map = columns.reduce((acc, column) => {
-    if (column.getCellData) {
+    if (column.getCellValue) {
       useFastAccessor = false;
-      acc[column.name] = column.getCellData;
+      acc[column.name] = column.getCellValue;
     }
     return acc;
   }, {});
@@ -32,20 +32,20 @@ export class Grid extends React.PureComponent {
   constructor(props) {
     super(props);
     this.memoizedRowIdGetter = memoize(rowIdGetter);
-    this.memoizedGetCellDataGetter = memoize(getCellDataGetter);
+    this.memoizedCellValueGetter = memoize(getCellValueGetter);
   }
   render() {
     const {
       rows, getRowId, columns,
       rootTemplate, headerPlaceholderTemplate, footerPlaceholderTemplate,
-      children, getCellData,
+      children, getCellValue,
     } = this.props;
     return (
       <PluginHost>
         <Getter name="rows" value={rows} />
         <Getter name="columns" value={columns} />
         <Getter name="getRowId" value={this.memoizedRowIdGetter(getRowId, rows)} />
-        <Getter name="getCellData" value={getCellData || this.memoizedGetCellDataGetter(columns)} />
+        <Getter name="getCellValue" value={getCellValue || this.memoizedCellValueGetter(columns)} />
         <Template name="header" />
         <Template name="body" />
         <Template name="footer" />
@@ -77,7 +77,7 @@ export class Grid extends React.PureComponent {
 Grid.propTypes = {
   rows: PropTypes.array.isRequired,
   getRowId: PropTypes.func,
-  getCellData: PropTypes.func,
+  getCellValue: PropTypes.func,
   columns: PropTypes.array.isRequired,
   rootTemplate: PropTypes.func.isRequired,
   headerPlaceholderTemplate: PropTypes.func,
@@ -90,7 +90,7 @@ Grid.propTypes = {
 
 Grid.defaultProps = {
   getRowId: null,
-  getCellData: null,
+  getCellValue: null,
   headerPlaceholderTemplate: null,
   footerPlaceholderTemplate: null,
   children: null,

--- a/packages/dx-react-grid/src/grid.test.jsx
+++ b/packages/dx-react-grid/src/grid.test.jsx
@@ -123,7 +123,7 @@ describe('Grid', () => {
     expect(!tree.find('.footer-placeholder').exists()).toBeTruthy();
   });
 
-  it('should calculate cell data', () => {
+  it('should calculate cell value', () => {
     const rows = [
       { a: 1, b: 1 },
       { a: 2, b: 2 },
@@ -143,35 +143,35 @@ describe('Grid', () => {
       </Grid>,
     );
 
-    expect(getComputedState(tree).getters.getCellData(rows[1], columns[1].name))
+    expect(getComputedState(tree).getters.getCellValue(rows[1], columns[1].name))
       .toBe(2);
   });
 
-  it('should calculate cell data by using a custom function', () => {
+  it('should calculate cell value by using a custom function', () => {
     const rows = [{ a: 1 }];
     const columns = [{ name: 'a' }];
-    const getCellData = jest.fn();
+    const getCellValue = jest.fn();
 
     const tree = mount(
       <Grid
         rows={rows}
         columns={columns}
         rootTemplate={() => <div />}
-        getCellData={getCellData}
+        getCellValue={getCellValue}
       >
         {pluginDepsToComponents(defaultDeps)}
       </Grid>,
     );
 
-    expect(getComputedState(tree).getters.getCellData(rows[0], columns[0].name));
-    expect(getCellData)
+    expect(getComputedState(tree).getters.getCellValue(rows[0], columns[0].name));
+    expect(getCellValue)
       .toBeCalledWith(rows[0], columns[0].name);
   });
 
-  it('should calculate cell data by using a custom function within column config', () => {
+  it('should calculate cell value by using a custom function within column config', () => {
     const rows = [{ a: 1 }];
-    const getCellData = jest.fn();
-    const columns = [{ name: 'a', getCellData }];
+    const getCellValue = jest.fn();
+    const columns = [{ name: 'a', getCellValue }];
 
     const tree = mount(
       <Grid
@@ -183,8 +183,8 @@ describe('Grid', () => {
       </Grid>,
     );
 
-    expect(getComputedState(tree).getters.getCellData(rows[0], columns[0].name));
-    expect(getCellData)
+    expect(getComputedState(tree).getters.getCellValue(rows[0], columns[0].name));
+    expect(getCellValue)
       .toBeCalledWith(rows[0], columns[0].name);
   });
 });

--- a/packages/dx-react-grid/src/plugins/local-filtering.jsx
+++ b/packages/dx-react-grid/src/plugins/local-filtering.jsx
@@ -11,8 +11,8 @@ export class LocalFiltering extends React.PureComponent {
   render() {
     const { filterFn } = this.props;
 
-    const rowsComputed = ({ rows, filters, getCellData }) =>
-      filteredRows(rows, filters, getCellData, filterFn);
+    const rowsComputed = ({ rows, filters, getCellValue }) =>
+      filteredRows(rows, filters, getCellValue, filterFn);
 
     return (
       <PluginContainer

--- a/packages/dx-react-grid/src/plugins/local-grouping.jsx
+++ b/packages/dx-react-grid/src/plugins/local-grouping.jsx
@@ -6,8 +6,8 @@ const pluginDependencies = [
   { pluginName: 'GroupingState' },
 ];
 
-const groupedRowsComputed = ({ rows, grouping, getCellData }) =>
-  groupedRows(rows, grouping, getCellData);
+const groupedRowsComputed = ({ rows, grouping, getCellValue }) =>
+  groupedRows(rows, grouping, getCellValue);
 const expandedGroupedRowsComputed = ({ rows, grouping, expandedGroups }) =>
   expandedGroupRows(rows, grouping, expandedGroups);
 

--- a/packages/dx-react-grid/src/plugins/local-sorting.jsx
+++ b/packages/dx-react-grid/src/plugins/local-sorting.jsx
@@ -6,7 +6,7 @@ const pluginDependencies = [
   { pluginName: 'SortingState' },
 ];
 
-const rowsComputed = ({ rows, sorting, getCellData }) => sortedRows(rows, sorting, getCellData);
+const rowsComputed = ({ rows, sorting, getCellValue }) => sortedRows(rows, sorting, getCellValue);
 
 // eslint-disable-next-line react/prefer-stateless-function
 export class LocalSorting extends React.PureComponent {

--- a/packages/dx-react-grid/src/plugins/table-edit-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.jsx
@@ -17,7 +17,7 @@ const getEditTableCellTemplateArgs = (
   getters,
   { changeRow, changeAddedRow },
 ) => {
-  const { getCellData, createRowChange } = getters;
+  const { getCellValue, createRowChange } = getters;
   const isNew = isAddedTableRow(params.tableRow);
   const { rowId, row } = params.tableRow;
   const { column } = params.tableColumn;
@@ -28,7 +28,7 @@ const getEditTableCellTemplateArgs = (
     ...params,
     row,
     column,
-    value: getCellData(changedRow, column.name),
+    value: getCellValue(changedRow, column.name),
     onValueChange: (newValue) => {
       const changeArgs = {
         rowId,

--- a/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
@@ -26,7 +26,7 @@ const defaultDeps = {
     editingRows: [1, 2],
     addedRows: [{ a: 'text' }, {}],
     changedRows: [{ 1: { a: 'text' } }],
-    getCellData: jest.fn(),
+    getCellValue: jest.fn(),
     createRowChange: jest.fn(),
   },
   action: {
@@ -110,7 +110,7 @@ describe('TableEditRow', () => {
       </PluginHost>,
     );
 
-    expect(defaultDeps.getter.getCellData).toBeCalledWith(
+    expect(defaultDeps.getter.getCellValue).toBeCalledWith(
       { ...defaultDeps.template.tableViewCell.tableRow.row },
       defaultDeps.template.tableViewCell.tableColumn.column.name,
     );

--- a/packages/dx-react-grid/src/plugins/table-view.jsx
+++ b/packages/dx-react-grid/src/plugins/table-view.jsx
@@ -31,12 +31,12 @@ const getTableLayoutTemplateArgs = (
 
 const getDataTableCellTemplateArgs = (
   params,
-  { getCellData },
+  { getCellValue },
 ) => ({
   ...params,
   row: params.tableRow.row,
   column: params.tableColumn.column,
-  value: getCellData(params.tableRow.row, params.tableColumn.column.name),
+  value: getCellValue(params.tableRow.row, params.tableColumn.column.name),
 });
 
 const getDataTableRowTemplateArgs = params => ({

--- a/packages/dx-react-grid/src/plugins/table-view.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-view.test.jsx
@@ -27,7 +27,7 @@ const defaultDeps = {
     columns: [{ name: 'field' }],
     rows: [{ field: 1 }],
     getRowId: () => {},
-    getCellData: () => {},
+    getCellValue: () => {},
   },
   action: {
     setColumnOrder: jest.fn(),


### PR DESCRIPTION
BREAKING CHANGES:

The `getCellData` property of the TableView plugin and the `getCellData` field of the Column interface have been renamed to `getCellValue`.