### PR TITLE
refactor(react-grid): rename VirtualTableView to VirtualTable component

### DIFF
--- a/packages/dx-react-demos/src/bootstrap3/featured-virtual-scrolling/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-virtual-scrolling/demo.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  VirtualTableView, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow,
+  VirtualTable, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow,
   TableColumnReordering, GroupingPanel, DragDropContext,
 } from '@devexpress/dx-react-grid-bootstrap3';
 import {
@@ -85,7 +85,7 @@ export default class Demo extends React.PureComponent {
 
         <SelectionState />
 
-        <VirtualTableView
+        <VirtualTable
           tableCellTemplate={this.tableCellTemplate}
         />
 

--- a/packages/dx-react-demos/src/bootstrap3/filtering/remote-filtering.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/filtering/remote-filtering.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  VirtualTableView,
+  VirtualTable,
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -87,7 +87,7 @@ export default class Demo extends React.PureComponent {
           <FilteringState
             onFiltersChange={this.changeFilters}
           />
-          <VirtualTableView />
+          <VirtualTable />
           <TableHeaderRow />
           <TableFilterRow rowHeight={51} />
         </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/grouping/remote-grouping-with-local-expanding.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/grouping/remote-grouping-with-local-expanding.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  VirtualTableView,
+  VirtualTable,
   TableHeaderRow,
   TableGroupRow,
   GroupingPanel,
@@ -118,7 +118,7 @@ export default class Demo extends React.PureComponent {
             grouping={tempGrouping}
             expandedGroups={tempExpandedGroups}
           />
-          <VirtualTableView />
+          <VirtualTable />
           <TableHeaderRow allowDragging />
           <TableGroupRow />
           <GroupingPanel allowDragging />

--- a/packages/dx-react-demos/src/bootstrap3/selection/select-all-virtual.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/selection/select-all-virtual.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  VirtualTableView,
+  VirtualTable,
   TableHeaderRow,
   TableSelection,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -45,7 +45,7 @@ export default class Demo extends React.PureComponent {
             selection={selection}
             onSelectionChange={this.changeSelection}
           />
-          <VirtualTableView />
+          <VirtualTable />
           <TableHeaderRow />
           <TableSelection />
         </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/sorting/remote-sorting.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/sorting/remote-sorting.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  VirtualTableView,
+  VirtualTable,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -85,7 +85,7 @@ export default class Demo extends React.PureComponent {
             sorting={sorting}
             onSortingChange={this.changeSorting}
           />
-          <VirtualTableView />
+          <VirtualTable />
           <TableHeaderRow allowSorting />
         </Grid>
         {loading && <Loading />}

--- a/packages/dx-react-demos/src/bootstrap3/virtual-scrolling/basic.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/virtual-scrolling/basic.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Grid,
-  VirtualTableView,
+  VirtualTable,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -39,7 +39,7 @@ export default class Demo extends React.PureComponent {
         columns={columns}
         getRowId={getRowId}
       >
-        <VirtualTableView />
+        <VirtualTable />
         <TableHeaderRow />
       </Grid>
     );

--- a/packages/dx-react-demos/src/material-ui/featured-virtual-scrolling/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-virtual-scrolling/demo.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  VirtualTableView, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow,
+  VirtualTable, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow,
   GroupingPanel, DragDropContext, TableColumnReordering,
 } from '@devexpress/dx-react-grid-material-ui';
 import {
@@ -85,7 +85,7 @@ export default class Demo extends React.PureComponent {
 
         <SelectionState />
 
-        <VirtualTableView
+        <VirtualTable
           tableCellTemplate={this.tableCellTemplate}
         />
         <TableHeaderRow allowSorting allowDragging />

--- a/packages/dx-react-demos/src/material-ui/filtering/remote-filtering.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/remote-filtering.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  VirtualTableView,
+  VirtualTable,
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -87,7 +87,7 @@ export default class Demo extends React.PureComponent {
           <FilteringState
             onFiltersChange={this.changeFilters}
           />
-          <VirtualTableView />
+          <VirtualTable />
           <TableHeaderRow />
           <TableFilterRow rowHeight={51} />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/grouping/remote-grouping-with-local-expanding.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/remote-grouping-with-local-expanding.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  VirtualTableView,
+  VirtualTable,
   TableHeaderRow,
   TableGroupRow,
   GroupingPanel,
@@ -118,7 +118,7 @@ export default class Demo extends React.PureComponent {
             grouping={tempGrouping}
             expandedGroups={tempExpandedGroups}
           />
-          <VirtualTableView />
+          <VirtualTable />
           <TableHeaderRow allowDragging />
           <TableGroupRow />
           <GroupingPanel allowDragging />

--- a/packages/dx-react-demos/src/material-ui/selection/select-all-virtual.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/select-all-virtual.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  VirtualTableView,
+  VirtualTable,
   TableHeaderRow,
   TableSelection,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -45,7 +45,7 @@ export default class Demo extends React.PureComponent {
             selection={selection}
             onSelectionChange={this.changeSelection}
           />
-          <VirtualTableView />
+          <VirtualTable />
           <TableHeaderRow />
           <TableSelection />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/sorting/remote-sorting.jsx
+++ b/packages/dx-react-demos/src/material-ui/sorting/remote-sorting.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  VirtualTableView,
+  VirtualTable,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
 
@@ -85,7 +85,7 @@ export default class Demo extends React.PureComponent {
             sorting={sorting}
             onSortingChange={this.changeSorting}
           />
-          <VirtualTableView />
+          <VirtualTable />
           <TableHeaderRow allowSorting />
         </Grid>
         {loading && <Loading />}

--- a/packages/dx-react-demos/src/material-ui/virtual-scrolling/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/virtual-scrolling/basic.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Grid,
-  VirtualTableView,
+  VirtualTable,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
 
@@ -39,7 +39,7 @@ export default class Demo extends React.PureComponent {
         columns={columns}
         getRowId={getRowId}
       >
-        <VirtualTableView />
+        <VirtualTable />
         <TableHeaderRow />
       </Grid>
     );

--- a/packages/dx-react-grid-bootstrap3/src/index.js
+++ b/packages/dx-react-grid-bootstrap3/src/index.js
@@ -7,7 +7,7 @@ export { TableRowDetail } from './plugins/table-row-detail';
 export { TableGroupRow } from './plugins/table-group-row';
 export { TableSelection } from './plugins/table-selection';
 export { TableView } from './plugins/table-view';
-export { VirtualTableView } from './plugins/virtual-table-view';
+export { VirtualTable } from './plugins/virtual-table';
 export { TableFilterRow } from './plugins/table-filter-row';
 export { TableHeaderRow } from './plugins/table-header-row';
 export { TableEditRow } from './plugins/table-edit-row';

--- a/packages/dx-react-grid-bootstrap3/src/plugins/virtual-table.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/plugins/virtual-table.jsx
@@ -3,23 +3,25 @@ import PropTypes from 'prop-types';
 import { combineTemplates } from '@devexpress/dx-react-core';
 import { TableView as TableViewBase } from '@devexpress/dx-react-grid';
 import { VirtualTableLayout } from '../templates/virtual-table-layout';
-import { TableRow } from '../templates/table-row';
 import { TableCell } from '../templates/table-cell';
-import { TableStubCell } from '../templates/table-stub-cell';
+import { TableRow } from '../templates/table-row';
 import { TableNoDataCell } from '../templates/table-no-data-cell';
+import { TableStubCell } from '../templates/table-stub-cell';
+import { TableStubHeaderCell } from '../templates/table-stub-header-cell';
 
 const tableLayoutTemplate = props => <VirtualTableLayout {...props} />;
 const defaultRowTemplate = props => <TableRow {...props} />;
 const defaultNoDataRowTemplate = props => <TableRow {...props} />;
 const defaultCellTemplate = props => <TableCell {...props} />;
 const defaultStubCellTemplate = props => <TableStubCell {...props} />;
+const defaultStubHeaderCellTemplate = props => <TableStubHeaderCell {...props} />;
 const defaultNoDataCellTemplate = props => <TableNoDataCell {...props} />;
 
 const defaultMessages = {
   noData: 'No data',
 };
 
-export class VirtualTableView extends React.PureComponent {
+export class VirtualTable extends React.PureComponent {
   render() {
     const {
       tableCellTemplate,
@@ -59,7 +61,7 @@ export class VirtualTableView extends React.PureComponent {
         )}
         tableStubHeaderCellTemplate={combineTemplates(
           tableStubHeaderCellTemplate,
-          defaultStubCellTemplate,
+          defaultStubHeaderCellTemplate,
         )}
         tableNoDataCellTemplate={combineTemplates(
           tableNoDataCellTemplate,
@@ -72,7 +74,7 @@ export class VirtualTableView extends React.PureComponent {
   }
 }
 
-VirtualTableView.propTypes = {
+VirtualTable.propTypes = {
   tableCellTemplate: PropTypes.func,
   tableRowTemplate: PropTypes.func,
   tableNoDataRowTemplate: PropTypes.func,
@@ -86,14 +88,14 @@ VirtualTableView.propTypes = {
   }),
 };
 
-VirtualTableView.defaultProps = {
+VirtualTable.defaultProps = {
   tableCellTemplate: undefined,
   tableRowTemplate: undefined,
   tableNoDataRowTemplate: undefined,
   tableStubCellTemplate: undefined,
   tableStubHeaderCellTemplate: undefined,
   tableNoDataCellTemplate: undefined,
-  estimatedRowHeight: 48,
+  estimatedRowHeight: 37,
   height: 530,
   messages: {},
 };

--- a/packages/dx-react-grid-material-ui/src/index.js
+++ b/packages/dx-react-grid-material-ui/src/index.js
@@ -7,7 +7,7 @@ export { TableRowDetail } from './plugins/table-row-detail';
 export { TableGroupRow } from './plugins/table-group-row';
 export { TableSelection } from './plugins/table-selection';
 export { TableView } from './plugins/table-view';
-export { VirtualTableView } from './plugins/virtual-table-view';
+export { VirtualTable } from './plugins/virtual-table';
 export { TableFilterRow } from './plugins/table-filter-row';
 export { TableHeaderRow } from './plugins/table-header-row';
 export { TableEditColumn } from './plugins/table-edit-column';

--- a/packages/dx-react-grid-material-ui/src/plugins/virtual-table.jsx
+++ b/packages/dx-react-grid-material-ui/src/plugins/virtual-table.jsx
@@ -3,25 +3,23 @@ import PropTypes from 'prop-types';
 import { combineTemplates } from '@devexpress/dx-react-core';
 import { TableView as TableViewBase } from '@devexpress/dx-react-grid';
 import { VirtualTableLayout } from '../templates/virtual-table-layout';
-import { TableCell } from '../templates/table-cell';
 import { TableRow } from '../templates/table-row';
-import { TableNoDataCell } from '../templates/table-no-data-cell';
+import { TableCell } from '../templates/table-cell';
 import { TableStubCell } from '../templates/table-stub-cell';
-import { TableStubHeaderCell } from '../templates/table-stub-header-cell';
+import { TableNoDataCell } from '../templates/table-no-data-cell';
 
 const tableLayoutTemplate = props => <VirtualTableLayout {...props} />;
 const defaultRowTemplate = props => <TableRow {...props} />;
 const defaultNoDataRowTemplate = props => <TableRow {...props} />;
 const defaultCellTemplate = props => <TableCell {...props} />;
 const defaultStubCellTemplate = props => <TableStubCell {...props} />;
-const defaultStubHeaderCellTemplate = props => <TableStubHeaderCell {...props} />;
 const defaultNoDataCellTemplate = props => <TableNoDataCell {...props} />;
 
 const defaultMessages = {
   noData: 'No data',
 };
 
-export class VirtualTableView extends React.PureComponent {
+export class VirtualTable extends React.PureComponent {
   render() {
     const {
       tableCellTemplate,
@@ -61,7 +59,7 @@ export class VirtualTableView extends React.PureComponent {
         )}
         tableStubHeaderCellTemplate={combineTemplates(
           tableStubHeaderCellTemplate,
-          defaultStubHeaderCellTemplate,
+          defaultStubCellTemplate,
         )}
         tableNoDataCellTemplate={combineTemplates(
           tableNoDataCellTemplate,
@@ -74,7 +72,7 @@ export class VirtualTableView extends React.PureComponent {
   }
 }
 
-VirtualTableView.propTypes = {
+VirtualTable.propTypes = {
   tableCellTemplate: PropTypes.func,
   tableRowTemplate: PropTypes.func,
   tableNoDataRowTemplate: PropTypes.func,
@@ -88,14 +86,14 @@ VirtualTableView.propTypes = {
   }),
 };
 
-VirtualTableView.defaultProps = {
+VirtualTable.defaultProps = {
   tableCellTemplate: undefined,
   tableRowTemplate: undefined,
   tableNoDataRowTemplate: undefined,
   tableStubCellTemplate: undefined,
   tableStubHeaderCellTemplate: undefined,
   tableNoDataCellTemplate: undefined,
-  estimatedRowHeight: 37,
+  estimatedRowHeight: 48,
   height: 530,
   messages: {},
 };

--- a/packages/dx-react-grid/demos/featured/virtual-scrolling.md
+++ b/packages/dx-react-grid/demos/featured/virtual-scrolling.md
@@ -1,5 +1,5 @@
 # React Grid Virtual Scrolling (200K rows)
 
-The `VirtualTableView` plugin provides the virtual scrolling mode as an alternative to data paging. It allows end users to navigate to data rows using the vertical scrollbar. In this demo, the Grid with enabled virtual scrolling is bound to a 200,000 record data source.
+The `VirtualTable` plugin provides the virtual scrolling mode as an alternative to data paging. It allows end users to navigate to data rows using the vertical scrollbar. In this demo, the Grid with enabled virtual scrolling is bound to a 200,000 record data source.
 
 .embedded-demo(featured-virtual-scrolling/demo)

--- a/packages/dx-react-grid/docs/guides/virtual-scrolling.md
+++ b/packages/dx-react-grid/docs/guides/virtual-scrolling.md
@@ -6,7 +6,7 @@ Virtual scrolling allows the Grid component to display thousands of records on a
 
 ## Plugin List
 
-The [VirtualTableView](../reference/virtual-table-view.md) plugin implements the virtual scrolling mode, and it should be used instead of the [TableView](../reference/table-view.md) as they implement the same interfaces.
+The [VirtualTable](../reference/virtual-table.md) plugin implements the virtual scrolling mode, and it should be used instead of the [TableView](../reference/table-view.md) as they implement the same interfaces.
 
 Note that the [plugin order](./plugin-overview.md#plugin-order) is important.
 

--- a/packages/dx-react-grid/docs/reference/virtual-table.md
+++ b/packages/dx-react-grid/docs/reference/virtual-table.md
@@ -1,4 +1,4 @@
-# VirtualTableView Plugin Reference
+# VirtualTable Plugin Reference
 
 The plugin extends the [TableView](table-view.md) plugin. It renders a scrollable table instead of a static one.
 

--- a/site/_data/docs/navigation.yml
+++ b/site/_data/docs/navigation.yml
@@ -72,8 +72,8 @@ react:
           path: /react/grid/docs/reference/local-paging
         - title: TableView
           path: /react/grid/docs/reference/table-view
-        - title: VirtualTableView
-          path: /react/grid/docs/reference/virtual-table-view
+        - title: VirtualTable
+          path: /react/grid/docs/reference/virtual-table
         - title: TableHeaderRow
           path: /react/grid/docs/reference/table-header-row
         - title: TableSelection


### PR DESCRIPTION
BREAKING CHANGES:

The `VirtualTableView` component has been renamed to `VirtualTable`.