### PR TITLE
refactor(react-grid): use a custom filtering algorithm depend on column name

### DIFF
--- a/packages/dx-grid-core/src/plugins/filtering-state/computeds.js
+++ b/packages/dx-grid-core/src/plugins/filtering-state/computeds.js
@@ -1,15 +1,23 @@
 const toLowerCase = value => String(value).toLowerCase();
 
+const defaultPredicate = (value, filter) =>
+  toLowerCase(value).indexOf(toLowerCase(filter.value)) > -1;
+
 export const filteredRows = (
   rows,
   filters,
   getCellValue,
-  predicate = (value, filter) => toLowerCase(value).indexOf(toLowerCase(filter.value)) > -1,
+  getColumnPredicate,
 ) => {
   if (!filters.length) return rows;
 
   return rows.filter(row => filters.reduce(
-    (acc, filter) => acc && predicate(getCellValue(row, filter.columnName), filter, row),
+    (acc, filter) => {
+      const { columnName, ...filterConfig } = filter;
+      const predicate = (getColumnPredicate && getColumnPredicate(columnName)) || defaultPredicate;
+
+      return acc && predicate(getCellValue(row, columnName), filterConfig, row);
+    },
     true,
   ));
 };

--- a/packages/dx-grid-core/src/plugins/filtering-state/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/filtering-state/computeds.test.js
@@ -38,5 +38,31 @@ describe('FilteringState computeds', () => {
         { a: 1, b: 2 },
       ]);
     });
+
+    it('can filter using custom predicate', () => {
+      const getColumnPredicate = jest.fn();
+
+      getColumnPredicate
+        .mockImplementation(() => (value, filter, row) => value === 1 && row.b === 2);
+
+      const filters = [{ columnName: 'a', value: 1 }];
+      const filtered = filteredRows(rows, filters, getCellValue, getColumnPredicate);
+
+      expect(getColumnPredicate).toBeCalledWith(filters[0].columnName);
+      expect(filtered).toEqual([
+        { a: 1, b: 2 },
+      ]);
+    });
+
+    it('should filter using default predicate if custom predicate returns nothing', () => {
+      const getColumnPredicate = () => undefined;
+      const filters = [{ columnName: 'a', value: 1 }];
+      const filtered = filteredRows(rows, filters, getCellValue, getColumnPredicate);
+
+      expect(filtered).toEqual([
+        { a: 1, b: 1 },
+        { a: 1, b: 2 },
+      ]);
+    });
   });
 });

--- a/packages/dx-react-demos/src/bootstrap3/filtering/custom-filtering-algorithm.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/filtering/custom-filtering-algorithm.jsx
@@ -15,8 +15,8 @@ import {
 } from '../../demo-data/generator';
 
 const toLowerCase = value => String(value).toLowerCase();
