### PR TITLE
refactor(react-grid): export of TableColumnResizing from theme packages

### DIFF
--- a/packages/dx-react-demos/src/bootstrap3/column-resizing/controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/column-resizing/controlled.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import {
-  TableColumnResizing,
-} from '@devexpress/dx-react-grid';
-import {
   Grid,
   TableView,
   TableHeaderRow,
+  TableColumnResizing,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
 import {

--- a/packages/dx-react-demos/src/bootstrap3/column-resizing/uncontrolled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/column-resizing/uncontrolled.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import {
-  TableColumnResizing,
-} from '@devexpress/dx-react-grid';
-import {
   Grid,
   TableView,
   TableHeaderRow,
+  TableColumnResizing,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
 import {

--- a/packages/dx-react-demos/src/bootstrap3/featured-redux-integration/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-redux-integration/demo.jsx
@@ -5,12 +5,12 @@ import { connect, Provider } from 'react-redux';
 import {
   SortingState, SelectionState, FilteringState, PagingState, GroupingState, RowDetailState,
   LocalFiltering, LocalGrouping, LocalPaging, LocalSorting,
-  ColumnOrderState, TableColumnResizing,
+  ColumnOrderState,
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
   TableView, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow, TableRowDetail,
-  GroupingPanel, PagingPanel, DragDropContext,
+  GroupingPanel, PagingPanel, DragDropContext, TableColumnResizing,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
 import {

--- a/packages/dx-react-demos/src/material-ui/column-resizing/controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-resizing/controlled.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import {
-  TableColumnResizing,
-} from '@devexpress/dx-react-grid';
-import {
   Grid,
   TableView,
   TableHeaderRow,
+  TableColumnResizing,
 } from '@devexpress/dx-react-grid-material-ui';
 
 import {

--- a/packages/dx-react-demos/src/material-ui/column-resizing/uncontrolled.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-resizing/uncontrolled.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import {
-  TableColumnResizing,
-} from '@devexpress/dx-react-grid';
-import {
   Grid,
   TableView,
   TableHeaderRow,
+  TableColumnResizing,
 } from '@devexpress/dx-react-grid-material-ui';
 
 import {

--- a/packages/dx-react-demos/src/material-ui/featured-redux-integration/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-redux-integration/demo.jsx
@@ -5,12 +5,12 @@ import { connect, Provider } from 'react-redux';
 import {
   SortingState, SelectionState, FilteringState, PagingState, GroupingState, RowDetailState,
   LocalFiltering, LocalGrouping, LocalPaging, LocalSorting,
-  ColumnOrderState, TableColumnResizing,
+  ColumnOrderState,
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
   TableView, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow, TableRowDetail,
-  GroupingPanel, PagingPanel, DragDropContext,
+  GroupingPanel, PagingPanel, DragDropContext, TableColumnResizing,
 } from '@devexpress/dx-react-grid-material-ui';
 
 import { withStyles } from 'material-ui/styles';

--- a/packages/dx-react-grid-bootstrap3/src/index.js
+++ b/packages/dx-react-grid-bootstrap3/src/index.js
@@ -13,3 +13,4 @@ export { TableHeaderRow } from './plugins/table-header-row';
 export { TableEditRow } from './plugins/table-edit-row';
 export { TableEditColumn } from './plugins/table-edit-column';
 export { TableColumnVisibility } from './plugins/table-column-visibility';
+export { TableColumnResizing } from './plugins/table-column-resizing';

--- a/packages/dx-react-grid-bootstrap3/src/plugins/table-column-resizing.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/plugins/table-column-resizing.jsx
@@ -1,21 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { TableColumnResizing as TableColumnResizingBase } from '@devexpress/dx-react-grid';
 
-export const TableColumnResizing = ({ columnWidths, onColumnWidthsChange, ...restProps }) => (
-  <TableColumnResizingBase
-    columnWidths={columnWidths}
-    onColumnWidthsChange={onColumnWidthsChange}
-    {...restProps}
-  />
-);
-
-TableColumnResizing.propTypes = {
-  columnWidths: PropTypes.objectOf(PropTypes.number),
-  onColumnWidthsChange: PropTypes.func,
-};
-
-TableColumnResizing.defaultProps = {
-  columnWidths: undefined,
-  onColumnWidthsChange: undefined,
-};
+export class TableColumnResizing extends React.PureComponent {
+  render() {
+    return (
+      <TableColumnResizingBase
+        {...this.props}
+      />
+    );
+  }
+}

--- a/packages/dx-react-grid-bootstrap3/src/plugins/table-column-resizing.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/plugins/table-column-resizing.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TableColumnResizing as TableColumnResizingBase } from '@devexpress/dx-react-grid';
+
+export const TableColumnResizing = ({ columnWidths, onColumnWidthsChange, ...restProps }) => (
+  <TableColumnResizingBase
+    columnWidths={columnWidths}
+    onColumnWidthsChange={onColumnWidthsChange}
+    {...restProps}
+  />
+);
+
+TableColumnResizing.propTypes = {
+  columnWidths: PropTypes.objectOf(PropTypes.number),
+  onColumnWidthsChange: PropTypes.func,
+};
+
+TableColumnResizing.defaultProps = {
+  columnWidths: undefined,
+  onColumnWidthsChange: undefined,
+};

--- a/packages/dx-react-grid-material-ui/src/index.js
+++ b/packages/dx-react-grid-material-ui/src/index.js
@@ -12,3 +12,4 @@ export { TableHeaderRow } from './plugins/table-header-row';
 export { TableEditColumn } from './plugins/table-edit-column';
 export { TableEditRow } from './plugins/table-edit-row';
 export { TableColumnVisibility } from './plugins/table-column-visibility';
+export { TableColumnResizing } from './plugins/table-column-resizing';

--- a/packages/dx-react-grid-material-ui/src/plugins/table-column-resizing.jsx
+++ b/packages/dx-react-grid-material-ui/src/plugins/table-column-resizing.jsx
@@ -1,21 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { TableColumnResizing as TableColumnResizingBase } from '@devexpress/dx-react-grid';
 
-export const TableColumnResizing = ({ columnWidths, onColumnWidthsChange, ...restProps }) => (
-  <TableColumnResizingBase
-    columnWidths={columnWidths}
-    onColumnWidthsChange={onColumnWidthsChange}
-    {...restProps}
-  />
-);
-
-TableColumnResizing.propTypes = {
-  columnWidths: PropTypes.objectOf(PropTypes.number),
-  onColumnWidthsChange: PropTypes.func,
-};
-
-TableColumnResizing.defaultProps = {
-  columnWidths: undefined,
-  onColumnWidthsChange: undefined,
-};
+export class TableColumnResizing extends React.PureComponent {
+  render() {
+    return (
+      <TableColumnResizingBase
+        {...this.props}
+      />
+    );
+  }
+}

--- a/packages/dx-react-grid-material-ui/src/plugins/table-column-resizing.jsx
+++ b/packages/dx-react-grid-material-ui/src/plugins/table-column-resizing.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TableColumnResizing as TableColumnResizingBase } from '@devexpress/dx-react-grid';
+
+export const TableColumnResizing = ({ columnWidths, onColumnWidthsChange, ...restProps }) => (
+  <TableColumnResizingBase
+    columnWidths={columnWidths}
+    onColumnWidthsChange={onColumnWidthsChange}
+    {...restProps}
+  />
+);
+
+TableColumnResizing.propTypes = {
+  columnWidths: PropTypes.objectOf(PropTypes.number),
+  onColumnWidthsChange: PropTypes.func,
+};
+
+TableColumnResizing.defaultProps = {
+  columnWidths: undefined,
+  onColumnWidthsChange: undefined,
+};


### PR DESCRIPTION
BREAKING CHANGES:

The TableColumnResizing plugin is now available in the "@devexpress/dx-react-grid-bootstrap3" and "@devexpress/dx-react-grid-material-ui" packages.

Use the following code to import the plugin.

```
import {
  TableColumnResizing,
} from from '@devexpress/dx-react-grid-bootstrap3'/* or '@devexpress/dx-react-grid-material-ui' */;
```