### PR TITLE
[wip]refactor(react-grid): rename CustomGrouping to CustomGroupingPlugin

### DIFF
--- a/packages/dx-grid-core/src/plugins/custom-grouping/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/custom-grouping/computeds.test.js
@@ -8,7 +8,7 @@ import {
   GRID_GROUP_LEVEL_KEY,
 } from '../local-grouping/constants';
 
-describe('CustomGrouping Plugin computeds', () => {
+describe('CustomGroupingPlugin computeds', () => {
   const groupRow = ({ groupedBy, ...restParams }) => ({
     ...restParams,
     groupedBy,

--- a/packages/dx-react-demos/src/bootstrap3/grouping/custom-grouping-static.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/grouping/custom-grouping-static.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   GroupingState,
-  CustomGrouping,
+  CustomGroupingPlugin,
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
@@ -56,7 +56,7 @@ export default class Demo extends React.PureComponent {
         <GroupingState
           grouping={grouping}
         />
-        <CustomGrouping
+        <CustomGroupingPlugin
           getChildGroups={getChildGroups}
         />
         <Table />

--- a/packages/dx-react-demos/src/bootstrap3/grouping/remote-grouping-with-local-expanding.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/grouping/remote-grouping-with-local-expanding.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   GroupingState,
-  CustomGrouping,
+  CustomGroupingPlugin,
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
@@ -113,7 +113,7 @@ export default class Demo extends React.PureComponent {
             expandedGroups={expandedGroups}
             onExpandedGroupsChange={this.changeExpandedGroups}
           />
-          <CustomGrouping
+          <CustomGroupingPlugin
             getChildGroups={getChildGroups}
             grouping={tempGrouping}
             expandedGroups={tempExpandedGroups}

--- a/packages/dx-react-demos/src/material-ui/grouping/custom-grouping-static.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/custom-grouping-static.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   GroupingState,
-  CustomGrouping,
+  CustomGroupingPlugin,
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
@@ -57,7 +57,7 @@ export default class Demo extends React.PureComponent {
           <GroupingState
             grouping={grouping}
           />
-          <CustomGrouping
+          <CustomGroupingPlugin
             getChildGroups={getChildGroups}
           />
           <Table />

--- a/packages/dx-react-demos/src/material-ui/grouping/remote-grouping-with-local-expanding.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/remote-grouping-with-local-expanding.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   GroupingState,
-  CustomGrouping,
+  CustomGroupingPlugin,
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
@@ -114,7 +114,7 @@ export default class Demo extends React.PureComponent {
             expandedGroups={expandedGroups}
             onExpandedGroupsChange={this.changeExpandedGroups}
           />
-          <CustomGrouping
+          <CustomGroupingPlugin
             getChildGroups={getChildGroups}
             grouping={tempGrouping}
             expandedGroups={tempExpandedGroups}

--- a/packages/dx-react-grid/docs/guides/grouping.md
+++ b/packages/dx-react-grid/docs/guides/grouping.md
@@ -8,7 +8,7 @@ The following plugins implement grouping features:
 
 - [GroupingState](../reference/grouping-state.md) - controls the grouping state
 - [LocalGrouping](../reference/local-grouping.md) - performs local data grouping
-- [CustomGrouping](../reference/custom-grouping.md) - converts custom formatted grouped data to a supported format
+- [CustomGroupingPlugin](../reference/custom-grouping-plugin.md) - converts custom formatted grouped data to a supported format
 - [TableGroupRow](../reference/table-group-row.md) - renders group rows
 - [TableHeaderRow](../reference/table-header-row.md) - renders the header row and implements column dragging
 - [GroupingPanel](../reference/grouping-panel.md) - renders the Group Panel
@@ -17,7 +17,7 @@ Note that [plugin order](./plugin-overview.md#plugin-order) is important.
 
 ## Basic Grouping Setup
 
-Use the `GroupingState`, `LocalGrouping` (or `CustomGrouping`) and `TableGroupRow` plugins to set up a Grid with simple static grouping.
+Use the `GroupingState`, `LocalGrouping` (or `CustomGroupingPlugin`) and `TableGroupRow` plugins to set up a Grid with simple static grouping.
 
 In the following examples, the grouping options are specified using the `GroupingState` plugin's `grouping` property, which is usual for the controlled mode. However, the `onGroupingChange` event handler is not specified because the grouping option is not supposed to be changed internally as the grouping UI is not available.
 
@@ -29,9 +29,9 @@ In the following example, the data is specified as plain rows. In this case, the
 
 ### Custom Grouping
 
-If the data has a hierarchical structure (already grouped), use the `CustomGrouping` plugin.
+If the data has a hierarchical structure (already grouped), use `CustomGroupingPlugin`.
 
-In the following example, the data is specified as an array of groups. Specify the `CustomGrouping` plugin's `getChildGroups` property to parse a custom group structure.
+In the following example, the data is specified as an array of groups. Specify the `getChildGroups` property of `CustomGroupingPlugin` to parse a custom group structure.
 
 .embedded-demo(grouping/custom-grouping-static)
 
@@ -87,9 +87,9 @@ You can perform grouping remotely by handling grouping state changes, generating
 
 Grouping options are updated whenever an end-user interacts with the grouping UI. Handle grouping option changes using the `GroupingState` plugin's `onGroupingChange` and `onExpandedGroupsChange` events and request data from the server using the newly applied grouping options.
 
-For remote grouping, you should use the `CustomGrouping` plugin instead of the `LocalGrouping` plugin.
+For remote grouping, you should use `CustomGroupingPlugin` instead of the `LocalGrouping` plugin.
 
-While waiting for a response from a server, there is a timeframe where the grouping state does not match the data available to the `Grid` in its `rows` property. To avoid any issues due to this discrepancy, you should temporarily assign the "old" values of the `grouping` and `expandedGroups` state fields to the properties with the same names on the `GroupingState` plugin. The result is that the `Grid` does not yet see the configuration change. Once the grouped data is received from the server, pass it to the `Grid` component's `rows` property and reset the `CustomGrouping` plugin's `grouping` and `expandedGroups` property values (set them to `null`). At this point, the `Grid` becomes aware of the change to its grouping configuration, and it reeceives the updated set of data at the same time.
+While waiting for a response from a server, there is a time frame where the grouping state does not match the data available to the `Grid` in its `rows` property. To avoid any issues due to this discrepancy, you should temporarily assign the "old" values of the `grouping` and `expandedGroups` state fields to the properties with the same names on the `GroupingState` plugin. The result is that the `Grid` does not yet see the configuration change. Once the grouped data is received from the server, pass it to the `Grid` component's `rows` property and reset the `grouping` and `expandedGroups` properties of `CustomGroupingPlugin` (set their values to `null`). At this point, the `Grid` becomes aware of the change to its grouping configuration, and it receives the updated set of data at the same time.
 
 The following example demonstrates remote grouping with local expanding/collapsing, as well as the approach outlined in the previous paragraph:
 

--- a/packages/dx-react-grid/docs/reference/custom-grouping-plugin.md
+++ b/packages/dx-react-grid/docs/reference/custom-grouping-plugin.md
@@ -1,4 +1,4 @@
-# CustomGrouping Plugin Reference
+# CustomGroupingPlugin Reference
 
 A plugin that converts custom formatted grouped data to a supported format and performs local group expanding/collapsing.
 

--- a/packages/dx-react-grid/src/index.js
+++ b/packages/dx-react-grid/src/index.js
@@ -11,7 +11,7 @@ export { LocalPaging } from './plugins/local-paging';
 
 export { GroupingState } from './plugins/grouping-state';
 export { LocalGrouping } from './plugins/local-grouping';
-export { CustomGrouping } from './plugins/custom-grouping';
+export { CustomGroupingPlugin } from './plugins/custom-grouping';
 
 export { SelectionState } from './plugins/selection-state';
 

--- a/packages/dx-react-grid/src/plugins/custom-grouping.jsx
+++ b/packages/dx-react-grid/src/plugins/custom-grouping.jsx
@@ -18,7 +18,7 @@ const expandedGroupedRowsComputed = ({ rows, grouping, expandedGroups }) =>
 const getRowIdComputed = ({ getRowId, rows }) =>
   customGroupingRowIdGetter(getRowId, rows);
 
-export class CustomGrouping extends React.PureComponent {
+export class CustomGroupingPlugin extends React.PureComponent {
   render() {
     const {
       getChildGroups,
@@ -49,13 +49,13 @@ export class CustomGrouping extends React.PureComponent {
   }
 }
 
-CustomGrouping.propTypes = {
+CustomGroupingPlugin.propTypes = {
   getChildGroups: PropTypes.func.isRequired,
   grouping: PropTypes.array,
   expandedGroups: PropTypes.array,
 };
 
-CustomGrouping.defaultProps = {
+CustomGroupingPlugin.defaultProps = {
   grouping: undefined,
   expandedGroups: undefined,
 };

--- a/packages/dx-react-grid/src/plugins/custom-grouping.test.jsx
+++ b/packages/dx-react-grid/src/plugins/custom-grouping.test.jsx
@@ -9,7 +9,7 @@ import {
   expandedGroupRows,
 } from '@devexpress/dx-grid-core';
 import { PluginHost } from '@devexpress/dx-react-core';
-import { CustomGrouping } from './custom-grouping';
+import { CustomGroupingPlugin } from './custom-grouping';
 import { pluginDepsToComponents, getComputedState } from './test-utils';
 
 jest.mock('@devexpress/dx-grid-core', () => ({
@@ -34,7 +34,7 @@ const defaultProps = {
   getChildGroups: () => {},
 };
 
-describe('CustomGrouping', () => {
+describe('CustomGroupingPlugin', () => {
   let resetConsole;
   beforeAll(() => {
     resetConsole = setupConsole({ ignore: ['validateDOMNesting'] });
@@ -58,7 +58,7 @@ describe('CustomGrouping', () => {
     const tree = mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <CustomGrouping
+        <CustomGroupingPlugin
           {...defaultProps}
         />
       </PluginHost>
@@ -72,7 +72,7 @@ describe('CustomGrouping', () => {
     const tree = mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <CustomGrouping
+        <CustomGroupingPlugin
           {...defaultProps}
         />
       </PluginHost>
@@ -86,7 +86,7 @@ describe('CustomGrouping', () => {
     const tree = mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <CustomGrouping
+        <CustomGroupingPlugin
           {...defaultProps}
         />
       </PluginHost>
@@ -114,7 +114,7 @@ describe('CustomGrouping', () => {
     const tree = mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <CustomGrouping
+        <CustomGroupingPlugin
           {...defaultProps}
         />
       </PluginHost>
@@ -138,7 +138,7 @@ describe('CustomGrouping', () => {
       const tree = mount((
         <PluginHost>
           {pluginDepsToComponents(defaultDeps)}
-          <CustomGrouping
+          <CustomGroupingPlugin
             {...defaultProps}
             grouping={grouping}
             expandedGroups={expandedGroups}
@@ -159,7 +159,7 @@ describe('CustomGrouping', () => {
       const tree = mount((
         <PluginHost>
           {pluginDepsToComponents(defaultDeps)}
-          <CustomGrouping
+          <CustomGroupingPlugin
             {...defaultProps}
             grouping={grouping}
             expandedGroups={expandedGroups}

--- a/site/_data/docs/navigation.yml
+++ b/site/_data/docs/navigation.yml
@@ -66,8 +66,8 @@ react:
           path: /react/grid/docs/reference/local-sorting
         - title: LocalGrouping
           path: /react/grid/docs/reference/local-grouping
-        - title: CustomGrouping
-          path: /react/grid/docs/reference/custom-grouping
+        - title: CustomGroupingPlugin
+          path: /react/grid/docs/reference/custom-grouping-plugin
         - title: LocalPaging
           path: /react/grid/docs/reference/local-paging
         - title: Table


### PR DESCRIPTION
BREAKING CHANGE

The `CustomGrouping` plugin has been renamed to `CustomGroupingPlugin` within the task of making all plugin names consistent.