### PR TITLE
refactor(react-grid-material-ui): get rid of the Paper wrapper

### DIFF
--- a/packages/dx-react-demos/src/demo-viewer/demo-renderer.jsx
+++ b/packages/dx-react-demos/src/demo-viewer/demo-renderer.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Paper } from 'material-ui';
+
 import { themes, demos } from '../demo-registry';
 
 export const DemoRenderer = ({
@@ -15,11 +17,19 @@ export const DemoRenderer = ({
   const { DemoContainer } = themes
     .find(({ name: theme }) => theme === currentTheme);
 
-  return (
+  const demo = (
     <DemoContainer>
       <Component />
     </DemoContainer>
   );
+  if (currentTheme === 'material-ui') {
+    return (
+      <Paper>
+        {demo}
+      </Paper>
+    );
+  }
+  return demo;
 };
 
 DemoRenderer.propTypes = {

--- a/packages/dx-react-demos/src/demo-viewer/demo-renderer.jsx
+++ b/packages/dx-react-demos/src/demo-viewer/demo-renderer.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { Paper } from 'material-ui';
-
 import { themes, demos } from '../demo-registry';
 
 export const DemoRenderer = ({
@@ -17,19 +14,11 @@ export const DemoRenderer = ({
   const { DemoContainer } = themes
     .find(({ name: theme }) => theme === currentTheme);
 
-  const demo = (
+  return (
     <DemoContainer>
       <Component />
     </DemoContainer>
   );
-  if (currentTheme === 'material-ui') {
-    return (
-      <Paper>
-        {demo}
-      </Paper>
-    );
-  }
-  return demo;
 };
 
 DemoRenderer.propTypes = {

--- a/packages/dx-react-demos/src/material-ui/basic/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/basic/basic.jsx
@@ -5,6 +5,8 @@ import {
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
 
+import Paper from 'material-ui/Paper';
+
 import {
   generateRows,
   globalSalesValues,
@@ -30,13 +32,15 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <TableView />
-        <TableHeaderRow />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <TableView />
+          <TableHeaderRow />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/basic/table-cell-template.jsx
+++ b/packages/dx-react-demos/src/material-ui/basic/table-cell-template.jsx
@@ -6,7 +6,7 @@ import {
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
 
-import { TableCell } from 'material-ui';
+import { TableCell, Paper } from 'material-ui';
 
 import {
   generateRows,
@@ -68,13 +68,15 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <TableView tableCellTemplate={this.tableCellTemplate} />
-        <TableHeaderRow />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <TableView tableCellTemplate={this.tableCellTemplate} />
+          <TableHeaderRow />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/basic/table-row-template.jsx
+++ b/packages/dx-react-demos/src/material-ui/basic/table-row-template.jsx
@@ -6,7 +6,7 @@ import {
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
 
-import { TableRow } from 'material-ui';
+import { TableRow, Paper } from 'material-ui';
 
 import {
   generateRows,
@@ -41,13 +41,15 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <TableView tableRowTemplate={this.tableRowTemplate} />
-        <TableHeaderRow />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <TableView tableRowTemplate={this.tableRowTemplate} />
+          <TableHeaderRow />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/column-chooser/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-chooser/basic.jsx
@@ -39,16 +39,18 @@ export default class Demo extends React.PureComponent {
     return (
       <MUIGrid container>
         <MUIGrid item xs={12} sm={9}>
-          <Grid
-            rows={rows}
-            columns={columns}
-          >
-            <TableView />
-            <TableHeaderRow />
-            <TableColumnVisibility
-              hiddenColumns={hiddenColumns}
-            />
-          </Grid>
+          <Paper>
+            <Grid
+              rows={rows}
+              columns={columns}
+            >
+              <TableView />
+              <TableHeaderRow />
+              <TableColumnVisibility
+                hiddenColumns={hiddenColumns}
+              />
+            </Grid>
+          </Paper>
         </MUIGrid>
         <MUIGrid item xs={12} sm={3}>
           <Paper>

--- a/packages/dx-react-demos/src/material-ui/column-reordering/controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-reordering/controlled.jsx
@@ -6,7 +6,7 @@ import {
   TableHeaderRow,
   TableColumnReordering,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -35,18 +35,20 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, columnOrder } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <DragDropContext />
-        <TableView />
-        <TableColumnReordering
-          order={columnOrder}
-          onOrderChange={this.changeColumnOrder}
-        />
-        <TableHeaderRow allowDragging />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <DragDropContext />
+          <TableView />
+          <TableColumnReordering
+            order={columnOrder}
+            onOrderChange={this.changeColumnOrder}
+          />
+          <TableHeaderRow allowDragging />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/column-reordering/uncontrolled.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-reordering/uncontrolled.jsx
@@ -6,7 +6,7 @@ import {
   TableHeaderRow,
   TableColumnReordering,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -29,17 +29,19 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <DragDropContext />
-        <TableView />
-        <TableColumnReordering
-          defaultOrder={['city', 'sex', 'car', 'name']}
-        />
-        <TableHeaderRow allowDragging />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <DragDropContext />
+          <TableView />
+          <TableColumnReordering
+            defaultOrder={['city', 'sex', 'car', 'name']}
+          />
+          <TableHeaderRow allowDragging />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/column-resizing/controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-resizing/controlled.jsx
@@ -5,7 +5,7 @@ import {
   TableHeaderRow,
   TableColumnResizing,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -35,17 +35,19 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, columnWidths } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <TableView />
-        <TableColumnResizing
-          columnWidths={columnWidths}
-          onColumnWidthsChange={this.changeColumnWidths}
-        />
-        <TableHeaderRow allowResizing />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <TableView />
+          <TableColumnResizing
+            columnWidths={columnWidths}
+            onColumnWidthsChange={this.changeColumnWidths}
+          />
+          <TableHeaderRow allowResizing />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/column-resizing/uncontrolled.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-resizing/uncontrolled.jsx
@@ -5,7 +5,7 @@ import {
   TableHeaderRow,
   TableColumnResizing,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -31,14 +31,16 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, defaultColumnWidths } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <TableView />
-        <TableColumnResizing defaultColumnWidths={defaultColumnWidths} />
-        <TableHeaderRow allowResizing />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <TableView />
+          <TableColumnResizing defaultColumnWidths={defaultColumnWidths} />
+          <TableHeaderRow allowResizing />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors-in-columns.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors-in-columns.jsx
@@ -9,7 +9,7 @@ import {
   TableEditRow,
   TableEditColumn,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
   defaultNestedColumnValues,
@@ -91,19 +91,21 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-        getRowId={getRowId}
-      >
-        <EditingState
-          onCommitChanges={this.commitChanges}
-        />
-        <TableView />
-        <TableHeaderRow />
-        <TableEditRow />
-        <TableEditColumn allowAdding allowEditing allowDeleting />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+          getRowId={getRowId}
+        >
+          <EditingState
+            onCommitChanges={this.commitChanges}
+          />
+          <TableView />
+          <TableHeaderRow />
+          <TableEditRow />
+          <TableEditColumn allowAdding allowEditing allowDeleting />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors.jsx
@@ -9,7 +9,7 @@ import {
   TableEditRow,
   TableEditColumn,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
   defaultNestedColumnValues,
@@ -89,21 +89,23 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-        getRowId={getRowId}
-        getCellValue={getCellValue}
-      >
-        <EditingState
-          createRowChange={createRowChange}
-          onCommitChanges={this.commitChanges}
-        />
-        <TableView />
-        <TableHeaderRow />
-        <TableEditRow />
-        <TableEditColumn allowAdding allowEditing allowDeleting />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+          getRowId={getRowId}
+          getCellValue={getCellValue}
+        >
+          <EditingState
+            createRowChange={createRowChange}
+            onCommitChanges={this.commitChanges}
+          />
+          <TableView />
+          <TableHeaderRow />
+          <TableEditRow />
+          <TableEditColumn allowAdding allowEditing allowDeleting />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/data-types/editors.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-types/editors.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Chip from 'material-ui/Chip';
 import {
   DataTypeProvider,
   EditingState,
@@ -12,8 +11,10 @@ import {
   TableEditColumn,
 } from '@devexpress/dx-react-grid-material-ui';
 import {
+  Chip,
   Input,
   MenuItem,
+  Paper,
   Select,
 } from 'material-ui';
 
@@ -82,25 +83,27 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-        getRowId={row => row.id}
-      >
-        <BooleanTypeProvider />
-        <EditingState
-          onCommitChanges={this.commitChanges}
-          defaultEditingRows={[0]}
-        />
-        <TableView />
-        <TableHeaderRow />
-        <TableEditRow />
-        <TableEditColumn
-          allowAdding
-          allowEditing
-          allowDeleting
-        />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+          getRowId={row => row.id}
+        >
+          <BooleanTypeProvider />
+          <EditingState
+            onCommitChanges={this.commitChanges}
+            defaultEditingRows={[0]}
+          />
+          <TableView />
+          <TableHeaderRow />
+          <TableEditRow />
+          <TableEditColumn
+            allowAdding
+            allowEditing
+            allowDeleting
+          />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/data-types/formatters.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-types/formatters.jsx
@@ -7,7 +7,7 @@ import {
   TableView,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
   globalSalesValues,
@@ -49,15 +49,17 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <CurrencyTypeProvider />
-        <DateTypeProvider />
-        <TableView />
-        <TableHeaderRow />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <CurrencyTypeProvider />
+          <DateTypeProvider />
+          <TableView />
+          <TableHeaderRow />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/detail-row/detail-row-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/detail-row/detail-row-controlled.jsx
@@ -8,7 +8,7 @@ import {
   TableHeaderRow,
   TableRowDetail,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -35,20 +35,22 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, expandedRows } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <RowDetailState
-          expandedRows={expandedRows}
-          onExpandedRowsChange={this.changeExpandedDetails}
-        />
-        <TableView />
-        <TableHeaderRow />
-        <TableRowDetail
-          template={this.rowTemplate}
-        />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <RowDetailState
+            expandedRows={expandedRows}
+            onExpandedRowsChange={this.changeExpandedDetails}
+          />
+          <TableView />
+          <TableHeaderRow />
+          <TableRowDetail
+            template={this.rowTemplate}
+          />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/detail-row/simple-detail-row.jsx
+++ b/packages/dx-react-demos/src/material-ui/detail-row/simple-detail-row.jsx
@@ -8,7 +8,7 @@ import {
   TableHeaderRow,
   TableRowDetail,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -33,19 +33,21 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <RowDetailState
-          defaultExpandedRows={[2, 5]}
-        />
-        <TableView />
-        <TableHeaderRow />
-        <TableRowDetail
-          template={this.rowTemplate}
-        />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <RowDetailState
+            defaultExpandedRows={[2, 5]}
+          />
+          <TableView />
+          <TableHeaderRow />
+          <TableRowDetail
+            template={this.rowTemplate}
+          />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/editing/edit-row-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/editing/edit-row-controlled.jsx
@@ -9,7 +9,7 @@ import {
   TableEditRow,
   TableEditColumn,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
   defaultColumnValues,
@@ -80,29 +80,31 @@ export default class Demo extends React.PureComponent {
     } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-        getRowId={getRowId}
-      >
-        <EditingState
-          editingRows={editingRows}
-          onEditingRowsChange={this.changeEditingRows}
-          changedRows={changedRows}
-          onChangedRowsChange={this.changeChangedRows}
-          addedRows={addedRows}
-          onAddedRowsChange={this.changeAddedRows}
-          onCommitChanges={this.commitChanges}
-        />
-        <TableView />
-        <TableHeaderRow />
-        <TableEditRow />
-        <TableEditColumn
-          allowAdding={!addedRows.length}
-          allowEditing
-          allowDeleting
-        />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+          getRowId={getRowId}
+        >
+          <EditingState
+            editingRows={editingRows}
+            onEditingRowsChange={this.changeEditingRows}
+            changedRows={changedRows}
+            onChangedRowsChange={this.changeChangedRows}
+            addedRows={addedRows}
+            onAddedRowsChange={this.changeAddedRows}
+            onCommitChanges={this.commitChanges}
+          />
+          <TableView />
+          <TableHeaderRow />
+          <TableEditRow />
+          <TableEditColumn
+            allowAdding={!addedRows.length}
+            allowEditing
+            allowDeleting
+          />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/editing/edit-row.jsx
+++ b/packages/dx-react-demos/src/material-ui/editing/edit-row.jsx
@@ -9,7 +9,7 @@ import {
   TableEditRow,
   TableEditColumn,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
   defaultColumnValues,
@@ -61,23 +61,25 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-        getRowId={getRowId}
-      >
-        <EditingState
-          onCommitChanges={this.commitChanges}
-        />
-        <TableView />
-        <TableHeaderRow />
-        <TableEditRow />
-        <TableEditColumn
-          allowAdding
-          allowEditing
-          allowDeleting
-        />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+          getRowId={getRowId}
+        >
+          <EditingState
+            onCommitChanges={this.commitChanges}
+          />
+          <TableView />
+          <TableHeaderRow />
+          <TableEditRow />
+          <TableEditColumn
+            allowAdding
+            allowEditing
+            allowDeleting
+          />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
@@ -20,6 +20,7 @@ import {
   DialogTitle,
   MenuItem,
   Select,
+  Paper,
 } from 'material-ui';
 
 import DeleteIcon from 'material-ui-icons/Delete';
@@ -270,7 +271,7 @@ class DemoBase extends React.PureComponent {
     } = this.state;
 
     return (
-      <div>
+      <Paper>
         <Grid
           rows={rows}
           columns={columns}
@@ -352,7 +353,7 @@ class DemoBase extends React.PureComponent {
             <Button onClick={this.deleteRows} color="accent">Delete</Button>
           </DialogActions>
         </Dialog>
-      </div>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
@@ -338,15 +338,17 @@ class DemoBase extends React.PureComponent {
             <DialogContentText>
               Are you sure to delete the following row?
             </DialogContentText>
-            <Grid
-              rows={rows.filter(row => deletingRows.indexOf(row.id) > -1)}
-              columns={columns}
-            >
-              <TableView
-                tableCellTemplate={this.tableCellTemplate}
-              />
-              <TableHeaderRow />
-            </Grid>
+            <Paper>
+              <Grid
+                rows={rows.filter(row => deletingRows.indexOf(row.id) > -1)}
+                columns={columns}
+              >
+                <TableView
+                  tableCellTemplate={this.tableCellTemplate}
+                />
+                <TableHeaderRow />
+              </Grid>
+            </Paper>
           </DialogContent>
           <DialogActions>
             <Button onClick={this.cancelDelete} color="primary">Cancel</Button>

--- a/packages/dx-react-demos/src/material-ui/featured-redux-integration/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-redux-integration/demo.jsx
@@ -37,13 +37,15 @@ const GridDetailContainerBase = ({
     <div>
       <h5>{data.firstName} {data.lastName}&apos;s Tasks:</h5>
     </div>
-    <Grid
-      rows={data.tasks}
-      columns={columns}
-    >
-      <TableView />
-      <TableHeaderRow />
-    </Grid>
+    <Paper>
+      <Grid
+        rows={data.tasks}
+        columns={columns}
+      >
+        <TableView />
+        <TableHeaderRow />
+      </Grid>
+    </Paper>
   </div>
 );
 GridDetailContainerBase.propTypes = {

--- a/packages/dx-react-demos/src/material-ui/featured-redux-integration/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-redux-integration/demo.jsx
@@ -11,7 +11,7 @@ import {
   TableView, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow, TableRowDetail,
   GroupingPanel, PagingPanel, DragDropContext, TableColumnReordering, TableColumnResizing,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import { withStyles } from 'material-ui/styles';
 
 import {
@@ -81,77 +81,78 @@ const GridContainer = ({
   columnWidths,
   onColumnWidthsChange,
 }) => (
-  <Grid
-    rows={rows}
-    columns={columns}
-  >
-    <FilteringState
-      filters={filters}
-      onFiltersChange={onFiltersChange}
-    />
-    <SortingState
-      sorting={sorting}
-      onSortingChange={onSortingChange}
-    />
-    <GroupingState
-      grouping={grouping}
-      onGroupingChange={onGroupingChange}
-      expandedGroups={expandedGroups}
-      onExpandedGroupsChange={onExpandedGroupsChange}
-    />
-    <PagingState
-      currentPage={currentPage}
-      onCurrentPageChange={onCurrentPageChange}
-      pageSize={pageSize}
-      onPageSizeChange={onPageSizeChange}
-    />
-    <RowDetailState
-      expandedRows={expandedRows}
-      onExpandedRowsChange={onExpandedRowsChange}
-    />
+  <Paper>
+    <Grid
+      rows={rows}
+      columns={columns}
+    >
+      <FilteringState
+        filters={filters}
+        onFiltersChange={onFiltersChange}
+      />
+      <SortingState
+        sorting={sorting}
+        onSortingChange={onSortingChange}
+      />
+      <GroupingState
+        grouping={grouping}
+        onGroupingChange={onGroupingChange}
+        expandedGroups={expandedGroups}
+        onExpandedGroupsChange={onExpandedGroupsChange}
+      />
+      <PagingState
+        currentPage={currentPage}
+        onCurrentPageChange={onCurrentPageChange}
+        pageSize={pageSize}
+        onPageSizeChange={onPageSizeChange}
+      />
+      <RowDetailState
+        expandedRows={expandedRows}
+        onExpandedRowsChange={onExpandedRowsChange}
+      />
 
-    <LocalFiltering />
-    <LocalSorting />
-    <LocalGrouping />
-    <LocalPaging />
+      <LocalFiltering />
+      <LocalSorting />
+      <LocalGrouping />
+      <LocalPaging />
 
-    <SelectionState
-      selection={selection}
-      onSelectionChange={onSelectionChange}
-    />
+      <SelectionState
+        selection={selection}
+        onSelectionChange={onSelectionChange}
+      />
 
-    <DragDropContext />
+      <DragDropContext />
 
-    <TableView />
+      <TableView />
 
-    <TableColumnReordering
-      order={columnOrder}
-      onOrderChange={onColumnOrderChange}
-    />
+      <TableColumnReordering
+        order={columnOrder}
+        onOrderChange={onColumnOrderChange}
+      />
 
-    <TableColumnResizing
-      columnWidths={columnWidths}
-      onColumnWidthsChange={onColumnWidthsChange}
-    />
+      <TableColumnResizing
+        columnWidths={columnWidths}
+        onColumnWidthsChange={onColumnWidthsChange}
+      />
 
-    <TableHeaderRow allowSorting allowDragging allowResizing />
-    <TableFilterRow />
-    <TableSelection />
-    <TableRowDetail
-      template={({ row }) => (
-        <GridDetailContainer
-          data={row}
-          columns={detailColumns}
-        />
-      )}
-    />
-    <TableGroupRow />
-    <GroupingPanel allowSorting allowDragging />
-    <PagingPanel
-      allowedPageSizes={allowedPageSizes}
-    />
-
-  </Grid>
+      <TableHeaderRow allowSorting allowDragging allowResizing />
+      <TableFilterRow />
+      <TableSelection />
+      <TableRowDetail
+        template={({ row }) => (
+          <GridDetailContainer
+            data={row}
+            columns={detailColumns}
+          />
+        )}
+      />
+      <TableGroupRow />
+      <GroupingPanel allowSorting allowDragging />
+      <PagingPanel
+        allowedPageSizes={allowedPageSizes}
+      />
+    </Grid>
+  </Paper>
 );
 GridContainer.propTypes = {
   rows: PropTypes.array.isRequired,

--- a/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
@@ -10,7 +10,7 @@ import {
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
-import { TableCell } from 'material-ui';
+import { TableCell, Paper } from 'material-ui';
 import { withStyles } from 'material-ui/styles';
 import { Loading } from '../components/loading';
 
@@ -155,7 +155,7 @@ export default class Demo extends React.PureComponent {
     } = this.state;
 
     return (
-      <div style={{ position: 'relative' }}>
+      <Paper style={{ position: 'relative' }}>
         <Grid
           rows={rows}
           columns={columns}
@@ -188,7 +188,7 @@ export default class Demo extends React.PureComponent {
           />
         </Grid>
         {loading && <Loading />}
-      </div>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/featured-theming/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-theming/demo.jsx
@@ -181,49 +181,51 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, allowedPageSizes } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <SortingState />
-        <GroupingState />
-        <PagingState
-          defaultCurrentPage={0}
-          defaultPageSize={10}
-        />
-        <RowDetailState
-          defaultExpandedRows={[2]}
-        />
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <SortingState />
+          <GroupingState />
+          <PagingState
+            defaultCurrentPage={0}
+            defaultPageSize={10}
+          />
+          <RowDetailState
+            defaultExpandedRows={[2]}
+          />
 
-        <LocalSorting />
-        <LocalGrouping />
-        <LocalPaging />
+          <LocalSorting />
+          <LocalGrouping />
+          <LocalPaging />
 
-        <SelectionState
-          defaultSelection={[1, 3, 18]}
-        />
+          <SelectionState
+            defaultSelection={[1, 3, 18]}
+          />
 
-        <DragDropContext />
+          <DragDropContext />
 
-        <TableView />
+          <TableView />
 
-        <TableColumnReordering defaultOrder={columns.map(column => column.name)} />
+          <TableColumnReordering defaultOrder={columns.map(column => column.name)} />
 
-        <TableHeaderRow allowSorting allowDragging />
-        <PagingPanel
-          allowedPageSizes={allowedPageSizes}
-        />
-        <TableSelection />
-        <TableRowDetail
-          template={({ row }) => (
-            <GridDetailContainer
-              data={row}
-            />
-          )}
-        />
-        <TableGroupRow />
-        <GroupingPanel allowSorting allowDragging />
-      </Grid>
+          <TableHeaderRow allowSorting allowDragging />
+          <PagingPanel
+            allowedPageSizes={allowedPageSizes}
+          />
+          <TableSelection />
+          <TableRowDetail
+            template={({ row }) => (
+              <GridDetailContainer
+                data={row}
+              />
+            )}
+          />
+          <TableGroupRow />
+          <GroupingPanel allowSorting allowDragging />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/featured-uncontrolled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-uncontrolled-mode/demo.jsx
@@ -8,13 +8,13 @@ import {
   TableView, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow,
   PagingPanel, GroupingPanel, DragDropContext, TableColumnReordering,
 } from '@devexpress/dx-react-grid-material-ui';
+import Paper from 'material-ui/Paper';
 import {
   ProgressBarCell,
 } from '../templates/progress-bar-cell';
 import {
   HighlightedCell,
 } from '../templates/highlighted-cell';
-
 import {
   generateRows,
   globalSalesValues,
@@ -41,67 +41,68 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, allowedPageSizes } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <FilteringState
-          defaultFilters={[{ columnName: 'saleDate', value: '2016-02' }]}
-        />
-        <SortingState
-          defaultSorting={[
-            { columnName: 'product', direction: 'asc' },
-            { columnName: 'saleDate', direction: 'asc' },
-          ]}
-        />
-        <GroupingState
-          defaultGrouping={[{ columnName: 'product' }]}
-          defaultExpandedGroups={['EnviroCare Max']}
-        />
-        <PagingState
-          defaultCurrentPage={0}
-          defaultPageSize={10}
-        />
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <FilteringState
+            defaultFilters={[{ columnName: 'saleDate', value: '2016-02' }]}
+          />
+          <SortingState
+            defaultSorting={[
+              { columnName: 'product', direction: 'asc' },
+              { columnName: 'saleDate', direction: 'asc' },
+            ]}
+          />
+          <GroupingState
+            defaultGrouping={[{ columnName: 'product' }]}
+            defaultExpandedGroups={['EnviroCare Max']}
+          />
+          <PagingState
+            defaultCurrentPage={0}
+            defaultPageSize={10}
+          />
 
-        <LocalGrouping />
-        <LocalFiltering />
-        <LocalSorting />
+          <LocalGrouping />
+          <LocalFiltering />
+          <LocalSorting />
 
-        <LocalPaging />
+          <LocalPaging />
 
-        <SelectionState
-          defaultSelection={[1, 3, 18]}
-        />
+          <SelectionState
+            defaultSelection={[1, 3, 18]}
+          />
 
-        <DragDropContext />
+          <DragDropContext />
 
-        <TableView
-          tableCellTemplate={({ row, column, style }) => {
-            if (column.name === 'discount') {
-              return (
-                <ProgressBarCell value={row.discount * 100} style={style} />
-              );
-            } else if (column.name === 'amount') {
-              return (
-                <HighlightedCell align={column.align} value={row.amount} style={style} />
-              );
-            }
-            return undefined;
-          }}
-        />
+          <TableView
+            tableCellTemplate={({ row, column, style }) => {
+              if (column.name === 'discount') {
+                return (
+                  <ProgressBarCell value={row.discount * 100} style={style} />
+                );
+              } else if (column.name === 'amount') {
+                return (
+                  <HighlightedCell align={column.align} value={row.amount} style={style} />
+                );
+              }
+              return undefined;
+            }}
+          />
 
-        <TableColumnReordering defaultOrder={columns.map(column => column.name)} />
+          <TableColumnReordering defaultOrder={columns.map(column => column.name)} />
 
-        <TableHeaderRow allowSorting allowDragging />
-        <TableFilterRow />
-        <PagingPanel
-          allowedPageSizes={allowedPageSizes}
-        />
-        <TableSelection />
-        <TableGroupRow />
-        <GroupingPanel allowSorting allowDragging />
-
-      </Grid>
+          <TableHeaderRow allowSorting allowDragging />
+          <TableFilterRow />
+          <PagingPanel
+            allowedPageSizes={allowedPageSizes}
+          />
+          <TableSelection />
+          <TableGroupRow />
+          <GroupingPanel allowSorting allowDragging />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/featured-virtual-scrolling/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-virtual-scrolling/demo.jsx
@@ -8,13 +8,13 @@ import {
   VirtualTableView, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow,
   GroupingPanel, DragDropContext, TableColumnReordering,
 } from '@devexpress/dx-react-grid-material-ui';
+import Paper from 'material-ui/Paper';
 import {
   ProgressBarCell,
 } from '../templates/progress-bar-cell';
 import {
   HighlightedCell,
 } from '../templates/highlighted-cell';
-
 import {
   generateRows,
   globalSalesValues,
@@ -58,43 +58,45 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-        getRowId={getRowId}
-      >
-        <DragDropContext />
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+          getRowId={getRowId}
+        >
+          <DragDropContext />
 
-        <FilteringState
-          defaultFilters={[{ columnName: 'saleDate', value: '2016-02' }]}
-        />
-        <SortingState
-          defaultSorting={[
-            { columnName: 'product', direction: 'asc' },
-            { columnName: 'saleDate', direction: 'asc' },
-          ]}
-        />
-        <GroupingState
-          defaultGrouping={[{ columnName: 'product' }]}
-          defaultExpandedGroups={['EnviroCare Max']}
-        />
+          <FilteringState
+            defaultFilters={[{ columnName: 'saleDate', value: '2016-02' }]}
+          />
+          <SortingState
+            defaultSorting={[
+              { columnName: 'product', direction: 'asc' },
+              { columnName: 'saleDate', direction: 'asc' },
+            ]}
+          />
+          <GroupingState
+            defaultGrouping={[{ columnName: 'product' }]}
+            defaultExpandedGroups={['EnviroCare Max']}
+          />
 
-        <LocalFiltering />
-        <LocalSorting />
-        <LocalGrouping />
+          <LocalFiltering />
+          <LocalSorting />
+          <LocalGrouping />
 
-        <SelectionState />
+          <SelectionState />
 
-        <VirtualTableView
-          tableCellTemplate={this.tableCellTemplate}
-        />
-        <TableHeaderRow allowSorting allowDragging />
-        <TableColumnReordering defaultOrder={columns.map(column => column.name)} />
-        <TableFilterRow />
-        <TableSelection />
-        <TableGroupRow />
-        <GroupingPanel allowSorting allowDragging />
-      </Grid>
+          <VirtualTableView
+            tableCellTemplate={this.tableCellTemplate}
+          />
+          <TableHeaderRow allowSorting allowDragging />
+          <TableColumnReordering defaultOrder={columns.map(column => column.name)} />
+          <TableFilterRow />
+          <TableSelection />
+          <TableGroupRow />
+          <GroupingPanel allowSorting allowDragging />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/filtering/custom-filter-row.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/custom-filter-row.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Input from 'material-ui/Input';
-import { TableCell } from 'material-ui/Table';
+import { Input, TableCell, Paper } from 'material-ui';
 import { withStyles } from 'material-ui/styles';
 import {
   FilteringState,
@@ -84,24 +83,26 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <FilteringState defaultFilters={[{ columnName: 'units', value: 2 }]} />
-        <LocalFiltering />
-        <TableView />
-        <TableHeaderRow />
-        <TableFilterRow
-          filterCellTemplate={({ column, filter, setFilter }) => {
-            if (column.name === 'units') {
-              return <UnitsFilterCell filter={filter} setFilter={setFilter} />;
-            }
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <FilteringState defaultFilters={[{ columnName: 'units', value: 2 }]} />
+          <LocalFiltering />
+          <TableView />
+          <TableHeaderRow />
+          <TableFilterRow
+            filterCellTemplate={({ column, filter, setFilter }) => {
+              if (column.name === 'units') {
+                return <UnitsFilterCell filter={filter} setFilter={setFilter} />;
+              }
 
-            return undefined;
-          }}
-        />
-      </Grid>
+              return undefined;
+            }}
+          />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/filtering/custom-filtering-algorithm.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/custom-filtering-algorithm.jsx
@@ -9,7 +9,7 @@ import {
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -36,16 +36,18 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <FilteringState defaultFilters={[{ columnName: 'city', value: 'Paris' }]} />
-        <LocalFiltering getColumnPredicate={getColumnPredicate} />
-        <TableView />
-        <TableHeaderRow />
-        <TableFilterRow />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <FilteringState defaultFilters={[{ columnName: 'city', value: 'Paris' }]} />
+          <LocalFiltering getColumnPredicate={getColumnPredicate} />
+          <TableView />
+          <TableHeaderRow />
+          <TableFilterRow />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/filtering/local-filter-row.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/local-filter-row.jsx
@@ -9,7 +9,7 @@ import {
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -32,16 +32,18 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <FilteringState defaultFilters={[]} />
-        <LocalFiltering />
-        <TableView />
-        <TableHeaderRow />
-        <TableFilterRow />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <FilteringState defaultFilters={[]} />
+          <LocalFiltering />
+          <TableView />
+          <TableHeaderRow />
+          <TableFilterRow />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/filtering/local-filtering-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/local-filtering-controlled.jsx
@@ -9,7 +9,7 @@ import {
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -35,19 +35,21 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <FilteringState
-          filters={this.state.filters}
-          onFiltersChange={this.changeFilters}
-        />
-        <LocalFiltering />
-        <TableView />
-        <TableHeaderRow />
-        <TableFilterRow />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <FilteringState
+            filters={this.state.filters}
+            onFiltersChange={this.changeFilters}
+          />
+          <LocalFiltering />
+          <TableView />
+          <TableHeaderRow />
+          <TableFilterRow />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/filtering/remote-filtering.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/remote-filtering.jsx
@@ -8,7 +8,7 @@ import {
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import { Loading } from '../components/loading';
 
 const URL = 'https://js.devexpress.com/Demos/Mvc/api/DataGridWebApi';
@@ -79,7 +79,7 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, loading } = this.state;
 
     return (
-      <div style={{ position: 'relative' }}>
+      <Paper style={{ position: 'relative' }}>
         <Grid
           rows={rows}
           columns={columns}
@@ -92,7 +92,7 @@ export default class Demo extends React.PureComponent {
           <TableFilterRow rowHeight={51} />
         </Grid>
         {loading && <Loading />}
-      </div>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/grouping/custom-grouping-static.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/custom-grouping-static.jsx
@@ -9,7 +9,7 @@ import {
   TableHeaderRow,
   TableGroupRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
   defaultColumnValues,
@@ -49,20 +49,22 @@ export default class Demo extends React.PureComponent {
     const { data, columns, grouping } = this.state;
 
     return (
-      <Grid
-        rows={data}
-        columns={columns}
-      >
-        <GroupingState
-          grouping={grouping}
-        />
-        <CustomGrouping
-          getChildGroups={getChildGroups}
-        />
-        <TableView />
-        <TableHeaderRow />
-        <TableGroupRow />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={data}
+          columns={columns}
+        >
+          <GroupingState
+            grouping={grouping}
+          />
+          <CustomGrouping
+            getChildGroups={getChildGroups}
+          />
+          <TableView />
+          <TableHeaderRow />
+          <TableGroupRow />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/grouping/local-grouping-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/local-grouping-controlled.jsx
@@ -11,7 +11,7 @@ import {
   GroupingPanel,
   DragDropContext,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -37,21 +37,23 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <DragDropContext />
-        <GroupingState
-          grouping={this.state.grouping}
-          onGroupingChange={this.changeGrouping}
-        />
-        <LocalGrouping />
-        <TableView />
-        <TableHeaderRow allowDragging allowGroupingByClick />
-        <TableGroupRow />
-        <GroupingPanel allowDragging allowUngroupingByClick />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <DragDropContext />
+          <GroupingState
+            grouping={this.state.grouping}
+            onGroupingChange={this.changeGrouping}
+          />
+          <LocalGrouping />
+          <TableView />
+          <TableHeaderRow allowDragging allowGroupingByClick />
+          <TableGroupRow />
+          <GroupingPanel allowDragging allowUngroupingByClick />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/grouping/local-grouping-custom-advanced.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/local-grouping-custom-advanced.jsx
@@ -11,7 +11,7 @@ import {
   TableGroupRow,
 } from '@devexpress/dx-react-grid-material-ui';
 
-import { TableCell } from 'material-ui';
+import { TableCell, Paper } from 'material-ui';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -84,29 +84,31 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, grouping } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <GroupingState
-          grouping={grouping}
-          defaultExpandedGroups={['N-Z']}
-        />
-        <LocalGrouping
-          getColumnIdentity={this.getColumnIdentity}
-        />
-        <TableView />
-        <TableHeaderRow />
-        <TableGroupRow
-          groupCellTemplate={(props) => {
-            const { column } = props;
-            if (column.name === 'name') {
-              return <GroupCellTemplate {...props} />;
-            }
-            return undefined;
-          }}
-        />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <GroupingState
+            grouping={grouping}
+            defaultExpandedGroups={['N-Z']}
+          />
+          <LocalGrouping
+            getColumnIdentity={this.getColumnIdentity}
+          />
+          <TableView />
+          <TableHeaderRow />
+          <TableGroupRow
+            groupCellTemplate={(props) => {
+              const { column } = props;
+              if (column.name === 'name') {
+                return <GroupCellTemplate {...props} />;
+              }
+              return undefined;
+            }}
+          />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/grouping/local-grouping-custom.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/local-grouping-custom.jsx
@@ -9,7 +9,7 @@ import {
   TableHeaderRow,
   TableGroupRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -43,20 +43,22 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, grouping } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <GroupingState
-          grouping={grouping}
-        />
-        <LocalGrouping
-          getColumnIdentity={this.getColumnIdentity}
-        />
-        <TableView />
-        <TableHeaderRow />
-        <TableGroupRow />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <GroupingState
+            grouping={grouping}
+          />
+          <LocalGrouping
+            getColumnIdentity={this.getColumnIdentity}
+          />
+          <TableView />
+          <TableHeaderRow />
+          <TableGroupRow />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/grouping/local-grouping-static.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/local-grouping-static.jsx
@@ -9,7 +9,7 @@ import {
   TableHeaderRow,
   TableGroupRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -32,18 +32,20 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <GroupingState
-          grouping={[{ columnName: 'city' }]}
-        />
-        <LocalGrouping />
-        <TableView />
-        <TableHeaderRow />
-        <TableGroupRow />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <GroupingState
+            grouping={[{ columnName: 'city' }]}
+          />
+          <LocalGrouping />
+          <TableView />
+          <TableHeaderRow />
+          <TableGroupRow />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/grouping/local-grouping-with-ui.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/local-grouping-with-ui.jsx
@@ -11,7 +11,7 @@ import {
   GroupingPanel,
   DragDropContext,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -34,18 +34,20 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <DragDropContext />
-        <GroupingState defaultGrouping={[{ columnName: 'city' }]} />
-        <LocalGrouping />
-        <TableView />
-        <TableHeaderRow allowDragging />
-        <TableGroupRow />
-        <GroupingPanel allowDragging />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <DragDropContext />
+          <GroupingState defaultGrouping={[{ columnName: 'city' }]} />
+          <LocalGrouping />
+          <TableView />
+          <TableHeaderRow allowDragging />
+          <TableGroupRow />
+          <GroupingPanel allowDragging />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/grouping/remote-grouping-with-local-expanding.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/remote-grouping-with-local-expanding.jsx
@@ -11,6 +11,7 @@ import {
   GroupingPanel,
   DragDropContext,
 } from '@devexpress/dx-react-grid-material-ui';
+import Paper from 'material-ui/Paper';
 import { Loading } from '../components/loading';
 
 const URL = 'https://js.devexpress.com/Demos/Mvc/api/DataGridWebApi';
@@ -100,7 +101,7 @@ export default class Demo extends React.PureComponent {
     } = this.state;
 
     return (
-      <div style={{ position: 'relative' }}>
+      <Paper style={{ position: 'relative' }}>
         <Grid
           rows={data}
           columns={columns}
@@ -124,7 +125,7 @@ export default class Demo extends React.PureComponent {
           <GroupingPanel allowDragging />
         </Grid>
         {loading && <Loading />}
-      </div>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/immutability/seamless-immutable.jsx
+++ b/packages/dx-react-demos/src/material-ui/immutability/seamless-immutable.jsx
@@ -10,7 +10,7 @@ import {
   TableHeaderRow,
   TableSelection,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import Immutable from 'seamless-immutable';
 
 import {
@@ -55,23 +55,25 @@ export default class Demo extends React.PureComponent {
     } = this.state.data;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <SortingState
-          sorting={sorting}
-          onSortingChange={this.changeSorting}
-        />
-        <LocalSorting />
-        <SelectionState
-          selection={selection}
-          onSelectionChange={this.changeSelection}
-        />
-        <TableView />
-        <TableHeaderRow allowSorting />
-        <TableSelection />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <SortingState
+            sorting={sorting}
+            onSortingChange={this.changeSorting}
+          />
+          <LocalSorting />
+          <SelectionState
+            selection={selection}
+            onSelectionChange={this.changeSelection}
+          />
+          <TableView />
+          <TableHeaderRow allowSorting />
+          <TableSelection />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/localization/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/localization/basic.jsx
@@ -20,7 +20,7 @@ import {
   PagingPanel,
   DragDropContext,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
   globalSalesValues,
@@ -69,53 +69,55 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <DragDropContext />
-        <FilteringState defaultFilters={[]} />
-        <GroupingState defaultGrouping={[]} />
-        <EditingState
-          onCommitChanges={this.commitChanges}
-        />
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <DragDropContext />
+          <FilteringState defaultFilters={[]} />
+          <GroupingState defaultGrouping={[]} />
+          <EditingState
+            onCommitChanges={this.commitChanges}
+          />
 
-        <LocalFiltering />
-        <LocalGrouping />
-        <PagingState
-          defaultCurrentPage={0}
-          defaultPageSize={5}
-        />
-        <LocalPaging />
-        <TableView
-          messages={tableViewMessages}
-        />
-        <TableHeaderRow allowDragging />
+          <LocalFiltering />
+          <LocalGrouping />
+          <PagingState
+            defaultCurrentPage={0}
+            defaultPageSize={5}
+          />
+          <LocalPaging />
+          <TableView
+            messages={tableViewMessages}
+          />
+          <TableHeaderRow allowDragging />
 
-        <TableEditRow />
-        <TableEditColumn
-          allowAdding
-          allowEditing
-          allowDeleting
-          width={250}
-          messages={editColumnMessages}
-        />
+          <TableEditRow />
+          <TableEditColumn
+            allowAdding
+            allowEditing
+            allowDeleting
+            width={250}
+            messages={editColumnMessages}
+          />
 
-        <TableFilterRow
-          messages={filterRowMessages}
-        />
-        <GroupingPanel
-          allowUngroupingByClick
-          allowDragging
-          messages={groupingPanelMessages}
-        />
+          <TableFilterRow
+            messages={filterRowMessages}
+          />
+          <GroupingPanel
+            allowUngroupingByClick
+            allowDragging
+            messages={groupingPanelMessages}
+          />
 
-        <TableGroupRow />
-        <PagingPanel
-          allowedPageSizes={[5, 10, 15, 0]}
-          messages={pagingPanelMessages}
-        />
-      </Grid>
+          <TableGroupRow />
+          <PagingPanel
+            allowedPageSizes={[5, 10, 15, 0]}
+            messages={pagingPanelMessages}
+          />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/paging/local-paging-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/paging/local-paging-controlled.jsx
@@ -9,7 +9,7 @@ import {
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -40,23 +40,25 @@ export default class Demo extends React.PureComponent {
     } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <PagingState
-          currentPage={this.state.currentPage}
-          onCurrentPageChange={this.changeCurrentPage}
-          pageSize={pageSize}
-          onPageSizeChange={this.changePageSize}
-        />
-        <LocalPaging />
-        <TableView />
-        <TableHeaderRow />
-        <PagingPanel
-          allowedPageSizes={allowedPageSizes}
-        />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <PagingState
+            currentPage={this.state.currentPage}
+            onCurrentPageChange={this.changeCurrentPage}
+            pageSize={pageSize}
+            onPageSizeChange={this.changePageSize}
+          />
+          <LocalPaging />
+          <TableView />
+          <TableHeaderRow />
+          <PagingPanel
+            allowedPageSizes={allowedPageSizes}
+          />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/paging/local-paging.jsx
+++ b/packages/dx-react-demos/src/material-ui/paging/local-paging.jsx
@@ -9,7 +9,7 @@ import {
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -32,19 +32,21 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <PagingState
-          defaultCurrentPage={0}
-          pageSize={5}
-        />
-        <LocalPaging />
-        <TableView />
-        <TableHeaderRow />
-        <PagingPanel />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <PagingState
+            defaultCurrentPage={0}
+            pageSize={5}
+          />
+          <LocalPaging />
+          <TableView />
+          <TableHeaderRow />
+          <PagingPanel />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/paging/page-size-selector.jsx
+++ b/packages/dx-react-demos/src/material-ui/paging/page-size-selector.jsx
@@ -9,7 +9,7 @@ import {
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import { generateRows } from '../../demo-data/generator';
 
 export default class Demo extends React.PureComponent {
@@ -32,21 +32,23 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, allowedPageSizes } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <PagingState
-          defaultCurrentPage={0}
-          defaultPageSize={5}
-        />
-        <LocalPaging />
-        <TableView />
-        <TableHeaderRow />
-        <PagingPanel
-          allowedPageSizes={allowedPageSizes}
-        />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <PagingState
+            defaultCurrentPage={0}
+            defaultPageSize={5}
+          />
+          <LocalPaging />
+          <TableView />
+          <TableHeaderRow />
+          <PagingPanel
+            allowedPageSizes={allowedPageSizes}
+          />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/paging/remote-paging.jsx
+++ b/packages/dx-react-demos/src/material-ui/paging/remote-paging.jsx
@@ -8,7 +8,7 @@ import {
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import { Loading } from '../components/loading';
 
 const URL = 'https://js.devexpress.com/Demos/WidgetsGallery/data/orderItems';
@@ -75,7 +75,7 @@ export default class Demo extends React.PureComponent {
     } = this.state;
 
     return (
-      <div style={{ position: 'relative' }}>
+      <Paper style={{ position: 'relative' }}>
         <Grid
           rows={rows}
           columns={columns}
@@ -91,7 +91,7 @@ export default class Demo extends React.PureComponent {
           <PagingPanel />
         </Grid>
         {loading && <Loading />}
-      </div>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/selection/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/basic.jsx
@@ -7,7 +7,7 @@ import {
   TableView,
   TableSelection,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -33,17 +33,19 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, selection } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <SelectionState
-          selection={selection}
-          onSelectionChange={this.changeSelection}
-        />
-        <TableView />
-        <TableSelection />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <SelectionState
+            selection={selection}
+            onSelectionChange={this.changeSelection}
+          />
+          <TableView />
+          <TableSelection />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/selection/hidden-checkboxes.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/hidden-checkboxes.jsx
@@ -7,7 +7,7 @@ import {
   TableView,
   TableSelection,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -33,21 +33,23 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, selection } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <SelectionState
-          selection={selection}
-          onSelectionChange={this.changeSelection}
-        />
-        <TableView />
-        <TableSelection
-          selectByRowClick
-          highlightSelected
-          showSelectionColumn={false}
-        />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <SelectionState
+            selection={selection}
+            onSelectionChange={this.changeSelection}
+          />
+          <TableView />
+          <TableSelection
+            selectByRowClick
+            highlightSelected
+            showSelectionColumn={false}
+          />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/selection/hidden-select-all.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/hidden-select-all.jsx
@@ -11,7 +11,7 @@ import {
   TableSelection,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -37,26 +37,28 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, selection } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <SelectionState
-          selection={selection}
-          onSelectionChange={this.changeSelection}
-        />
-        <PagingState
-          defaultCurrentPage={0}
-          pageSize={6}
-        />
-        <LocalPaging />
-        <TableView />
-        <TableHeaderRow />
-        <TableSelection
-          showSelectAll={false}
-        />
-        <PagingPanel />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <SelectionState
+            selection={selection}
+            onSelectionChange={this.changeSelection}
+          />
+          <PagingState
+            defaultCurrentPage={0}
+            pageSize={6}
+          />
+          <LocalPaging />
+          <TableView />
+          <TableHeaderRow />
+          <TableSelection
+            showSelectAll={false}
+          />
+          <PagingPanel />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/selection/select-all-by-all-pages.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/select-all-by-all-pages.jsx
@@ -11,7 +11,7 @@ import {
   TableSelection,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -39,25 +39,26 @@ export default class Demo extends React.PureComponent {
     return (
       <div>
         <span>Total rows selected: {selection.length}</span>
-
-        <Grid
-          rows={rows}
-          columns={columns}
-        >
-          <SelectionState
-            selection={selection}
-            onSelectionChange={this.changeSelection}
-          />
-          <PagingState
-            defaultCurrentPage={0}
-            pageSize={6}
-          />
-          <LocalPaging />
-          <TableView />
-          <TableHeaderRow />
-          <TableSelection />
-          <PagingPanel />
-        </Grid>
+        <Paper>
+          <Grid
+            rows={rows}
+            columns={columns}
+          >
+            <SelectionState
+              selection={selection}
+              onSelectionChange={this.changeSelection}
+            />
+            <PagingState
+              defaultCurrentPage={0}
+              pageSize={6}
+            />
+            <LocalPaging />
+            <TableView />
+            <TableHeaderRow />
+            <TableSelection />
+            <PagingPanel />
+          </Grid>
+        </Paper>
       </div>
     );
   }

--- a/packages/dx-react-demos/src/material-ui/selection/select-all-by-page.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/select-all-by-page.jsx
@@ -11,7 +11,7 @@ import {
   TableSelection,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -39,25 +39,26 @@ export default class Demo extends React.PureComponent {
     return (
       <div>
         <span>Total rows selected: {selection.length}</span>
-
-        <Grid
-          rows={rows}
-          columns={columns}
-        >
-          <PagingState
-            defaultCurrentPage={0}
-            pageSize={6}
-          />
-          <LocalPaging />
-          <SelectionState
-            selection={selection}
-            onSelectionChange={this.changeSelection}
-          />
-          <TableView />
-          <TableHeaderRow />
-          <TableSelection />
-          <PagingPanel />
-        </Grid>
+        <Paper>
+          <Grid
+            rows={rows}
+            columns={columns}
+          >
+            <PagingState
+              defaultCurrentPage={0}
+              pageSize={6}
+            />
+            <LocalPaging />
+            <SelectionState
+              selection={selection}
+              onSelectionChange={this.changeSelection}
+            />
+            <TableView />
+            <TableHeaderRow />
+            <TableSelection />
+            <PagingPanel />
+          </Grid>
+        </Paper>
       </div>
     );
   }

--- a/packages/dx-react-demos/src/material-ui/selection/select-all-virtual.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/select-all-virtual.jsx
@@ -8,7 +8,7 @@ import {
   TableHeaderRow,
   TableSelection,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -36,19 +36,20 @@ export default class Demo extends React.PureComponent {
     return (
       <div>
         <span>Total rows selected: {selection.length}</span>
-
-        <Grid
-          rows={rows}
-          columns={columns}
-        >
-          <SelectionState
-            selection={selection}
-            onSelectionChange={this.changeSelection}
-          />
-          <VirtualTableView />
-          <TableHeaderRow />
-          <TableSelection />
-        </Grid>
+        <Paper>
+          <Grid
+            rows={rows}
+            columns={columns}
+          >
+            <SelectionState
+              selection={selection}
+              onSelectionChange={this.changeSelection}
+            />
+            <VirtualTableView />
+            <TableHeaderRow />
+            <TableSelection />
+          </Grid>
+        </Paper>
       </div>
     );
   }

--- a/packages/dx-react-demos/src/material-ui/selection/select-by-row-click.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/select-by-row-click.jsx
@@ -7,7 +7,7 @@ import {
   TableView,
   TableSelection,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -33,19 +33,21 @@ export default class Demo extends React.PureComponent {
     const { rows, columns, selection } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <SelectionState
-          selection={selection}
-          onSelectionChange={this.changeSelection}
-        />
-        <TableView />
-        <TableSelection
-          selectByRowClick
-        />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <SelectionState
+            selection={selection}
+            onSelectionChange={this.changeSelection}
+          />
+          <TableView />
+          <TableSelection
+            selectByRowClick
+          />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/sorting/local-custom-sorting.jsx
+++ b/packages/dx-react-demos/src/material-ui/sorting/local-custom-sorting.jsx
@@ -8,7 +8,7 @@ import {
   TableView,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
   employeeTaskValues,
@@ -53,17 +53,19 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <SortingState />
-        <LocalSorting
-          getColumnCompare={getColumnCompare}
-        />
-        <TableView />
-        <TableHeaderRow allowSorting />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <SortingState />
+          <LocalSorting
+            getColumnCompare={getColumnCompare}
+          />
+          <TableView />
+          <TableHeaderRow allowSorting />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/sorting/local-group-sorting.jsx
+++ b/packages/dx-react-demos/src/material-ui/sorting/local-group-sorting.jsx
@@ -12,7 +12,7 @@ import {
   TableGroupRow,
   GroupingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -35,26 +35,28 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <SortingState
-          defaultSorting={[
-            { columnName: 'city', direction: 'asc' },
-            { columnName: 'name', direction: 'desc' },
-          ]}
-        />
-        <GroupingState
-          defaultGrouping={[{ columnName: 'city' }]}
-        />
-        <LocalSorting />
-        <LocalGrouping />
-        <TableView />
-        <TableHeaderRow allowSorting />
-        <TableGroupRow />
-        <GroupingPanel allowSorting />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <SortingState
+            defaultSorting={[
+              { columnName: 'city', direction: 'asc' },
+              { columnName: 'name', direction: 'desc' },
+            ]}
+          />
+          <GroupingState
+            defaultGrouping={[{ columnName: 'city' }]}
+          />
+          <LocalSorting />
+          <LocalGrouping />
+          <TableView />
+          <TableHeaderRow allowSorting />
+          <TableGroupRow />
+          <GroupingPanel allowSorting />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/sorting/local-header-sorting.jsx
+++ b/packages/dx-react-demos/src/material-ui/sorting/local-header-sorting.jsx
@@ -8,7 +8,7 @@ import {
   TableView,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -31,15 +31,17 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <SortingState />
-        <LocalSorting />
-        <TableView />
-        <TableHeaderRow allowSorting />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <SortingState />
+          <LocalSorting />
+          <TableView />
+          <TableHeaderRow allowSorting />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/sorting/local-sorting-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/sorting/local-sorting-controlled.jsx
@@ -8,7 +8,7 @@ import {
   TableView,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
 } from '../../demo-data/generator';
@@ -34,18 +34,20 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-      >
-        <SortingState
-          sorting={this.state.sorting}
-          onSortingChange={this.changeSorting}
-        />
-        <LocalSorting />
-        <TableView />
-        <TableHeaderRow allowSorting />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+        >
+          <SortingState
+            sorting={this.state.sorting}
+            onSortingChange={this.changeSorting}
+          />
+          <LocalSorting />
+          <TableView />
+          <TableHeaderRow allowSorting />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/sorting/remote-sorting.jsx
+++ b/packages/dx-react-demos/src/material-ui/sorting/remote-sorting.jsx
@@ -7,7 +7,7 @@ import {
   VirtualTableView,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import { Loading } from '../components/loading';
 
 const URL = 'https://js.devexpress.com/Demos/WidgetsGallery/data/orderItems';
@@ -76,7 +76,7 @@ export default class Demo extends React.PureComponent {
     } = this.state;
 
     return (
-      <div style={{ position: 'relative' }}>
+      <Paper style={{ position: 'relative' }}>
         <Grid
           rows={rows}
           columns={columns}
@@ -89,7 +89,7 @@ export default class Demo extends React.PureComponent {
           <TableHeaderRow allowSorting />
         </Grid>
         {loading && <Loading />}
-      </div>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-demos/src/material-ui/virtual-scrolling/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/virtual-scrolling/basic.jsx
@@ -4,7 +4,7 @@ import {
   VirtualTableView,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
-
+import Paper from 'material-ui/Paper';
 import {
   generateRows,
   defaultColumnValues,
@@ -34,14 +34,16 @@ export default class Demo extends React.PureComponent {
     const { rows, columns } = this.state;
 
     return (
-      <Grid
-        rows={rows}
-        columns={columns}
-        getRowId={getRowId}
-      >
-        <VirtualTableView />
-        <TableHeaderRow />
-      </Grid>
+      <Paper>
+        <Grid
+          rows={rows}
+          columns={columns}
+          getRowId={getRowId}
+        >
+          <VirtualTableView />
+          <TableHeaderRow />
+        </Grid>
+      </Paper>
     );
   }
 }

--- a/packages/dx-react-grid-material-ui/src/templates/layout.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/layout.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
-import { Paper } from 'material-ui';
 
 const styles = theme => ({
   headingPanel: {
@@ -20,11 +19,11 @@ export const Root = ({
   bodyTemplate,
   footerTemplate,
 }) => (
-  <Paper>
+  <div>
     {headerTemplate()}
     {bodyTemplate()}
     {footerTemplate()}
-  </Paper>
+  </div>
 );
 
 Root.propTypes = {

--- a/packages/dx-react-grid/docs/guides/localization.md
+++ b/packages/dx-react-grid/docs/guides/localization.md
@@ -5,7 +5,7 @@ The React Grid provides a simple localization API. Each plugin accepts the `mess
 {% raw %}
 ```js
 <TableView
-  messages={{ noData: 'Keine Daten verfügba' }}
+  messages={{ noData: 'Keine Daten verfügbar' }}
 />
 ```
 {% endraw %}


### PR DESCRIPTION
BREAKING CHANGE:
 
To make Grid for Material UI more flexible we've stopped using the [Paper](https://material-ui-1dab0.firebaseapp.com/demos/paper/) component inside the Grid's layout. 
 
It allows placing our Grid to an existing Paper with other components. For example:

```js
<Paper>
  <Button>Products</Button>
  <Button>Customers</Button>
  <Button>Sales</Button>
  <Grid
    /* ... */
  >
    {/* ... */}
  </Grid>
</Paper>
```