### PR TITLE
refactor(react-grid): change custom filtering function signature

### DIFF
--- a/packages/dx-grid-core/src/plugins/filtering-state/computeds.js
+++ b/packages/dx-grid-core/src/plugins/filtering-state/computeds.js
@@ -1,13 +1,15 @@
-const toString = value => String(value).toLowerCase();
+const toLowerCase = value => String(value).toLowerCase();
 
-const applyFilter = (filter, value) => (toString(value).indexOf(toString(filter.value)) > -1);
-
-export const filteredRows = (rows, filters, getCellData, userFilterFn) => {
+export const filteredRows = (
+  rows,
+  filters,
+  getCellData,
+  predicate = (value, filter) => toLowerCase(value).indexOf(toLowerCase(filter.value)) > -1,
+) => {
   if (!filters.length) return rows;
 
-  const filterFn = userFilterFn ||
-    ((row, filter) => applyFilter(filter, getCellData(row, filter.columnName)));
-
-  return rows.filter(row => filters.reduce((accumulator, filter) =>
-    accumulator && filterFn(row, filter), true));
+  return rows.filter(row => filters.reduce(
+    (acc, filter) => acc && predicate(getCellData(row, filter.columnName), filter, row),
+    true,
+  ));
 };

--- a/packages/dx-react-demos/src/bootstrap3/filtering/custom-filter-row.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/filtering/custom-filter-row.jsx
@@ -15,13 +15,12 @@ import {
   generateRows,
 } from '../../demo-data/generator';
 
-const filterFn = (row, filter) => {
-  const toLowerCase = value => String(value).toLowerCase();
-
+const toLowerCase = value => String(value).toLowerCase();
+const predicate = (value, filter) => {
   if (filter.columnName === 'sex') {
-    return toLowerCase(row[filter.columnName]) === toLowerCase(filter.value);
+    return toLowerCase(value) === toLowerCase(filter.value);
   }
-  return toLowerCase(row[filter.columnName]).indexOf(toLowerCase(filter.value)) > -1;
+  return toLowerCase(value).indexOf(toLowerCase(filter.value)) > -1;
 };
 
 const SexFilterCell = ({ filter, setFilter }) => (
@@ -74,7 +73,7 @@ export default class Demo extends React.PureComponent {
         columns={columns}
       >
         <FilteringState defaultFilters={[]} />
-        <LocalFiltering filterFn={filterFn} />
+        <LocalFiltering predicate={predicate} />
         <TableView />
         <TableHeaderRow />
         <TableFilterRow

--- a/packages/dx-react-demos/src/material-ui/filtering/custom-filter-row.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/custom-filter-row.jsx
@@ -18,13 +18,12 @@ import {
   generateRows,
 } from '../../demo-data/generator';
 
-const filterFn = (row, filter) => {
-  const toLowerCase = value => String(value).toLowerCase();
-
+const toLowerCase = value => String(value).toLowerCase();
+const predicate = (value, filter) => {
   if (filter.columnName === 'sex') {
-    return toLowerCase(row[filter.columnName]) === toLowerCase(filter.value);
+    return toLowerCase(value) === toLowerCase(filter.value);
   }
-  return toLowerCase(row[filter.columnName]).indexOf(toLowerCase(filter.value)) > -1;
+  return toLowerCase(value).indexOf(toLowerCase(filter.value)) > -1;
 };
 
 const styles = theme => ({
@@ -79,7 +78,7 @@ export default class Demo extends React.PureComponent {
         columns={columns}
       >
         <FilteringState defaultFilters={[]} />
-        <LocalFiltering filterFn={filterFn} />
+        <LocalFiltering predicate={predicate} />
         <TableView />
         <TableHeaderRow />
         <TableFilterRow

--- a/packages/dx-react-grid/docs/guides/filtering.md
+++ b/packages/dx-react-grid/docs/guides/filtering.md
@@ -33,7 +33,7 @@ Define a filter row cell template using the `TableFilterRow` plugin's `filterCel
 
 ## Custom Filtering Algorithm
 
-You can also specify a filtering predicate using the `LocalFiltering` plugin's `filterFn` property to implement a custom filtering logic.
+You can also specify a filtering predicate using the `LocalFiltering` plugin's `predicate` property to implement a custom filtering logic.
 
 .embedded-demo(filtering/custom-filter-row)
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,7 +12,7 @@ Plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-filterFn | (row: [Row](grid.md#row), filter: [Filter](filtering-state.md#filter)) => boolean | | A function used to apply the filter to the data row
+predicate | (value: any, filter: [Filter](filtering-state.md#filter), row: [Row](grid.md#row)) => boolean | | A function used to apply the filter to the cell value
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/src/plugins/local-filtering.jsx
+++ b/packages/dx-react-grid/src/plugins/local-filtering.jsx
@@ -9,10 +9,10 @@ const pluginDependencies = [
 
 export class LocalFiltering extends React.PureComponent {
   render() {
-    const { filterFn } = this.props;
+    const { predicate } = this.props;
 
     const rowsComputed = ({ rows, filters, getCellData }) =>
-      filteredRows(rows, filters, getCellData, filterFn);
+      filteredRows(rows, filters, getCellData, predicate);
 
     return (
       <PluginContainer
@@ -26,10 +26,10 @@ export class LocalFiltering extends React.PureComponent {
 }
 
 LocalFiltering.propTypes = {
-  filterFn: PropTypes.func,
+  predicate: PropTypes.func,
 };
 
 LocalFiltering.defaultProps = {
-  filterFn: undefined,
+  predicate: undefined,
 };
 


### PR DESCRIPTION
BREAKING CHANGE:
The 'filterFn' property of the LocalFiltering has been renamed to 'predicate'. The argument list has been changed from `filterFn(row: Row, filter: Filter) => boolean` to  `predicate(value: any, filter: Filter, row: Row) => boolean`.