-const predicate = (value, filter) =>
-  toLowerCase(value).startsWith(toLowerCase(filter.value));
+const filterByCity = (value, filter) => toLowerCase(value).startsWith(toLowerCase(filter.value));
+const getColumnPredicate = columnName => (columnName === 'city' ? filterByCity : undefined);
 
 export default class Demo extends React.PureComponent {
   constructor(props) {
@@ -41,7 +41,7 @@ export default class Demo extends React.PureComponent {
         columns={columns}
       >
         <FilteringState defaultFilters={[{ columnName: 'city', value: 'Paris' }]} />
-        <LocalFiltering predicate={predicate} />
+        <LocalFiltering getColumnPredicate={getColumnPredicate} />
         <TableView />
         <TableHeaderRow />
         <TableFilterRow />

--- a/packages/dx-react-demos/src/material-ui/filtering/custom-filtering-algorithm.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/custom-filtering-algorithm.jsx
@@ -15,8 +15,8 @@ import {
 } from '../../demo-data/generator';
 
 const toLowerCase = value => String(value).toLowerCase();
-const predicate = (value, filter) =>
-  toLowerCase(value).startsWith(toLowerCase(filter.value));
+const filterByCity = (value, filter) => toLowerCase(value).startsWith(toLowerCase(filter.value));
+const getColumnPredicate = columnName => (columnName === 'city' ? filterByCity : undefined);
 
 export default class Demo extends React.PureComponent {
   constructor(props) {
@@ -41,7 +41,7 @@ export default class Demo extends React.PureComponent {
         columns={columns}
       >
         <FilteringState defaultFilters={[{ columnName: 'city', value: 'Paris' }]} />
-        <LocalFiltering predicate={predicate} />
+        <LocalFiltering getColumnPredicate={getColumnPredicate} />
         <TableView />
         <TableHeaderRow />
         <TableFilterRow />

--- a/packages/dx-react-grid/docs/guides/filtering.md
+++ b/packages/dx-react-grid/docs/guides/filtering.md
@@ -27,9 +27,9 @@ In the [controlled mode](controlled-and-uncontrolled-modes.md), pass the filteri
 
 .embedded-demo(filtering/local-filtering-controlled)
 
-### Using Custom Filtering Algorithms
+### <a name="using-custom-filtering-algorithm"></a>Using Custom Filtering Algorithms
 
-You can also specify a filtering predicate using the `LocalFiltering` plugin's `predicate` property to implement a custom filtering logic.
+You can also specify a filtering predicate using the `LocalFiltering` plugin's `getColumnPredicate` property to implement a custom filtering logic.
 
 .embedded-demo(filtering/custom-filtering-algorithm)
 

--- a/packages/dx-react-grid/docs/guides/filtering.md
+++ b/packages/dx-react-grid/docs/guides/filtering.md
@@ -35,7 +35,7 @@ You can also specify a filtering predicate using the `LocalFiltering` plugin's `
 
 ## Setting up Remote Filtering
 
-You can handle the Grid's filtering state changes to request data from the server with the corresponding filters applied if your data service supports filtering operations.
+It is possible to perform filtering remotely by handling filtering state changes, generating a request, and sending it to the server.
 
 Filtering options are updated once an end-user modifies a text within a Filter Row editor or other filtering control. Handle filtering option changes using the `FilteringState` plugin's `onFiltersChange` event and request data from the server using the applied filtering options. Once the filtered data is received from the server, pass it to the `Grid` component's `rows` property.
 

--- a/packages/dx-react-grid/docs/guides/filtering.md
+++ b/packages/dx-react-grid/docs/guides/filtering.md
@@ -35,7 +35,7 @@ You can also specify a filtering predicate using the `LocalFiltering` plugin's `
 
 ## Setting up Remote Filtering
 
-You can handle Grid filtering state changes to request data from the server with the corresponding filters applied if your data service supports filtering operations.
+You can handle the Grid's filtering state changes to request data from the server with the corresponding filters applied if your data service supports filtering operations.
 
 Filtering options are updated once an end-user modifies a text within a Filter Row editor or other filtering control. Handle filtering option changes using the `FilteringState` plugin's `onFiltersChange` event and request data from the server using the applied filtering options. Once the filtered data is received from the server, pass it to the `Grid` component's `rows` property.
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,7 +12,11 @@ Plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-getColumnPredicate | (columnName: string) => (value: any, filter: Object, row: [Row](grid.md#row)) => boolean | | A function used to apply the filter to the cell value. The `filter` parameter accepts an object containing the 'value' field. However, you can use the [setFilter](table-filter-row.md#filter-cell-args) function to extend this object to the fields your filtering algorithm requires.
+getColumnPredicate | (columnName: string) => [Predicate](#predicate) &#124; undefined | | A function used to apply the filter to the cell value. See the [filtering guide](../guides/filtering.md#using-custom-filtering-algorithm) for more information.
+
+## Interfaces
+### <a name="predicate"></a>Predicate
+A function with the following signature `(value: any, filter: Object, row: Row) => boolean`. The `filter` parameter accepts an object containing the 'value' field. However, you can use the [setFilter](table-filter-row.md#filter-cell-args) function to extend this object to the fields your filtering algorithm requires.
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,7 +12,7 @@ Plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-getColumnPredicate | Function | | A function used to apply the filter to the cell value. Should return the filtering function like `(value, filter, row) => boolean`. For more information see the [filtering guide](../guides/filtering.md#using-custom-filtering-algorithm).
+getColumnPredicate | Function | | A function used to apply the filter to the cell value. Should return the filtering function like `(value: any, filter: object, row: Row) => boolean`. The `filter` object contains the information about a filter value `{ value: '...' }` and can be extended through the [setFilter](table-filter-row.md#filter-cell-args) function, for instance. For more information see the [filtering guide](../guides/filtering.md#using-custom-filtering-algorithm).
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,7 +12,7 @@ Plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-getColumnPredicate | Function | | A function used to apply the filter to the cell value. Should return the filtering function like `(value: any, filter: object, row: Row) => boolean`. The `filter` object contains the information about a filter value `{ value: '...' }` and can be extended through the [setFilter](table-filter-row.md#filter-cell-args) function, for instance. For more information see the [filtering guide](../guides/filtering.md#using-custom-filtering-algorithm).
+getColumnPredicate | (columnName: string) => (value:&nbsp;any,&nbsp;filter:&nbsp;Object,&nbsp;row:&nbsp;[Row](grid.md#row))&nbsp;=>&nbsp;boolean | | A function used to apply the filter to the cell value. The `filter` is a configuration object that looks like `{ value: '...' }`. It can be extended through the [setFilter](table-filter-row.md#filter-cell-args) function, for instance. For more information see the [filtering guide](../guides/filtering.md#using-custom-filtering-algorithm).
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,7 +12,7 @@ Plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-getColumnPredicate | (columnName: string) => (value:&nbsp;any,&nbsp;filter:&nbsp;Object,&nbsp;row:&nbsp;[Row](grid.md#row))&nbsp;=>&nbsp;boolean | | A function used to apply the filter to the cell value. The `filter` is a configuration object that looks like `{ value: '...' }`. It can be extended through the [setFilter](table-filter-row.md#filter-cell-args) function, for instance. For more information see the [filtering guide](../guides/filtering.md#using-custom-filtering-algorithm).
+getColumnPredicate | (columnName: string) => (value: any, filter: Object, row: [Row](grid.md#row)) => boolean | | A function used to apply the filter to the cell value. The `filter` is a configuration object that looks like `{ value: '...' }`. It can be extended through the [setFilter](table-filter-row.md#filter-cell-args) function, for instance. For more information see the [filtering guide](../guides/filtering.md#using-custom-filtering-algorithm).
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,7 +12,7 @@ Plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-predicate | (value: any, filter: [Filter](filtering-state.md#filter), row: [Row](grid.md#row)) => boolean | | A function used to apply the filter to the cell value
+getColumnPredicate | Function | | A function used to apply the filter to the cell value. Should return the filtering function like `(value, filter, row) => boolean`. For more information see the [filtering guide](../guides/filtering.md#using-custom-filtering-algorithm).
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,7 +12,7 @@ Plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-getColumnPredicate | (columnName: string) => (value: any, filter: Object, row: [Row](grid.md#row)) => boolean | | A function used to apply the filter to the cell value. The `filter` parameter accepts an object containing the 'value' field. However, you can use the [setFilter](table-filter-row.md#filter-cell-args) function to extend this object by the fields your filtering algorithm requires.
+getColumnPredicate | (columnName: string) => (value: any, filter: Object, row: [Row](grid.md#row)) => boolean | | A function used to apply the filter to the cell value. The `filter` parameter accepts an object containing the 'value' field. However, you can use the [setFilter](table-filter-row.md#filter-cell-args) function to extend this object to the fields your filtering algorithm requires.
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,7 +12,7 @@ Plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-getColumnPredicate | (columnName: string) => (value: any, filter: Object, row: [Row](grid.md#row)) => boolean | | A function used to apply the filter to the cell value. The `filter` is a configuration object that looks like `{ value: '...' }`. It can be extended through the [setFilter](table-filter-row.md#filter-cell-args) function, for instance. For more information see the [filtering guide](../guides/filtering.md#using-custom-filtering-algorithm).
+getColumnPredicate | (columnName: string) => (value: any, filter: Object, row: [Row](grid.md#row)) => boolean | | A function used to apply the filter to the cell value. The `filter` parameter accepts an object containing the 'value' field. However, you can use the [setFilter](table-filter-row.md#filter-cell-args) function to extend this object by the fields your filtering algorithm requires.
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,7 +12,7 @@ Plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-getColumnPredicate | (columnName: string) => [Predicate](#predicate) &#124; undefined | | A function used to apply the filter to the cell value. See the [filtering guide](../guides/filtering.md#using-custom-filtering-algorithm) for more information.
+getColumnPredicate | (columnName: string) => [Predicate](#predicate) &#124; undefined | | A function used to apply the filter to the cell value. See the [Filtering guide](../guides/filtering.md#using-custom-filtering-algorithm) for more information.
 
 ## Interfaces
 ### <a name="predicate"></a>Predicate

--- a/packages/dx-react-grid/src/plugins/local-filtering.jsx
+++ b/packages/dx-react-grid/src/plugins/local-filtering.jsx
@@ -9,10 +9,10 @@ const pluginDependencies = [
 
 export class LocalFiltering extends React.PureComponent {
   render() {
-    const { predicate } = this.props;
+    const { getColumnPredicate } = this.props;
 
     const rowsComputed = ({ rows, filters, getCellValue }) =>
-      filteredRows(rows, filters, getCellValue, predicate);
+      filteredRows(rows, filters, getCellValue, getColumnPredicate);
 
     return (
       <PluginContainer
@@ -26,10 +26,10 @@ export class LocalFiltering extends React.PureComponent {
 }
 
 LocalFiltering.propTypes = {
-  predicate: PropTypes.func,
+  getColumnPredicate: PropTypes.func,
 };
 
 LocalFiltering.defaultProps = {
-  predicate: undefined,
+  getColumnPredicate: undefined,
 };
 


### PR DESCRIPTION
BREAKING CHANGE:
The `filterFn` property of the `LocalFiltering` has been renamed to `getColumnPredicate`. The argument list has been changed from `filterFn(row: Row, filter: Filter) => boolean` to  `getColumnPredicate(columnName: string) => Function`.  The returning function has the following signature `(value: any, filter, row: Row) => boolean`.