### PR TITLE
fix(react-grid): prevent click event propagation on detail toggle

### DIFF
--- a/packages/dx-react-grid-bootstrap3/src/templates/table-detail-toggle-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-detail-toggle-cell.jsx
@@ -8,9 +8,9 @@ const handleMouseDown = (e) => { e.target.style.outline = 'none'; };
 const handleBlur = (e) => { e.target.style.outline = ''; };
 
 export const TableDetailToggleCell = ({ style, expanded, toggleExpanded }) => {
-  const handleKeyDown = (event) => {
-    if (event.keyCode === ENTER_KEY_CODE || event.keyCode === SPACE_KEY_CODE) {
-      event.preventDefault();
+  const handleKeyDown = (e) => {
+    if (e.keyCode === ENTER_KEY_CODE || e.keyCode === SPACE_KEY_CODE) {
+      e.preventDefault();
       toggleExpanded();
     }
   };
@@ -21,7 +21,8 @@ export const TableDetailToggleCell = ({ style, expanded, toggleExpanded }) => {
         verticalAlign: 'middle',
         ...style,
       }}
-      onClick={() => {
+      onClick={(e) => {
+        e.stopPropagation();
         toggleExpanded();
       }}
 

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-detail-toggle-cell.test.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-detail-toggle-cell.test.jsx
@@ -17,9 +17,9 @@ describe('TableDetailToggleCell', () => {
       />
     ));
 
-    const clickHandlerButton = tree.find('td').prop('onClick');
+    const buttonClickHandler = tree.find('td').prop('onClick');
 
-    clickHandlerButton(mockEvent);
+    buttonClickHandler(mockEvent);
     expect(toggleExpanded)
       .toHaveBeenCalled();
     expect(mockEvent.stopPropagation)

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-detail-toggle-cell.test.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-detail-toggle-cell.test.jsx
@@ -1,13 +1,33 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { TableDetailToggleCell } from './table-detail-toggle-cell';
 
 const ENTER_KEY_CODE = 13;
 const SPACE_KEY_CODE = 32;
 
 describe('TableDetailToggleCell', () => {
+  it('should handle click with stopPropagation', () => {
+    const toggleExpanded = jest.fn();
+    const mockEvent = {
+      stopPropagation: jest.fn(),
+    };
+    const tree = shallow((
+      <TableDetailToggleCell
+        toggleExpanded={toggleExpanded}
+      />
+    ));
+
+    const clickHandlerButton = tree.find('td').prop('onClick');
+
+    clickHandlerButton(mockEvent);
+    expect(toggleExpanded)
+      .toHaveBeenCalled();
+    expect(mockEvent.stopPropagation)
+      .toHaveBeenCalled();
+  });
+
   it('can get focus', () => {
-    const tree = mount((
+    const tree = shallow((
       <TableDetailToggleCell />
     ));
 

--- a/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.jsx
@@ -26,7 +26,8 @@ const styles = theme => ({
 const TableDetailToggleCellBase = ({
   style, expanded, classes, toggleExpanded,
 }) => {
-  const handleClick = () => {
+  const handleClick = (e) => {
+    e.stopPropagation();
     toggleExpanded();
   };
   return (

--- a/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.test.jsx
@@ -1,39 +1,46 @@
 import React from 'react';
-import { createMount } from 'material-ui/test-utils';
+import { createShallow } from 'material-ui/test-utils';
 import { setupConsole } from '@devexpress/dx-testing';
+import { IconButton } from 'material-ui';
 import { TableDetailToggleCell } from './table-detail-toggle-cell';
 
 describe('TableDetailToggleCell', () => {
   let resetConsole;
-  let mount;
+  let shallow;
   beforeAll(() => {
     resetConsole = setupConsole({ ignore: ['validateDOMNesting', 'SheetsRegistry'] });
-    mount = createMount({ context: { table: {} }, childContextTypes: { table: () => null } });
+    shallow = createShallow({ dive: true });
   });
   afterAll(() => {
     resetConsole();
-    mount.cleanUp();
   });
 
   it('should render IconButton', () => {
-    const tree = mount((
+    const tree = shallow((
       <TableDetailToggleCell />
     ));
 
-    expect(tree.find('IconButton').exists())
+    expect(tree.find(IconButton).exists())
       .toBeTruthy();
   });
 
-  it('should handle click', () => {
+  it('should handle click with stopPropagation', () => {
     const toggleExpanded = jest.fn();
-    const tree = mount((
+    const mockEvent = {
+      stopPropagation: jest.fn(),
+    };
+    const tree = shallow((
       <TableDetailToggleCell
         toggleExpanded={toggleExpanded}
       />
     ));
 
-    tree.find('IconButton').simulate('click');
+    const clickHandlerButton = tree.find(IconButton).prop('onClick');
+
+    clickHandlerButton(mockEvent);
     expect(toggleExpanded)
+      .toHaveBeenCalled();
+    expect(mockEvent.stopPropagation)
       .toHaveBeenCalled();
   });
 });

--- a/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.test.jsx
@@ -35,9 +35,9 @@ describe('TableDetailToggleCell', () => {
       />
     ));
 
-    const clickHandlerButton = tree.find(IconButton).prop('onClick');
+    const buttonClickHandler = tree.find(IconButton).prop('onClick');
 
-    clickHandlerButton(mockEvent);
+    buttonClickHandler(mockEvent);
     expect(toggleExpanded)
       .toHaveBeenCalled();
     expect(mockEvent.stopPropagation)


### PR DESCRIPTION
fixes #492