### PR TITLE
fix(react-grid): remove a redundant SelectionState dependency on LocalGrouping

### DIFF
--- a/packages/dx-react-grid/src/plugins/selection-state.jsx
+++ b/packages/dx-react-grid/src/plugins/selection-state.jsx
@@ -7,10 +7,6 @@ import {
   getAvailableToSelect,
 } from '@devexpress/dx-grid-core';
 
-const pluginDependencies = [
-  { pluginName: 'LocalGrouping', optional: true },
-];
-
 const availableToSelectComputed = ({ rows, getRowId, isGroupRow }) =>
   getAvailableToSelect(rows, getRowId, isGroupRow);
 
@@ -39,7 +35,6 @@ export class SelectionState extends React.PureComponent {
     return (
       <PluginContainer
         pluginName="SelectionState"
-        dependencies={pluginDependencies}
       >
         <Action
           name="setRowsSelection"

--- a/packages/dx-react-grid/src/plugins/selection-state.test.jsx
+++ b/packages/dx-react-grid/src/plugins/selection-state.test.jsx
@@ -47,7 +47,6 @@ describe('SelectionState', () => {
       getter: {
         isGroupRow: () => false,
       },
-      plugins: ['LocalGrouping'],
     };
 
     const tree = mount((


### PR DESCRIPTION
fixes #428 