### PR TITLE
refactor(react-grid): rename Table to TablePlugin

### DIFF
--- a/packages/dx-grid-core/src/plugins/table/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table/computeds.test.js
@@ -4,7 +4,7 @@ import {
   tableColumnsWithDataRows,
 } from './computeds';
 
-describe('Table Plugin computeds', () => {
+describe('TablePlugin computeds', () => {
   describe('#tableColumnsWithDataRows', () => {
     it('should work', () => {
       const columns = [{ name: 'a' }, { name: 'b' }];

--- a/packages/dx-grid-core/src/plugins/table/helpers.test.js
+++ b/packages/dx-grid-core/src/plugins/table/helpers.test.js
@@ -6,7 +6,7 @@ import {
   isDataTableRow,
 } from './helpers';
 
-describe('Table Plugin helpers', () => {
+describe('TablePlugin helpers', () => {
   describe('#isNoDataTableRow', () => {
     it('should work', () => {
       expect(isNoDataTableRow({ type: TABLE_NODATA_TYPE }))

--- a/packages/dx-react-demos/src/bootstrap3/basic/basic.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/basic/basic.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -34,7 +34,7 @@ export default class Demo extends React.PureComponent {
         rows={rows}
         columns={columns}
       >
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/basic/table-cell-template.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/basic/table-cell-template.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -70,7 +70,7 @@ export default class Demo extends React.PureComponent {
         rows={rows}
         columns={columns}
       >
-        <Table tableCellTemplate={this.tableCellTemplate} />
+        <TablePlugin tableCellTemplate={this.tableCellTemplate} />
         <TableHeaderRow />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/basic/table-row-template.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/basic/table-row-template.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -43,7 +43,7 @@ export default class Demo extends React.PureComponent {
         rows={rows}
         columns={columns}
       >
-        <Table tableRowTemplate={this.tableRowTemplate} />
+        <TablePlugin tableRowTemplate={this.tableRowTemplate} />
         <TableHeaderRow />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/column-chooser/basic.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/column-chooser/basic.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Row, Col } from 'react-bootstrap';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   ColumnChooser,
   TableColumnVisibility,
@@ -40,7 +40,7 @@ export default class Demo extends React.PureComponent {
             rows={rows}
             columns={columns}
           >
-            <Table />
+            <TablePlugin />
             <TableHeaderRow />
             <TableColumnVisibility
               hiddenColumns={hiddenColumns}

--- a/packages/dx-react-demos/src/bootstrap3/column-reordering/controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/column-reordering/controlled.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   Grid,
   DragDropContext,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableColumnReordering,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -40,7 +40,7 @@ export default class Demo extends React.PureComponent {
         columns={columns}
       >
         <DragDropContext />
-        <Table />
+        <TablePlugin />
         <TableColumnReordering
           order={columnOrder}
           onOrderChange={this.changeColumnOrder}

--- a/packages/dx-react-demos/src/bootstrap3/column-reordering/uncontrolled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/column-reordering/uncontrolled.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   Grid,
   DragDropContext,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableColumnReordering,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -34,7 +34,7 @@ export default class Demo extends React.PureComponent {
         columns={columns}
       >
         <DragDropContext />
-        <Table />
+        <TablePlugin />
         <TableColumnReordering
           defaultOrder={['city', 'sex', 'car', 'name']}
         />

--- a/packages/dx-react-demos/src/bootstrap3/column-resizing/controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/column-resizing/controlled.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableColumnResizing,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -39,7 +39,7 @@ export default class Demo extends React.PureComponent {
         rows={rows}
         columns={columns}
       >
-        <Table />
+        <TablePlugin />
         <TableColumnResizing
           columnWidths={columnWidths}
           onColumnWidthsChange={this.changeColumnWidths}

--- a/packages/dx-react-demos/src/bootstrap3/column-resizing/uncontrolled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/column-resizing/uncontrolled.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableColumnResizing,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -35,7 +35,7 @@ export default class Demo extends React.PureComponent {
         rows={rows}
         columns={columns}
       >
-        <Table />
+        <TablePlugin />
         <TableColumnResizing defaultColumnWidths={defaultColumnWidths} />
         <TableHeaderRow allowResizing />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/data-accessors/custom-data-accessors-in-columns.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/data-accessors/custom-data-accessors-in-columns.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableEditRow,
   TableEditColumn,
@@ -99,7 +99,7 @@ export default class Demo extends React.PureComponent {
         <EditingState
           onCommitChanges={this.commitChanges}
         />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableEditRow />
         <TableEditColumn allowAdding allowEditing allowDeleting />

--- a/packages/dx-react-demos/src/bootstrap3/data-accessors/custom-data-accessors.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/data-accessors/custom-data-accessors.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableEditRow,
   TableEditColumn,
@@ -99,7 +99,7 @@ export default class Demo extends React.PureComponent {
           createRowChange={createRowChange}
           onCommitChanges={this.commitChanges}
         />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableEditRow />
         <TableEditColumn allowAdding allowEditing allowDeleting />

--- a/packages/dx-react-demos/src/bootstrap3/data-types/editors.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/data-types/editors.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableEditRow,
   TableEditColumn,
@@ -89,7 +89,7 @@ export default class Demo extends React.PureComponent {
           onCommitChanges={this.commitChanges}
           defaultEditingRows={[0]}
         />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableEditRow />
         <TableEditColumn

--- a/packages/dx-react-demos/src/bootstrap3/data-types/formatters.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/data-types/formatters.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -55,7 +55,7 @@ export default class Demo extends React.PureComponent {
       >
         <CurrencyTypeProvider />
         <DateTypeProvider />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/detail-row/detail-row-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/detail-row/detail-row-controlled.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableRowDetail,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -43,7 +43,7 @@ export default class Demo extends React.PureComponent {
           expandedRows={expandedRows}
           onExpandedRowsChange={this.changeExpandedDetails}
         />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableRowDetail
           template={this.rowTemplate}

--- a/packages/dx-react-demos/src/bootstrap3/detail-row/simple-detail-row.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/detail-row/simple-detail-row.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableRowDetail,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -40,7 +40,7 @@ export default class Demo extends React.PureComponent {
         <RowDetailState
           defaultExpandedRows={[2, 5]}
         />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableRowDetail
           template={this.rowTemplate}

--- a/packages/dx-react-demos/src/bootstrap3/editing/edit-row-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/editing/edit-row-controlled.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableEditRow,
   TableEditColumn,
@@ -94,7 +94,7 @@ export default class Demo extends React.PureComponent {
           onAddedRowsChange={this.changeAddedRows}
           onCommitChanges={this.commitChanges}
         />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableEditRow />
         <TableEditColumn

--- a/packages/dx-react-demos/src/bootstrap3/editing/edit-row.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/editing/edit-row.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableEditRow,
   TableEditColumn,
@@ -69,7 +69,7 @@ export default class Demo extends React.PureComponent {
         <EditingState
           onCommitChanges={this.commitChanges}
         />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableEditRow />
         <TableEditColumn

--- a/packages/dx-react-demos/src/bootstrap3/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-controlled-mode/demo.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table, TableHeaderRow, TableEditRow, TableEditColumn,
+  TablePlugin, TableHeaderRow, TableEditRow, TableEditColumn,
   PagingPanel, DragDropContext, TableColumnReordering,
 } from '@devexpress/dx-react-grid-bootstrap3';
 import {
@@ -274,7 +274,7 @@ export default class Demo extends React.PureComponent {
 
           <DragDropContext />
 
-          <Table
+          <TablePlugin
             tableCellTemplate={this.tableCellTemplate}
           />
 
@@ -313,7 +313,7 @@ export default class Demo extends React.PureComponent {
               rows={rows.filter(row => deletingRows.indexOf(row.id) > -1)}
               columns={columns}
             >
-              <Table
+              <TablePlugin
                 tableCellTemplate={this.tableCellTemplate}
               />
               <TableHeaderRow />

--- a/packages/dx-react-demos/src/bootstrap3/featured-redux-integration/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-redux-integration/demo.jsx
@@ -8,7 +8,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow, TableRowDetail,
+  TablePlugin, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow, TableRowDetail,
   GroupingPanel, PagingPanel, DragDropContext, TableColumnReordering, TableColumnResizing,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -32,7 +32,7 @@ const GridDetailContainer = ({
       rows={data.tasks}
       columns={columns}
     >
-      <Table />
+      <TablePlugin />
       <TableHeaderRow />
     </Grid>
   </div>
@@ -110,7 +110,7 @@ const GridContainer = ({
 
     <DragDropContext />
 
-    <Table />
+    <TablePlugin />
 
     <TableColumnReordering
       order={columnOrder}

--- a/packages/dx-react-demos/src/bootstrap3/featured-remote-data/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-remote-data/demo.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -126,7 +126,7 @@ export default class Demo extends React.PureComponent {
             onPageSizeChange={this.changePageSize}
             totalCount={totalCount}
           />
-          <Table
+          <TablePlugin
             tableCellTemplate={({ row, column }) => {
               if (column.name === 'SaleAmount') {
                 return (

--- a/packages/dx-react-demos/src/bootstrap3/featured-theming/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-theming/demo.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table, TableHeaderRow, TableSelection, TableGroupRow,
+  TablePlugin, TableHeaderRow, TableSelection, TableGroupRow,
   PagingPanel, GroupingPanel, DragDropContext, TableRowDetail,
   TableColumnReordering,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -180,7 +180,7 @@ export default class Demo extends React.PureComponent {
 
         <DragDropContext />
 
-        <Table />
+        <TablePlugin />
 
         <TableColumnReordering defaultOrder={columns.map(column => column.name)} />
 

--- a/packages/dx-react-demos/src/bootstrap3/featured-uncontrolled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-uncontrolled-mode/demo.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow,
+  TablePlugin, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow,
   PagingPanel, GroupingPanel, DragDropContext, TableColumnReordering,
 } from '@devexpress/dx-react-grid-bootstrap3';
 import {
@@ -75,7 +75,7 @@ export default class Demo extends React.PureComponent {
 
         <DragDropContext />
 
-        <Table
+        <TablePlugin
           tableCellTemplate={({ row, column, style }) => {
             if (column.name === 'discount') {
               return (

--- a/packages/dx-react-demos/src/bootstrap3/filtering/custom-filter-row.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/filtering/custom-filter-row.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -67,7 +67,7 @@ export default class Demo extends React.PureComponent {
       >
         <FilteringState defaultFilters={[{ columnName: 'units', value: 2 }]} />
         <LocalFiltering />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableFilterRow
           filterCellTemplate={({ column, filter, setFilter }) => {

--- a/packages/dx-react-demos/src/bootstrap3/filtering/custom-filtering-algorithm.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/filtering/custom-filtering-algorithm.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -42,7 +42,7 @@ export default class Demo extends React.PureComponent {
       >
         <FilteringState defaultFilters={[{ columnName: 'city', value: 'Paris' }]} />
         <LocalFiltering getColumnPredicate={getColumnPredicate} />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableFilterRow />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/filtering/local-filter-row.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/filtering/local-filter-row.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -38,7 +38,7 @@ export default class Demo extends React.PureComponent {
       >
         <FilteringState defaultFilters={[]} />
         <LocalFiltering />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableFilterRow />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/filtering/local-filtering-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/filtering/local-filtering-controlled.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -44,7 +44,7 @@ export default class Demo extends React.PureComponent {
           onFiltersChange={this.changeFilters}
         />
         <LocalFiltering />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableFilterRow />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/grouping/custom-grouping-static.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/grouping/custom-grouping-static.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -59,7 +59,7 @@ export default class Demo extends React.PureComponent {
         <CustomGrouping
           getChildGroups={getChildGroups}
         />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableGroupRow />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-controlled.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
   GroupingPanel,
@@ -47,7 +47,7 @@ export default class Demo extends React.PureComponent {
           onGroupingChange={this.changeGrouping}
         />
         <LocalGrouping />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow allowDragging allowGroupingByClick />
         <TableGroupRow />
         <GroupingPanel allowDragging allowUngroupingByClick />

--- a/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-custom-advanced.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-custom-advanced.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -92,7 +92,7 @@ export default class Demo extends React.PureComponent {
         <LocalGrouping
           getColumnIdentity={this.getColumnIdentity}
         />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableGroupRow
           groupCellTemplate={(props) => {

--- a/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-custom.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-custom.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -54,7 +54,7 @@ export default class Demo extends React.PureComponent {
         <LocalGrouping
           getColumnIdentity={this.getColumnIdentity}
         />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableGroupRow />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-static.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-static.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -40,7 +40,7 @@ export default class Demo extends React.PureComponent {
           grouping={[{ columnName: 'city' }]}
         />
         <LocalGrouping />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableGroupRow />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-with-ui.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-with-ui.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
   GroupingPanel,
@@ -41,7 +41,7 @@ export default class Demo extends React.PureComponent {
         <DragDropContext />
         <GroupingState defaultGrouping={[{ columnName: 'city' }]} />
         <LocalGrouping />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow allowDragging />
         <TableGroupRow />
         <GroupingPanel allowDragging />

--- a/packages/dx-react-demos/src/bootstrap3/immutability/seamless-immutable.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/immutability/seamless-immutable.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableSelection,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -68,7 +68,7 @@ export default class Demo extends React.PureComponent {
           selection={selection}
           onSelectionChange={this.changeSelection}
         />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow allowSorting />
         <TableSelection />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/localization/basic.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/localization/basic.jsx
@@ -10,7 +10,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableFilterRow,
   TableGroupRow,
@@ -83,7 +83,7 @@ export default class Demo extends React.PureComponent {
           defaultPageSize={5}
         />
         <LocalPaging />
-        <Table
+        <TablePlugin
           messages={tableMessages}
         />
         <TableHeaderRow allowDragging />

--- a/packages/dx-react-demos/src/bootstrap3/paging/local-paging-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/paging/local-paging-controlled.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -51,7 +51,7 @@ export default class Demo extends React.PureComponent {
           onPageSizeChange={this.changePageSize}
         />
         <LocalPaging />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <PagingPanel
           allowedPageSizes={allowedPageSizes}

--- a/packages/dx-react-demos/src/bootstrap3/paging/local-paging.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/paging/local-paging.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -41,7 +41,7 @@ export default class Demo extends React.PureComponent {
           pageSize={5}
         />
         <LocalPaging />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <PagingPanel />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/paging/page-size-selector.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/paging/page-size-selector.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -41,7 +41,7 @@ export default class Demo extends React.PureComponent {
           defaultPageSize={5}
         />
         <LocalPaging />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <PagingPanel
           allowedPageSizes={allowedPageSizes}

--- a/packages/dx-react-demos/src/bootstrap3/paging/remote-paging.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/paging/remote-paging.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-bootstrap3';
@@ -86,7 +86,7 @@ export default class Demo extends React.PureComponent {
             pageSize={pageSize}
             totalCount={totalCount}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <PagingPanel />
         </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/selection/basic.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/selection/basic.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableSelection,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -41,7 +41,7 @@ export default class Demo extends React.PureComponent {
           selection={selection}
           onSelectionChange={this.changeSelection}
         />
-        <Table />
+        <TablePlugin />
         <TableSelection />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/selection/hidden-checkboxes.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/selection/hidden-checkboxes.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableSelection,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -41,7 +41,7 @@ export default class Demo extends React.PureComponent {
           selection={selection}
           onSelectionChange={this.changeSelection}
         />
-        <Table />
+        <TablePlugin />
         <TableSelection
           selectByRowClick
           highlightSelected

--- a/packages/dx-react-demos/src/bootstrap3/selection/hidden-select-all.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/selection/hidden-select-all.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableSelection,
   PagingPanel,
@@ -50,7 +50,7 @@ export default class Demo extends React.PureComponent {
           pageSize={6}
         />
         <LocalPaging />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
         <TableSelection
           showSelectAll={false}

--- a/packages/dx-react-demos/src/bootstrap3/selection/select-all-by-all-pages.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/selection/select-all-by-all-pages.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableSelection,
   PagingPanel,
@@ -53,7 +53,7 @@ export default class Demo extends React.PureComponent {
             pageSize={6}
           />
           <LocalPaging />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableSelection />
           <PagingPanel />

--- a/packages/dx-react-demos/src/bootstrap3/selection/select-all-by-page.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/selection/select-all-by-page.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableSelection,
   PagingPanel,
@@ -53,7 +53,7 @@ export default class Demo extends React.PureComponent {
             selection={selection}
             onSelectionChange={this.changeSelection}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableSelection />
           <PagingPanel />

--- a/packages/dx-react-demos/src/bootstrap3/selection/select-by-row-click.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/selection/select-by-row-click.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableSelection,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -41,7 +41,7 @@ export default class Demo extends React.PureComponent {
           selection={selection}
           onSelectionChange={this.changeSelection}
         />
-        <Table />
+        <TablePlugin />
         <TableSelection
           selectByRowClick
         />

--- a/packages/dx-react-demos/src/bootstrap3/sorting/local-custom-sorting.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/sorting/local-custom-sorting.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -61,7 +61,7 @@ export default class Demo extends React.PureComponent {
         <LocalSorting
           getColumnCompare={getColumnCompare}
         />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow allowSorting />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/sorting/local-group-sorting.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/sorting/local-group-sorting.jsx
@@ -7,7 +7,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
   GroupingPanel,
@@ -50,7 +50,7 @@ export default class Demo extends React.PureComponent {
         />
         <LocalSorting />
         <LocalGrouping />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow allowSorting />
         <TableGroupRow />
         <GroupingPanel allowSorting />

--- a/packages/dx-react-demos/src/bootstrap3/sorting/local-header-sorting.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/sorting/local-header-sorting.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -37,7 +37,7 @@ export default class Demo extends React.PureComponent {
       >
         <SortingState />
         <LocalSorting />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow allowSorting />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/sorting/local-sorting-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/sorting/local-sorting-controlled.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-bootstrap3';
 
@@ -43,7 +43,7 @@ export default class Demo extends React.PureComponent {
           onSortingChange={this.changeSorting}
         />
         <LocalSorting />
-        <Table />
+        <TablePlugin />
         <TableHeaderRow allowSorting />
       </Grid>
     );

--- a/packages/dx-react-demos/src/material-ui/basic/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/basic/basic.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
 
@@ -37,7 +37,7 @@ export default class Demo extends React.PureComponent {
           rows={rows}
           columns={columns}
         >
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/basic/table-cell-template.jsx
+++ b/packages/dx-react-demos/src/material-ui/basic/table-cell-template.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
 
@@ -73,7 +73,7 @@ export default class Demo extends React.PureComponent {
           rows={rows}
           columns={columns}
         >
-          <Table tableCellTemplate={this.tableCellTemplate} />
+          <TablePlugin tableCellTemplate={this.tableCellTemplate} />
           <TableHeaderRow />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/basic/table-row-template.jsx
+++ b/packages/dx-react-demos/src/material-ui/basic/table-row-template.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
 
@@ -46,7 +46,7 @@ export default class Demo extends React.PureComponent {
           rows={rows}
           columns={columns}
         >
-          <Table tableRowTemplate={this.tableRowTemplate} />
+          <TablePlugin tableRowTemplate={this.tableRowTemplate} />
           <TableHeaderRow />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/column-chooser/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-chooser/basic.jsx
@@ -5,7 +5,7 @@ import Toolbar from 'material-ui/Toolbar';
 import Typography from 'material-ui/Typography';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   ColumnChooser,
   TableColumnVisibility,
@@ -44,7 +44,7 @@ export default class Demo extends React.PureComponent {
               rows={rows}
               columns={columns}
             >
-              <Table />
+              <TablePlugin />
               <TableHeaderRow />
               <TableColumnVisibility
                 hiddenColumns={hiddenColumns}

--- a/packages/dx-react-demos/src/material-ui/column-reordering/controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-reordering/controlled.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   Grid,
   DragDropContext,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableColumnReordering,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -41,7 +41,7 @@ export default class Demo extends React.PureComponent {
           columns={columns}
         >
           <DragDropContext />
-          <Table />
+          <TablePlugin />
           <TableColumnReordering
             order={columnOrder}
             onOrderChange={this.changeColumnOrder}

--- a/packages/dx-react-demos/src/material-ui/column-reordering/uncontrolled.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-reordering/uncontrolled.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   Grid,
   DragDropContext,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableColumnReordering,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -35,7 +35,7 @@ export default class Demo extends React.PureComponent {
           columns={columns}
         >
           <DragDropContext />
-          <Table />
+          <TablePlugin />
           <TableColumnReordering
             defaultOrder={['city', 'sex', 'car', 'name']}
           />

--- a/packages/dx-react-demos/src/material-ui/column-resizing/controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-resizing/controlled.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableColumnResizing,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -40,7 +40,7 @@ export default class Demo extends React.PureComponent {
           rows={rows}
           columns={columns}
         >
-          <Table />
+          <TablePlugin />
           <TableColumnResizing
             columnWidths={columnWidths}
             onColumnWidthsChange={this.changeColumnWidths}

--- a/packages/dx-react-demos/src/material-ui/column-resizing/uncontrolled.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-resizing/uncontrolled.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableColumnResizing,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -36,7 +36,7 @@ export default class Demo extends React.PureComponent {
           rows={rows}
           columns={columns}
         >
-          <Table />
+          <TablePlugin />
           <TableColumnResizing defaultColumnWidths={defaultColumnWidths} />
           <TableHeaderRow allowResizing />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors-in-columns.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors-in-columns.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableEditRow,
   TableEditColumn,
@@ -100,7 +100,7 @@ export default class Demo extends React.PureComponent {
           <EditingState
             onCommitChanges={this.commitChanges}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableEditRow />
           <TableEditColumn allowAdding allowEditing allowDeleting />

--- a/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableEditRow,
   TableEditColumn,
@@ -100,7 +100,7 @@ export default class Demo extends React.PureComponent {
             createRowChange={createRowChange}
             onCommitChanges={this.commitChanges}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableEditRow />
           <TableEditColumn allowAdding allowEditing allowDeleting />

--- a/packages/dx-react-demos/src/material-ui/data-types/editors.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-types/editors.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableEditRow,
   TableEditColumn,
@@ -94,7 +94,7 @@ export default class Demo extends React.PureComponent {
             onCommitChanges={this.commitChanges}
             defaultEditingRows={[0]}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableEditRow />
           <TableEditColumn

--- a/packages/dx-react-demos/src/material-ui/data-types/formatters.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-types/formatters.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
 import Paper from 'material-ui/Paper';
@@ -56,7 +56,7 @@ export default class Demo extends React.PureComponent {
         >
           <CurrencyTypeProvider />
           <DateTypeProvider />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/detail-row/detail-row-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/detail-row/detail-row-controlled.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableRowDetail,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -44,7 +44,7 @@ export default class Demo extends React.PureComponent {
             expandedRows={expandedRows}
             onExpandedRowsChange={this.changeExpandedDetails}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableRowDetail
             template={this.rowTemplate}

--- a/packages/dx-react-demos/src/material-ui/detail-row/simple-detail-row.jsx
+++ b/packages/dx-react-demos/src/material-ui/detail-row/simple-detail-row.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableRowDetail,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -41,7 +41,7 @@ export default class Demo extends React.PureComponent {
           <RowDetailState
             defaultExpandedRows={[2, 5]}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableRowDetail
             template={this.rowTemplate}

--- a/packages/dx-react-demos/src/material-ui/editing/edit-row-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/editing/edit-row-controlled.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableEditRow,
   TableEditColumn,
@@ -95,7 +95,7 @@ export default class Demo extends React.PureComponent {
             onAddedRowsChange={this.changeAddedRows}
             onCommitChanges={this.commitChanges}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableEditRow />
           <TableEditColumn

--- a/packages/dx-react-demos/src/material-ui/editing/edit-row.jsx
+++ b/packages/dx-react-demos/src/material-ui/editing/edit-row.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableEditRow,
   TableEditColumn,
@@ -70,7 +70,7 @@ export default class Demo extends React.PureComponent {
           <EditingState
             onCommitChanges={this.commitChanges}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableEditRow />
           <TableEditColumn

--- a/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table, TableHeaderRow, TableEditRow, TableEditColumn,
+  TablePlugin, TableHeaderRow, TableEditRow, TableEditColumn,
   PagingPanel, DragDropContext, TableColumnReordering,
 } from '@devexpress/dx-react-grid-material-ui';
 import {
@@ -301,7 +301,7 @@ class DemoBase extends React.PureComponent {
 
           <DragDropContext />
 
-          <Table
+          <TablePlugin
             tableCellTemplate={this.tableCellTemplate}
           />
 
@@ -341,7 +341,7 @@ class DemoBase extends React.PureComponent {
                 rows={rows.filter(row => deletingRows.indexOf(row.id) > -1)}
                 columns={columns}
               >
-                <Table
+                <TablePlugin
                   tableCellTemplate={this.tableCellTemplate}
                 />
                 <TableHeaderRow />

--- a/packages/dx-react-demos/src/material-ui/featured-redux-integration/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-redux-integration/demo.jsx
@@ -8,7 +8,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow, TableRowDetail,
+  TablePlugin, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow, TableRowDetail,
   GroupingPanel, PagingPanel, DragDropContext, TableColumnReordering, TableColumnResizing,
 } from '@devexpress/dx-react-grid-material-ui';
 import Paper from 'material-ui/Paper';
@@ -42,7 +42,7 @@ const GridDetailContainerBase = ({
         rows={data.tasks}
         columns={columns}
       >
-        <Table />
+        <TablePlugin />
         <TableHeaderRow />
       </Grid>
     </Paper>
@@ -125,7 +125,7 @@ const GridContainer = ({
 
       <DragDropContext />
 
-      <Table />
+      <TablePlugin />
 
       <TableColumnReordering
         order={columnOrder}

--- a/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -171,7 +171,7 @@ export default class Demo extends React.PureComponent {
             onPageSizeChange={this.changePageSize}
             totalCount={totalCount}
           />
-          <Table
+          <TablePlugin
             tableCellTemplate={({ row, column }) => {
               if (column.name === 'SaleAmount') {
                 return <SaleAmountCell row={row} />;

--- a/packages/dx-react-demos/src/material-ui/featured-theming/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-theming/demo.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table, TableHeaderRow, TableSelection, TableGroupRow,
+  TablePlugin, TableHeaderRow, TableSelection, TableGroupRow,
   PagingPanel, GroupingPanel, DragDropContext, TableRowDetail,
   TableColumnReordering,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -206,7 +206,7 @@ export default class Demo extends React.PureComponent {
 
           <DragDropContext />
 
-          <Table />
+          <TablePlugin />
 
           <TableColumnReordering defaultOrder={columns.map(column => column.name)} />
 

--- a/packages/dx-react-demos/src/material-ui/featured-uncontrolled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-uncontrolled-mode/demo.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow,
+  TablePlugin, TableHeaderRow, TableFilterRow, TableSelection, TableGroupRow,
   PagingPanel, GroupingPanel, DragDropContext, TableColumnReordering,
 } from '@devexpress/dx-react-grid-material-ui';
 import Paper from 'material-ui/Paper';
@@ -76,7 +76,7 @@ export default class Demo extends React.PureComponent {
 
           <DragDropContext />
 
-          <Table
+          <TablePlugin
             tableCellTemplate={({ row, column, style }) => {
               if (column.name === 'discount') {
                 return (

--- a/packages/dx-react-demos/src/material-ui/filtering/custom-filter-row.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/custom-filter-row.jsx
@@ -8,7 +8,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -90,7 +90,7 @@ export default class Demo extends React.PureComponent {
         >
           <FilteringState defaultFilters={[{ columnName: 'units', value: 2 }]} />
           <LocalFiltering />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableFilterRow
             filterCellTemplate={({ column, filter, setFilter }) => {

--- a/packages/dx-react-demos/src/material-ui/filtering/custom-filtering-algorithm.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/custom-filtering-algorithm.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -43,7 +43,7 @@ export default class Demo extends React.PureComponent {
         >
           <FilteringState defaultFilters={[{ columnName: 'city', value: 'Paris' }]} />
           <LocalFiltering getColumnPredicate={getColumnPredicate} />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableFilterRow />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/filtering/local-filter-row.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/local-filter-row.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -39,7 +39,7 @@ export default class Demo extends React.PureComponent {
         >
           <FilteringState defaultFilters={[]} />
           <LocalFiltering />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableFilterRow />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/filtering/local-filtering-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/local-filtering-controlled.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableFilterRow,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -45,7 +45,7 @@ export default class Demo extends React.PureComponent {
             onFiltersChange={this.changeFilters}
           />
           <LocalFiltering />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableFilterRow />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/grouping/custom-grouping-static.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/custom-grouping-static.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -60,7 +60,7 @@ export default class Demo extends React.PureComponent {
           <CustomGrouping
             getChildGroups={getChildGroups}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableGroupRow />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/grouping/local-grouping-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/local-grouping-controlled.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
   GroupingPanel,
@@ -48,7 +48,7 @@ export default class Demo extends React.PureComponent {
             onGroupingChange={this.changeGrouping}
           />
           <LocalGrouping />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow allowDragging allowGroupingByClick />
           <TableGroupRow />
           <GroupingPanel allowDragging allowUngroupingByClick />

--- a/packages/dx-react-demos/src/material-ui/grouping/local-grouping-custom-advanced.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/local-grouping-custom-advanced.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -96,7 +96,7 @@ export default class Demo extends React.PureComponent {
           <LocalGrouping
             getColumnIdentity={this.getColumnIdentity}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableGroupRow
             groupCellTemplate={(props) => {

--- a/packages/dx-react-demos/src/material-ui/grouping/local-grouping-custom.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/local-grouping-custom.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -54,7 +54,7 @@ export default class Demo extends React.PureComponent {
           <LocalGrouping
             getColumnIdentity={this.getColumnIdentity}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableGroupRow />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/grouping/local-grouping-static.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/local-grouping-static.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -41,7 +41,7 @@ export default class Demo extends React.PureComponent {
             grouping={[{ columnName: 'city' }]}
           />
           <LocalGrouping />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableGroupRow />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/grouping/local-grouping-with-ui.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/local-grouping-with-ui.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
   GroupingPanel,
@@ -42,7 +42,7 @@ export default class Demo extends React.PureComponent {
           <DragDropContext />
           <GroupingState defaultGrouping={[{ columnName: 'city' }]} />
           <LocalGrouping />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow allowDragging />
           <TableGroupRow />
           <GroupingPanel allowDragging />

--- a/packages/dx-react-demos/src/material-ui/immutability/seamless-immutable.jsx
+++ b/packages/dx-react-demos/src/material-ui/immutability/seamless-immutable.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableSelection,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -69,7 +69,7 @@ export default class Demo extends React.PureComponent {
             selection={selection}
             onSelectionChange={this.changeSelection}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow allowSorting />
           <TableSelection />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/localization/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/localization/basic.jsx
@@ -10,7 +10,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableFilterRow,
   TableGroupRow,
@@ -88,7 +88,7 @@ export default class Demo extends React.PureComponent {
             defaultPageSize={5}
           />
           <LocalPaging />
-          <Table
+          <TablePlugin
             messages={tableMessages}
           />
           <TableHeaderRow allowDragging />

--- a/packages/dx-react-demos/src/material-ui/paging/local-paging-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/paging/local-paging-controlled.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -52,7 +52,7 @@ export default class Demo extends React.PureComponent {
             onPageSizeChange={this.changePageSize}
           />
           <LocalPaging />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <PagingPanel
             allowedPageSizes={allowedPageSizes}

--- a/packages/dx-react-demos/src/material-ui/paging/local-paging.jsx
+++ b/packages/dx-react-demos/src/material-ui/paging/local-paging.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -42,7 +42,7 @@ export default class Demo extends React.PureComponent {
             pageSize={5}
           />
           <LocalPaging />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <PagingPanel />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/paging/page-size-selector.jsx
+++ b/packages/dx-react-demos/src/material-ui/paging/page-size-selector.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -42,7 +42,7 @@ export default class Demo extends React.PureComponent {
             defaultPageSize={5}
           />
           <LocalPaging />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <PagingPanel
             allowedPageSizes={allowedPageSizes}

--- a/packages/dx-react-demos/src/material-ui/paging/remote-paging.jsx
+++ b/packages/dx-react-demos/src/material-ui/paging/remote-paging.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
@@ -86,7 +86,7 @@ export default class Demo extends React.PureComponent {
             pageSize={pageSize}
             totalCount={totalCount}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <PagingPanel />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/selection/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/basic.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableSelection,
 } from '@devexpress/dx-react-grid-material-ui';
 import Paper from 'material-ui/Paper';
@@ -42,7 +42,7 @@ export default class Demo extends React.PureComponent {
             selection={selection}
             onSelectionChange={this.changeSelection}
           />
-          <Table />
+          <TablePlugin />
           <TableSelection />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/selection/hidden-checkboxes.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/hidden-checkboxes.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableSelection,
 } from '@devexpress/dx-react-grid-material-ui';
 import Paper from 'material-ui/Paper';
@@ -42,7 +42,7 @@ export default class Demo extends React.PureComponent {
             selection={selection}
             onSelectionChange={this.changeSelection}
           />
-          <Table />
+          <TablePlugin />
           <TableSelection
             selectByRowClick
             highlightSelected

--- a/packages/dx-react-demos/src/material-ui/selection/hidden-select-all.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/hidden-select-all.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableSelection,
   PagingPanel,
@@ -51,7 +51,7 @@ export default class Demo extends React.PureComponent {
             pageSize={6}
           />
           <LocalPaging />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow />
           <TableSelection
             showSelectAll={false}

--- a/packages/dx-react-demos/src/material-ui/selection/select-all-by-all-pages.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/select-all-by-all-pages.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableSelection,
   PagingPanel,
@@ -53,7 +53,7 @@ export default class Demo extends React.PureComponent {
               pageSize={6}
             />
             <LocalPaging />
-            <Table />
+            <TablePlugin />
             <TableHeaderRow />
             <TableSelection />
             <PagingPanel />

--- a/packages/dx-react-demos/src/material-ui/selection/select-all-by-page.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/select-all-by-page.jsx
@@ -6,7 +6,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableSelection,
   PagingPanel,
@@ -53,7 +53,7 @@ export default class Demo extends React.PureComponent {
               selection={selection}
               onSelectionChange={this.changeSelection}
             />
-            <Table />
+            <TablePlugin />
             <TableHeaderRow />
             <TableSelection />
             <PagingPanel />

--- a/packages/dx-react-demos/src/material-ui/selection/select-by-row-click.jsx
+++ b/packages/dx-react-demos/src/material-ui/selection/select-by-row-click.jsx
@@ -4,7 +4,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableSelection,
 } from '@devexpress/dx-react-grid-material-ui';
 import Paper from 'material-ui/Paper';
@@ -42,7 +42,7 @@ export default class Demo extends React.PureComponent {
             selection={selection}
             onSelectionChange={this.changeSelection}
           />
-          <Table />
+          <TablePlugin />
           <TableSelection
             selectByRowClick
           />

--- a/packages/dx-react-demos/src/material-ui/sorting/local-custom-sorting.jsx
+++ b/packages/dx-react-demos/src/material-ui/sorting/local-custom-sorting.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
 import Paper from 'material-ui/Paper';
@@ -62,7 +62,7 @@ export default class Demo extends React.PureComponent {
           <LocalSorting
             getColumnCompare={getColumnCompare}
           />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow allowSorting />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/sorting/local-group-sorting.jsx
+++ b/packages/dx-react-demos/src/material-ui/sorting/local-group-sorting.jsx
@@ -7,7 +7,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
   TableGroupRow,
   GroupingPanel,
@@ -51,7 +51,7 @@ export default class Demo extends React.PureComponent {
           />
           <LocalSorting />
           <LocalGrouping />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow allowSorting />
           <TableGroupRow />
           <GroupingPanel allowSorting />

--- a/packages/dx-react-demos/src/material-ui/sorting/local-header-sorting.jsx
+++ b/packages/dx-react-demos/src/material-ui/sorting/local-header-sorting.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
 import Paper from 'material-ui/Paper';
@@ -38,7 +38,7 @@ export default class Demo extends React.PureComponent {
         >
           <SortingState />
           <LocalSorting />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow allowSorting />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/sorting/local-sorting-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/sorting/local-sorting-controlled.jsx
@@ -5,7 +5,7 @@ import {
 } from '@devexpress/dx-react-grid';
 import {
   Grid,
-  Table,
+  TablePlugin,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
 import Paper from 'material-ui/Paper';
@@ -44,7 +44,7 @@ export default class Demo extends React.PureComponent {
             onSortingChange={this.changeSorting}
           />
           <LocalSorting />
-          <Table />
+          <TablePlugin />
           <TableHeaderRow allowSorting />
         </Grid>
       </Paper>

--- a/packages/dx-react-grid-bootstrap3/README.md
+++ b/packages/dx-react-grid-bootstrap3/README.md
@@ -53,7 +53,7 @@ Components:
 
 Plugins:
 
-- [TablePlugin](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table/)
+- [TablePlugin](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-plugin/)
 - [TableHeaderRow](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-header-row/)
 - [TableSelection](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-selection/)
 - [TableFilterRow](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-filter-row/)

--- a/packages/dx-react-grid-bootstrap3/README.md
+++ b/packages/dx-react-grid-bootstrap3/README.md
@@ -14,7 +14,7 @@ Add the required modules to your project:
 
 ```js
 import {
-  Grid, Table, TableHeaderRow
+  Grid, TablePlugin, TableHeaderRow
 } from '@devexpress/dx-react-grid-bootstrap3';
 
 const App = () => (
@@ -28,7 +28,7 @@ const App = () => (
       { name: 'product', title: 'Product' },
       { name: 'owner', title: 'Owner' },
     ]}>
-    <Table />
+    <TablePlugin />
     <TableHeaderRow />
   </Grid>
 );
@@ -53,7 +53,7 @@ Components:
 
 Plugins:
 
-- [Table](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table/)
+- [TablePlugin](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table/)
 - [TableHeaderRow](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-header-row/)
 - [TableSelection](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-selection/)
 - [TableFilterRow](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-filter-row/)

--- a/packages/dx-react-grid-bootstrap3/src/index.js
+++ b/packages/dx-react-grid-bootstrap3/src/index.js
@@ -6,7 +6,7 @@ export { GroupingPanel } from './plugins/grouping-panel';
 export { TableRowDetail } from './plugins/table-row-detail';
 export { TableGroupRow } from './plugins/table-group-row';
 export { TableSelection } from './plugins/table-selection';
-export { Table } from './plugins/table';
+export { TablePlugin } from './plugins/table';
 export { VirtualTable } from './plugins/virtual-table';
 export { TableFilterRow } from './plugins/table-filter-row';
 export { TableHeaderRow } from './plugins/table-header-row';

--- a/packages/dx-react-grid-bootstrap3/src/plugins/table.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/plugins/table.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { combineTemplates } from '@devexpress/dx-react-core';
-import { Table as TableBase } from '@devexpress/dx-react-grid';
+import { TablePlugin as TablePluginBase } from '@devexpress/dx-react-grid';
 import { TableLayout } from '../templates/table-layout';
 import { TableCell } from '../templates/table-cell';
 import { TableStubCell } from '../templates/table-stub-cell';
@@ -21,7 +21,7 @@ const defaultMessages = {
   noData: 'No data',
 };
 
-export class Table extends React.PureComponent {
+export class TablePlugin extends React.PureComponent {
   render() {
     const {
       tableCellTemplate,
@@ -35,7 +35,7 @@ export class Table extends React.PureComponent {
     } = this.props;
 
     return (
-      <TableBase
+      <TablePluginBase
         tableLayoutTemplate={tableLayoutTemplate}
         tableRowTemplate={combineTemplates(
           tableRowTemplate,
@@ -68,7 +68,7 @@ export class Table extends React.PureComponent {
   }
 }
 
-Table.propTypes = {
+TablePlugin.propTypes = {
   tableCellTemplate: PropTypes.func,
   tableRowTemplate: PropTypes.func,
   tableNoDataRowTemplate: PropTypes.func,
@@ -80,7 +80,7 @@ Table.propTypes = {
   }),
 };
 
-Table.defaultProps = {
+TablePlugin.defaultProps = {
   tableCellTemplate: undefined,
   tableRowTemplate: undefined,
   tableNoDataRowTemplate: undefined,

--- a/packages/dx-react-grid-bootstrap3/src/plugins/virtual-table.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/plugins/virtual-table.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { combineTemplates } from '@devexpress/dx-react-core';
-import { Table as TableBase } from '@devexpress/dx-react-grid';
+import { TablePlugin as TablePluginBase } from '@devexpress/dx-react-grid';
 import { VirtualTableLayout } from '../templates/virtual-table-layout';
 import { TableCell } from '../templates/table-cell';
 import { TableRow } from '../templates/table-row';
@@ -37,7 +37,7 @@ export class VirtualTable extends React.PureComponent {
     } = this.props;
 
     return (
-      <TableBase
+      <TablePluginBase
         tableLayoutTemplate={props => tableLayoutTemplate({
           ...props,
           height,

--- a/packages/dx-react-grid-material-ui/README.md
+++ b/packages/dx-react-grid-material-ui/README.md
@@ -14,7 +14,7 @@ Add the required modules to your project:
 
 ```js
 import {
-  Grid, Table, TableHeaderRow
+  Grid, TablePlugin, TableHeaderRow
 } from '@devexpress/dx-react-grid-material-ui';
 
 const App = () => (
@@ -28,7 +28,7 @@ const App = () => (
       { name: 'product', title: 'Product' },
       { name: 'owner', title: 'Owner' },
     ]}>
-    <Table />
+    <TablePlugin />
     <TableHeaderRow />
   </Grid>
 );
@@ -53,7 +53,7 @@ Components:
 
 Plugins:
 
-- [Table](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table/)
+- [TablePlugin](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table/)
 - [TableHeaderRow](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-header-row/)
 - [TableSelection](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-selection/)
 - [TableFilterRow](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-filter-row/)

--- a/packages/dx-react-grid-material-ui/README.md
+++ b/packages/dx-react-grid-material-ui/README.md
@@ -53,7 +53,7 @@ Components:
 
 Plugins:
 
-- [TablePlugin](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table/)
+- [TablePlugin](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-plugin/)
 - [TableHeaderRow](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-header-row/)
 - [TableSelection](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-selection/)
 - [TableFilterRow](https://devexpress.github.io/devextreme-reactive/react/grid/docs/reference/table-filter-row/)

--- a/packages/dx-react-grid-material-ui/src/index.js
+++ b/packages/dx-react-grid-material-ui/src/index.js
@@ -6,7 +6,7 @@ export { GroupingPanel } from './plugins/grouping-panel';
 export { TableRowDetail } from './plugins/table-row-detail';
 export { TableGroupRow } from './plugins/table-group-row';
 export { TableSelection } from './plugins/table-selection';
-export { Table } from './plugins/table';
+export { TablePlugin } from './plugins/table';
 export { VirtualTable } from './plugins/virtual-table';
 export { TableFilterRow } from './plugins/table-filter-row';
 export { TableHeaderRow } from './plugins/table-header-row';

--- a/packages/dx-react-grid-material-ui/src/plugins/table.jsx
+++ b/packages/dx-react-grid-material-ui/src/plugins/table.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { combineTemplates } from '@devexpress/dx-react-core';
-import { Table as TableBase } from '@devexpress/dx-react-grid';
+import { TablePlugin as TablePluginBase } from '@devexpress/dx-react-grid';
 import { TableRow } from '../templates/table-row';
 import { TableLayout } from '../templates/table-layout';
 import { TableCell } from '../templates/table-cell';
@@ -19,7 +19,7 @@ const defaultMessages = {
   noData: 'No data',
 };
 
-export class Table extends React.PureComponent {
+export class TablePlugin extends React.PureComponent {
   render() {
     const {
       tableCellTemplate,
@@ -33,7 +33,7 @@ export class Table extends React.PureComponent {
     } = this.props;
 
     return (
-      <TableBase
+      <TablePluginBase
         tableLayoutTemplate={tableLayoutTemplate}
         tableRowTemplate={combineTemplates(
           tableRowTemplate,
@@ -66,7 +66,7 @@ export class Table extends React.PureComponent {
   }
 }
 
-Table.propTypes = {
+TablePlugin.propTypes = {
   tableCellTemplate: PropTypes.func,
   tableRowTemplate: PropTypes.func,
   tableNoDataRowTemplate: PropTypes.func,
@@ -78,7 +78,7 @@ Table.propTypes = {
   }),
 };
 
-Table.defaultProps = {
+TablePlugin.defaultProps = {
   tableCellTemplate: undefined,
   tableRowTemplate: undefined,
   tableNoDataRowTemplate: undefined,

--- a/packages/dx-react-grid-material-ui/src/plugins/virtual-table.jsx
+++ b/packages/dx-react-grid-material-ui/src/plugins/virtual-table.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { combineTemplates } from '@devexpress/dx-react-core';
-import { Table as TableBase } from '@devexpress/dx-react-grid';
+import { TablePlugin as TablePluginBase } from '@devexpress/dx-react-grid';
 import { VirtualTableLayout } from '../templates/virtual-table-layout';
 import { TableRow } from '../templates/table-row';
 import { TableCell } from '../templates/table-cell';
@@ -35,7 +35,7 @@ export class VirtualTable extends React.PureComponent {
     } = this.props;
 
     return (
-      <TableBase
+      <TablePluginBase
         tableLayoutTemplate={props => tableLayoutTemplate({
           ...props,
           height,

--- a/packages/dx-react-grid/README.md
+++ b/packages/dx-react-grid/README.md
@@ -40,11 +40,11 @@ React Grid uses the latest web platform standards. Thus, it cannot support older
 
 The Grid renders nothing by default. The root Grid component's nested plugin components implement its functionality, and it is necessary to specify at least one plugin that visualizes the grid data.
 
-Use the Table plugin to display the data as a simple table:
+Use the TablePlugin to display the data as a simple table:
 
 ```js
 import {
-  Grid, Table, TableHeaderRow
+  Grid, TablePlugin, TableHeaderRow
 } from '@devexpress/dx-react-grid-bootstrap3'/* or '@devexpress/dx-react-grid-material-ui' */;
 
 const App = () => (
@@ -58,7 +58,7 @@ const App = () => (
       { name: 'product', title: 'Product' },
       { name: 'owner', title: 'Owner' },
     ]}>
-    <Table />
+    <TablePlugin />
     <TableHeaderRow />
   </Grid>
 );

--- a/packages/dx-react-grid/README.md
+++ b/packages/dx-react-grid/README.md
@@ -40,7 +40,7 @@ React Grid uses the latest web platform standards. Thus, it cannot support older
 
 The Grid renders nothing by default. The root Grid component's nested plugin components implement its functionality, and it is necessary to specify at least one plugin that visualizes the grid data.
 
-Use the TablePlugin to display the data as a simple table:
+Use TablePlugin to display the data as a simple table:
 
 ```js
 import {

--- a/packages/dx-react-grid/docs/guides/column-reordering.md
+++ b/packages/dx-react-grid/docs/guides/column-reordering.md
@@ -7,7 +7,7 @@ The Grid component allows reordering grid columns programmatically or using the 
 The following plugins implement column reordering features:
 
 - [DragDropContext](../reference/drag-drop-context.md) - implements the drag-and-drop functionality and visualizes a column being dragged
-- [Table](../reference/table.md) - visualizes table column reordering
+- [TablePlugin](../reference/table-plugin.md) - visualizes table column reordering
 - [TableColumnReordering](../reference/table-column-reordering.md) - controls the column order
 - [TableHeaderRow](../reference/table-header-row.md) - visualizes header row column reordering
 

--- a/packages/dx-react-grid/docs/guides/column-resizing.md
+++ b/packages/dx-react-grid/docs/guides/column-resizing.md
@@ -6,7 +6,7 @@ Table columns in the Grid component can be resized programmatically or via the G
 
 The following plugins implement column resizing features:
 
-- [Table](../reference/table.md) - visualizes table column widths
+- [TablePlugin](../reference/table-plugin.md) - visualizes table column widths
 - [TableColumnResizing](../reference/table-column-resizing.md) - controls table column widths
 - [TableHeaderRow](../reference/table-header-row.md) - renders the table columns' resize handles
 

--- a/packages/dx-react-grid/docs/guides/getting-started.md
+++ b/packages/dx-react-grid/docs/guides/getting-started.md
@@ -46,7 +46,7 @@ React Grid uses the latest web platform standards, and cannot support older brow
 
 The Grid renders nothing by default. The root Grid component's nested plugin components implement its functionality, and it is necessary to specify at least one plugin that visualizes the grid data.
 
-Use the TablePlugin to display the data as a simple table:
+Use TablePlugin to display the data as a simple table:
 
 ```js
 import {

--- a/packages/dx-react-grid/docs/guides/getting-started.md
+++ b/packages/dx-react-grid/docs/guides/getting-started.md
@@ -46,11 +46,11 @@ React Grid uses the latest web platform standards, and cannot support older brow
 
 The Grid renders nothing by default. The root Grid component's nested plugin components implement its functionality, and it is necessary to specify at least one plugin that visualizes the grid data.
 
-Use the Table plugin to display the data as a simple table:
+Use the TablePlugin to display the data as a simple table:
 
 ```js
 import {
-  Grid, Table, TableHeaderRow
+  Grid, TablePlugin, TableHeaderRow
 } from '@devexpress/dx-react-grid-bootstrap3'/* or '@devexpress/dx-react-grid-material-ui' */;
 
 const App = () => (
@@ -64,7 +64,7 @@ const App = () => (
       { name: 'product', title: 'Product' },
       { name: 'owner', title: 'Owner' },
     ]}>
-    <Table />
+    <TablePlugin />
     <TableHeaderRow />
   </Grid>
 );

--- a/packages/dx-react-grid/docs/guides/grid-basics.md
+++ b/packages/dx-react-grid/docs/guides/grid-basics.md
@@ -20,7 +20,7 @@ The Grid component displays data specified via the `rows` property. You should a
 
 The grid requires the following plugins for basic data visualization:
 
-- [Table](../reference/table.md)
+- [TablePlugin](../reference/table-plugin.md)
  Renders a data table.
 
 - [TableHeaderRow](../reference/table-header-row.md)
@@ -31,7 +31,7 @@ The grid requires the following plugins for basic data visualization:
   rows={rows}
   columns={columns}
 >
-  <Table />
+  <TablePlugin />
   <TableHeaderRow />
 </Grid>
 ```

--- a/packages/dx-react-grid/docs/guides/grouping.md
+++ b/packages/dx-react-grid/docs/guides/grouping.md
@@ -71,7 +71,7 @@ You can also assign a function that returns a Boolean value depending on the `co
       grouping={[{ columnName: 'city' }, { columnName: 'car' }]}
     />
     <LocalGrouping />
-    <Table />
+    <TablePlugin />
     <TableHeaderRow showColumnWhenGrouped={columnName => columnName === 'city' || columnName === 'car'}/>
     <TableGroupRow />
   </Grid>

--- a/packages/dx-react-grid/docs/guides/plugin-overview.md
+++ b/packages/dx-react-grid/docs/guides/plugin-overview.md
@@ -27,7 +27,7 @@ const App = () => (
   <Grid rows={[/* ... */]} columns={[/* ... */]}>
     <FilteringState defaultFilters={[/* ... */]}/>
     <LocalFiltering/>
-    <Table/>
+    <TablePlugin />
   </Grid>
 );
 ```
@@ -39,14 +39,14 @@ import {
   FilteringState, LocalFiltering
 } from '@devexpress/dx-react-grid'
 import {
-  Grid, Table, TableFilterRow
+  Grid, TablePlugin, TableFilterRow
 } from '@devexpress/dx-react-grid-bootstrap3'/* or '@devexpress/dx-react-grid-material-ui' */;
 
 const App = () => (
   <Grid rows={[/* ... */]} columns={[/* ... */]}>
     <FilteringState defaultFilters={[/* ... */]}/>
     <LocalFiltering/>
-    <Table/>
+    <TablePlugin />
     <TableFilterRow filterCellTemplate={ /* ... */ }/>
   </Grid>
 );

--- a/packages/dx-react-grid/docs/guides/virtual-scrolling.md
+++ b/packages/dx-react-grid/docs/guides/virtual-scrolling.md
@@ -6,7 +6,7 @@ Virtual scrolling allows the Grid component to display thousands of records on a
 
 ## Plugin List
 
-The [VirtualTable](../reference/virtual-table.md) plugin implements the virtual scrolling mode, and it should be used instead of the [Table](../reference/table.md) as they implement the same interfaces.
+The [VirtualTable](../reference/virtual-table-plugin.md) plugin implements the virtual scrolling mode, and it should be used instead of the [TablePlugin](../reference/table-plugin.md) as they implement the same interfaces.
 
 Note that the [plugin order](./plugin-overview.md#plugin-order) is important.
 

--- a/packages/dx-react-grid/docs/guides/virtual-scrolling.md
+++ b/packages/dx-react-grid/docs/guides/virtual-scrolling.md
@@ -6,7 +6,7 @@ Virtual scrolling allows the Grid component to display thousands of records on a
 
 ## Plugin List
 
-The [VirtualTable](../reference/virtual-table-plugin.md) plugin implements the virtual scrolling mode, and it should be used instead of the [TablePlugin](../reference/table-plugin.md) as they implement the same interfaces.
+The [VirtualTable](../reference/virtual-table.md) plugin implements the virtual scrolling mode, and it should be used instead of the [TablePlugin](../reference/table-plugin.md) as they implement the same interfaces.
 
 Note that the [plugin order](./plugin-overview.md#plugin-order) is important.
 

--- a/packages/dx-react-grid/docs/reference/table-column-reordering.md
+++ b/packages/dx-react-grid/docs/reference/table-column-reordering.md
@@ -6,7 +6,7 @@ A plugin that manages the displayed columns' order.
 
 ### Dependencies
 
-- [Table](table.md)
+- [TablePlugin](table-plugin.md)
 
 ### Properties
 
@@ -16,7 +16,7 @@ order | Array&lt;string&gt; | | Specifies the column order.
 defaultOrder | Array&lt;string&gt; | | Specifies the initial column order in the uncontrolled mode.
 onOrderChange | (nextOrder: Array&lt;string&gt;) => void | | Handles column order changes.
 tableContainerTemplate | (args: [TableContainerArgs](#table-container-args)) => ReactElement | | A component that renders a table wrapper containing a drop target.
-reorderingRowTemplate | (args: [TableRowArgs](table.md#table-row-args)) => ReactElement | | A non-visual component that renders an invisible row required for drag-and-drop reordering.
+reorderingRowTemplate | (args: [TableRowArgs](table-plugin.md#table-row-args)) => ReactElement | | A non-visual component that renders an invisible row required for drag-and-drop reordering.
 reorderingCellTemplate | (args: [ReorderingCellArgs](#reordering-cell-args)) => ReactElement | | A non-visual component that renders an invisible cell required for drag-and-drop reordering.
 
 ## Interfaces
@@ -37,7 +37,7 @@ onDrop | (args: { payload: Array&lt;{ columnName: string }&gt;, clientOffset: { 
 
 Describes properties passed to the reordering row cell template.
 
-A value with the [TableCellArgs](table.md#table-cell-args) shape extended by the following fields:
+A value with the [TableCellArgs](table-plugin.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -49,15 +49,15 @@ getCellDimensions | (dimensionsGetter: () => { left: number, right: number }) =>
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Table columns.
-tableHeaderRows | Getter | Array&lt;[TableRow](table.md#table-row)&gt; | Header rows to be rendered.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Table columns.
+tableHeaderRows | Getter | Array&lt;[TableRow](table-plugin.md#table-row)&gt; | Header rows to be rendered.
 table | Template | Object? | A template that renders the table.
-tableRow | Template | [TableRowArgs](table.md#table-row-args) | A template that renders a table row.
-tableCell | Template | [TableCellArgs](table.md#table-cell-args) | A template that renders a table cell.
+tableRow | Template | [TableRowArgs](table-plugin.md#table-row-args) | A template that renders a table row.
+tableCell | Template | [TableCellArgs](table-plugin.md#table-cell-args) | A template that renders a table cell.
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Ordered table columns.
-tableHeaderRows | Getter | Array&lt;[TableRow](table.md#table-row)&gt; | Header rows including the service reordering row to be rendered.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Ordered table columns.
+tableHeaderRows | Getter | Array&lt;[TableRow](table-plugin.md#table-row)&gt; | Header rows including the service reordering row to be rendered.

--- a/packages/dx-react-grid/docs/reference/table-column-resizing.md
+++ b/packages/dx-react-grid/docs/reference/table-column-resizing.md
@@ -6,7 +6,7 @@ A plugin that manages table column widths measured in pixels.
 
 ### Dependencies
 
-- [Table](table.md)
+- [TablePlugin](table-plugin.md)
 
 ### Properties
 
@@ -22,13 +22,13 @@ onColumnWidthChange | (nextColumnWidths: { [columnName: string]: number }) => vo
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Table columns the widths are associated with.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Table columns the widths are associated with.
 
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Table columns with associated widths.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Table columns with associated widths.
 changeTableColumnWidths | Action | ({ shifts: { [columnName: string]: number } }) => void | Changes column widths. Each shift is added to the original column width value.
 changeDraftTableColumnWidths | Action | ({ shifts: { [columnName: string]: number } }) => void | Changes draft column widths. Each shift is added to the original column width value. If a shift is `null`, the draft width for the column is cleared.

--- a/packages/dx-react-grid/docs/reference/table-column-visibility.md
+++ b/packages/dx-react-grid/docs/reference/table-column-visibility.md
@@ -6,7 +6,7 @@ A plugin that manages Grid columns' visibility.
 
 ### Dependencies
 
-- [Table](table.md)
+- [TablePlugin](table-plugin.md)
 
 ### Properties
 
@@ -38,10 +38,10 @@ noColumns? | string | 'Nothing to show' | Specifies the text displayed when the 
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Table columns.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Table columns.
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Visible table columns.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Visible table columns.

--- a/packages/dx-react-grid/docs/reference/table-edit-column.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-column.md
@@ -7,7 +7,7 @@ A plugin that renders a command column (a column containing controls used for ro
 ### Dependencies
 
 - [EditingState](editing-state.md)
-- [Table](table.md)
+- [TablePlugin](table-plugin.md)
 
 ### Properties
 
@@ -28,7 +28,7 @@ messages | object | | An object that specifies the [localization messages](#loca
 
 Describes properties passed to a data row's command cell template.
 
-A value with the [TableCellArgs](table.md#table-cell-args) shape extended by the following fields:
+A value with the [TableCellArgs](table-plugin.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -47,7 +47,7 @@ getMessage | ([messageKey](#localization-messages): string) => string | Returns 
 
 Describes properties passed to a heading row's command cell template.
 
-A value with the [TableCellArgs](table.md#table-cell-args) shape extended by the following fields:
+A value with the [TableCellArgs](table-plugin.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -85,7 +85,7 @@ cancelCommand? | string | 'Cancel' | Specifies the cancel command button text.
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Table columns.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Table columns.
 addRow | Action | () => void | Creates a row.
 cancelAddedRows | Action | ({ rowIds: Array&lt;number&gt; }) => void | Removes uncommitted new rows from the `addedRows` array.
 commitAddedRows | Action | ({ rowIds: Array&lt;number&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](editing-state.md#change-set) and removes the specified rows from the `addedRows` array.
@@ -95,10 +95,10 @@ cancelChangedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => 
 commitChangedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](editing-state.md#change-set) and removes the specified rows from the `changedRows` array.
 deleteRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Prepares rows specified by the ID for deletion, adding them to the `deletedRows` array.
 commitDeletedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](editing-state.md#change-set) and removes the specified rows from the `deletedRows` array.
-tableCell | Template | [TableCellArgs](table.md#table-cell-args) | A template that renders a table cell.
+tableCell | Template | [TableCellArgs](table-plugin.md#table-cell-args) | A template that renders a table cell.
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Table columns including the edit column.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Table columns including the edit column.

--- a/packages/dx-react-grid/docs/reference/table-edit-row.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-row.md
@@ -7,7 +7,7 @@ A plugin that renders a row being edited.
 ### Dependencies
 
 - [EditingState](editing-state.md)
-- [Table](table.md)
+- [TablePlugin](table-plugin.md)
 - [DataTypeProvider](data-type-provider.md) [Optional]
 
 ### Properties
@@ -24,7 +24,7 @@ editRowTemplate | (args: [EditRowArgs](#edit-row-args)) => ReactElement | | A co
 
 Describes properties passed to the edit row's cell template.
 
-A value with the [TableCellArgs](table.md#table-cell-args) shape extended by the following fields:
+A value with the [TableCellArgs](table-plugin.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -37,7 +37,7 @@ onValueChange | (newValue: any) => void | Handles value changes.
 
 Describes properties passed to the edit row template.
 
-A value with the [TableRowArgs](table.md#table-row-args) shape extended by the following fields:
+A value with the [TableRowArgs](table-plugin.md#table-row-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -49,7 +49,7 @@ row | any | Specifies the initial row.
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableBodyRows | Getter | Array&lt;[TableRow](table.md#table-row)&gt; | Rows to be rendered inside the table body.
+tableBodyRows | Getter | Array&lt;[TableRow](table-plugin.md#table-row)&gt; | Rows to be rendered inside the table body.
 editingRows | Getter | Array&lt;number &#124; string&gt; | IDs of the rows being edited.
 addedRows | Getter | Array&lt;any&gt; | Created but not committed rows.
 changeAddedRow | Action | ({ rowId: number, change: any }) => void | Applies a change to a created but uncommitted row. Note: `rowId` is a row index within the `addedRows` array.
@@ -57,11 +57,11 @@ changedRows | Getter | { [key: string]: any } | An associative array storing cha
 changeRow | Action | ({ rowId: number &#124; string, change: Object }) => void | Applies a change to an existing row.
 getCellValue | Getter | (row: any, columnName: string) => any | A function used to get the column value for a given row.
 createRowChange | Getter | (row: any, columnName: string, value: string &#124; string) => any | A function that returns a value specifying row changes depending on the columns's editor values for the current row. This function is called each time the editor's value changes.
-tableCell | Template | [TableCellArgs](table.md#table-cell-args) | A template that renders a table cell.
-tableRow | Template | [TableRowArgs](table.md#table-row-args) | A template that renders a table row.
+tableCell | Template | [TableCellArgs](table-plugin.md#table-cell-args) | A template that renders a table cell.
+tableRow | Template | [TableRowArgs](table-plugin.md#table-row-args) | A template that renders a table row.
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableBodyRows | Getter | Array&lt;[TableRow](table.md#table-row)&gt; | Table data rows including editing rows.
+tableBodyRows | Getter | Array&lt;[TableRow](table-plugin.md#table-row)&gt; | Table data rows including editing rows.

--- a/packages/dx-react-grid/docs/reference/table-filter-row.md
+++ b/packages/dx-react-grid/docs/reference/table-filter-row.md
@@ -7,7 +7,7 @@ A plugin that renders a filter row.
 ### Dependencies
 
 - [FilteringState](filtering-state.md)
-- [Table](table.md)
+- [TablePlugin](table-plugin.md)
 - [DataTypeProvider](data-type-provider.md) [Optional]
 
 ### Properties
@@ -16,7 +16,7 @@ Name | Type | Default | Description
 -----|------|---------|------------
 rowHeight | number | | Specifies the filter row's height.
 filterCellTemplate | (args: [FilterCellArgs](#filter-cell-args)) => ReactElement | | A component that renders a filter cell.
-filterRowTemplate | (args: [TableRowArgs](table.md#table-row-args)) => ReactElement | | A component that renders a filter row.
+filterRowTemplate | (args: [TableRowArgs](table-plugin.md#table-row-args)) => ReactElement | | A component that renders a filter row.
 messages | object | | The object specifies [localization messages](#localization-messages).
 
 ## Interfaces
@@ -25,7 +25,7 @@ messages | object | | The object specifies [localization messages](#localization
 
 Describes properties passed to the filter row cell template.
 
-A value with the [TableCellArgs](table.md#table-cell-args) shape extended by the following fields:
+A value with the [TableCellArgs](table-plugin.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -48,14 +48,14 @@ filterPlaceholder? | string | 'Filter...' | The filter editor placeholder text. 
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableHeaderRows | Getter | Array&lt;[TableRow](table.md#table-row)&gt; | Header rows to be rendered.
+tableHeaderRows | Getter | Array&lt;[TableRow](table-plugin.md#table-row)&gt; | Header rows to be rendered.
 filters | Getter | Array&lt;[Filter](filtering-state.md#filter)&gt; | Applied column filters.
 setColumnFilter | Action | ({ columnName: string, config: Object }) => void | Changes a column filter. Removes the filter if config is `null`.
-tableCell | Template | [TableCellArgs](table.md#table-cell-args) | A template that renders a table cell.
-tableRow | Template | [TableRowArgs](table.md#table-row-args) | A template that renders a table row.
+tableCell | Template | [TableCellArgs](table-plugin.md#table-cell-args) | A template that renders a table cell.
+tableRow | Template | [TableRowArgs](table-plugin.md#table-row-args) | A template that renders a table row.
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableHeaderRows | Getter | Array&lt;[TableRow](table.md#table-row)&gt; | Header rows with filters to be rendered.
+tableHeaderRows | Getter | Array&lt;[TableRow](table-plugin.md#table-row)&gt; | Header rows with filters to be rendered.

--- a/packages/dx-react-grid/docs/reference/table-group-row.md
+++ b/packages/dx-react-grid/docs/reference/table-group-row.md
@@ -7,7 +7,7 @@ A plugin that renders group rows. Enables expanding and collapsing them.
 ### Dependencies
 
 - [GroupingState](grouping-state.md)
-- [Table](table.md)
+- [TablePlugin](table-plugin.md)
 - [DataTypeProvider](data-type-provider.md) [Optional]
 
 ### Properties
@@ -35,7 +35,7 @@ title? | string | Specifies a table column title.
 
 Describes the properties passed to the template that renders a group row.
 
-A value with the [TableCellArgs](table.md#table-cell-args) shape extended by the following fields:
+A value with the [TableCellArgs](table-plugin.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -48,7 +48,7 @@ toggleGroupExpanded | () => void | Toggles the group row's expanded state.
 
 Describes the properties passed to the template that renders a group row.
 
-A value with the [TableRowArgs](table.md#table-row-args) shape extended by the following fields:
+A value with the [TableRowArgs](table-plugin.md#table-row-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -58,7 +58,7 @@ row | [GroupRow](#group-row) | The group row.
 
 Describes properties passed to the template that renders a group indent cell.
 
-A value with the [TableCellArgs](table.md#table-cell-args) shape extended by the following fields:
+A value with the [TableCellArgs](table-plugin.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -80,19 +80,19 @@ value | any | The current group value.
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Table columns.
-tableBodyRows | Getter | Array&lt;[TableRow](table.md#table-row)&gt; | Table body rows.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Table columns.
+tableBodyRows | Getter | Array&lt;[TableRow](table-plugin.md#table-row)&gt; | Table body rows.
 grouping | Getter | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | Columns used for grouping.
 draftGrouping | Getter | Array&lt;[DraftGrouping](grouping-state.md#draft-grouping)&gt; | Grouping options used for preview.
 expandedGroups | Getter | Set&lt;[GroupKey](grouping-state.md#group-key)&gt; | Expanded groups.
 isGroupRow | Getter | (row: any) => boolean | A function used to identify a group row within ordinary rows.
 toggleGroupExpanded | Action | ({ groupKey: [GroupKey](grouping-state.md#group-key) }) => void | Toggles the expanded group state.
-tableCell | Template | [TableCellArgs](table.md#table-cell-args) | A template that renders a table cell.
-tableRow | Template | [TableRowArgs](table.md#table-row-args) | A template that renders a table row.
+tableCell | Template | [TableCellArgs](table-plugin.md#table-cell-args) | A template that renders a table cell.
+tableRow | Template | [TableRowArgs](table-plugin.md#table-row-args) | A template that renders a table row.
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Table columns, including the ones by which the table is grouped.
-tableBodyRows | Getter | Array&lt;[TableRow](table.md#table-column)&gt; | Table body rows with modified group rows.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Table columns, including the ones by which the table is grouped.
+tableBodyRows | Getter | Array&lt;[TableRow](table-plugin.md#table-column)&gt; | Table body rows with modified group rows.

--- a/packages/dx-react-grid/docs/reference/table-header-row.md
+++ b/packages/dx-react-grid/docs/reference/table-header-row.md
@@ -11,7 +11,7 @@ The plugin also allows an end-user to manage a column's sorting and grouping sta
 - [SortingState](sorting-state.md) [Optional]
 - [GroupingState](grouping-state.md) [Optional]
 - [DragDropContext](drag-drop-context.md) [Optional]
-- [Table](table.md)
+- [TablePlugin](table-plugin.md)
 - [TableColumnResizing](table-column-resizing.md) [Optional]
 
 ### Properties
@@ -19,7 +19,7 @@ The plugin also allows an end-user to manage a column's sorting and grouping sta
 Name | Type | Default | Description
 -----|------|---------|------------
 headerCellTemplate | (args: [HeaderCellArgs](#header-cell-args)) => ReactElement | | A component that renders a header cell.
-headerRowTemplate | (args: [TableRowArgs](table.md#table-row-args)) => ReactElement | | A component that renders a header row.
+headerRowTemplate | (args: [TableRowArgs](table-plugin.md#table-row-args)) => ReactElement | | A component that renders a header row.
 allowSorting | boolean | false | If true, it allows an end-user to change sorting by a column. Requires the [SortingState](sorting-state.md) dependency.
 allowDragging | boolean | false | If true, it allows an end-user to drag a column by the header cell. Requires the [DragDropContext](drag-drop-context.md) dependency.
 allowGroupingByClick | boolean | false | If true, it renders a component that toggles a column's grouping state. Requires the [GroupingState](grouping-state.md) dependency.
@@ -40,7 +40,7 @@ title? | string | Specifies a table column's title.
 
 Describes properties used to render a table header cell.
 
-A value with the [TableCellArgs](table.md#table-cell-args) shape extended by the following fields:
+A value with the [TableCellArgs](table-plugin.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -70,7 +70,7 @@ sortingHint? | string | 'Sort' | Specifies the 'Sort' hint's text. Available in 
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableHeaderRows | Getter | Array&lt;[TableRow](table.md#table-row)&gt; | Header rows to be rendered.
+tableHeaderRows | Getter | Array&lt;[TableRow](table-plugin.md#table-row)&gt; | Header rows to be rendered.
 sorting | Getter | Array&lt;[Sorting](sorting-state.md#sorting)&gt; | Column sorting.
 columns | Getter | Array&lt;[Column](#column)&gt; | Table columns.
 grouping | Getter | Array&lt;[Grouping](grouping-state.md#grouping)&gt; | Columns used for grouping.
@@ -78,11 +78,11 @@ setColumnSorting | Action | ({ columnName: string, direction: 'asc' &#124; 'desc
 groupByColumn | Action | ({ columnName: string, groupIndex?: number }) => void | Groups a table by the specified column or cancels grouping. If `groupIndex` is omitted, the group is added to the end of the group list.
 changeTableColumnWidths | Action | ({ shifts: { [columnName: string]: number } }) => void | Changes column widths. Each shift is added to the original column width value.
 changeDraftTableColumnWidths | Action | ({ shifts: { [columnName: string]: number } }) => void | Changes draft column widths. Each shift is added to the original column width value. If a shift is `null`, the draft width for the column is cleared.
-tableCell | Template | [TableCellArgs](table.md#table-cell-args) | A template that renders a table cell.
-tableRow | Template | [TableRowArgs](table.md#table-row-args) | A template that renders a table row.
+tableCell | Template | [TableCellArgs](table-plugin.md#table-cell-args) | A template that renders a table cell.
+tableRow | Template | [TableRowArgs](table-plugin.md#table-row-args) | A template that renders a table row.
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableHeaderRows | Getter | Array&lt;[TableRow](table.md#table-row)&gt; | Table rows including header rows.
+tableHeaderRows | Getter | Array&lt;[TableRow](table-plugin.md#table-row)&gt; | Table rows including header rows.

--- a/packages/dx-react-grid/docs/reference/table-plugin.md
+++ b/packages/dx-react-grid/docs/reference/table-plugin.md
@@ -1,4 +1,4 @@
-# Table Plugin Reference
+# TablePlugin Reference
 
 This plugin renders Grid data as a table. It contains the Table Row and Table Cell components that can be extended by other plugins, and provides ways to customize table rows and columns.
 
@@ -46,7 +46,7 @@ cellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | The t
 
 ### <a name="table-row"></a>TableRow
 
-Describes properties of a table row the Table plugin renders.
+Describes properties of a table row the TablePlugin renders.
 
 A value with the following shape:
 
@@ -60,7 +60,7 @@ height? | number | Specifies the table row height.
 
 ### <a name="table-column"></a>TableColumn
 
-Describes table column properties that the Table plugin takes into account.
+Describes table column properties that the TablePlugin takes into account.
 
 A value with the following shape:
 

--- a/packages/dx-react-grid/docs/reference/table-plugin.md
+++ b/packages/dx-react-grid/docs/reference/table-plugin.md
@@ -46,7 +46,7 @@ cellTemplate | (args: [TableCellArgs](#table-cell-args)) => ReactElement | The t
 
 ### <a name="table-row"></a>TableRow
 
-Describes properties of a table row the TablePlugin renders.
+Describes properties of a table row TablePlugin renders.
 
 A value with the following shape:
 
@@ -60,7 +60,7 @@ height? | number | Specifies the table row height.
 
 ### <a name="table-column"></a>TableColumn
 
-Describes table column properties that the TablePlugin takes into account.
+Describes table column properties that TablePlugin takes into account.
 
 A value with the following shape:
 

--- a/packages/dx-react-grid/docs/reference/table-row-detail.md
+++ b/packages/dx-react-grid/docs/reference/table-row-detail.md
@@ -7,7 +7,7 @@ A plugin that renders a table detail row.
 ### Dependencies
 
 - [RowDetailState](row-detail-state.md)
-- [Table](table.md)
+- [TablePlugin](table-plugin.md)
 
 ### Properties
 
@@ -36,7 +36,7 @@ row | any | A row.
 
 Describes properties passed to the template that renders a detail cell for a row
 
-A value with the [TableCellArgs](table.md#table-cell-args) shape extended by the following fields:
+A value with the [TableCellArgs](table-plugin.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -47,7 +47,7 @@ template | () => ReactElement | A component that renders row details.
 
 Describes properties passed to the template that renders a detail row
 
-A value with the [TableRowArgs](table.md#table-row-args) shape extended by the following fields:
+A value with the [TableRowArgs](table-plugin.md#table-row-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -57,7 +57,7 @@ row | any | A row.
 
 Describes properties passed to the template that renders the detail toggle control
 
-A value with the [TableCellArgs](table.md#table-cell-args) shape extended by the following fields:
+A value with the [TableCellArgs](table-plugin.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -71,16 +71,16 @@ toggleExpanded | () => void | Toggles a row's expanded state.
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Table columns.
-tableBodyRows | Getter | Array&lt;[TableRow](table.md#table-row)&gt; | Body rows to be rendered.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Table columns.
+tableBodyRows | Getter | Array&lt;[TableRow](table-plugin.md#table-row)&gt; | Body rows to be rendered.
 expandedRows | Getter | Array&lt;number &#124; string&gt; | Expanded rows.
 setDetailRowExpanded | Action | ({ rowId }) => void | Expands the specified row.
-tableCell | Template | [TableCellArgs](table.md#table-cell-args) | A template that renders a table cell.
-tableRow | Template | [TableRowArgs](table.md#table-row-args) | A template that renders a table row.
+tableCell | Template | [TableCellArgs](table-plugin.md#table-cell-args) | A template that renders a table cell.
+tableRow | Template | [TableRowArgs](table-plugin.md#table-row-args) | A template that renders a table row.
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Table columns including the detail cell.
-tableBodyRows | Getter | Array&lt;[TableRow](table.md#table-row)&gt; | Body rows to be rendered, including detailed rows.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Table columns including the detail cell.
+tableBodyRows | Getter | Array&lt;[TableRow](table-plugin.md#table-row)&gt; | Body rows to be rendered, including detailed rows.

--- a/packages/dx-react-grid/docs/reference/table-selection.md
+++ b/packages/dx-react-grid/docs/reference/table-selection.md
@@ -7,7 +7,7 @@ This plugin visualizes the selection state within a table by rendering selection
 ### Dependencies
 
 - [SelectionState](selection-state.md)
-- [Table](table.md)
+- [TablePlugin](table-plugin.md)
 
 ### Properties
 
@@ -25,7 +25,7 @@ selectionColumnWidth | number | | The selection column's width.
 
 ### <a name="table-row"></a>TableRow (Extension)
 
-A value with the [TableRow](table.md#table-row) shape extended by the following fields:
+A value with the [TableRow](table-plugin.md#table-row) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -35,7 +35,7 @@ selected? | boolean | Specifies if a row is selected.
 
 Describes properties passed to the template that renders a cell with selection control.
 
-A value with the [TableCellArgs](table.md#table-cell-args) shape extended by the following fields:
+A value with the [TableCellArgs](table-plugin.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -48,7 +48,7 @@ toggleAll | () => void | Selects or deselects all rows.
 
 Describes properties passed to a template that renders a cell with the selection control inside the heading row.
 
-A value with the [TableCellArgs](table.md#table-cell-args) shape extended by the following fields:
+A value with the [TableCellArgs](table-plugin.md#table-cell-args) shape extended by the following fields:
 
 Field | Type | Description
 ------|------|------------
@@ -62,17 +62,17 @@ changeSelected | () => void | Selects or deselects a row.
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Table columns.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Table columns.
 tableBodyRows | Getter | Array&lt;[TableRow](#table-row)&gt; | Body rows to be rendered.
 selection | Getter | Array&lt;number &#124; string&gt; | Selected rows.
 availableToSelect | Getter | Array&lt;number &#124; string&gt; | Rows to be rendered, which are available for selection.
 setRowsSelection | Action | ({ rowIds: Array&lt;number &#124; string&gt;, selected?: boolean }) => void | Selects/deselects rows. The `selected` argument specifies whether the rows should be selected (true), deselected (false), or their selection status should be set to the opposite value (undefined). In the last case, the function selects unselected rows and deselects selected ones. To select/deselect a single row, pass an array with a single item to the `rowIds` argument.
-tableCell | Template | [TableCellArgs](table.md#table-cell-args) | A template that renders a table cell.
-tableRow | Template | [TableRowArgs](table.md#table-row-args) | A template that renders a table row.
+tableCell | Template | [TableCellArgs](table-plugin.md#table-cell-args) | A template that renders a table cell.
+tableRow | Template | [TableRowArgs](table-plugin.md#table-row-args) | A template that renders a table row.
 
 ### Exports
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-tableColumns | Getter | Array&lt;[TableColumn](table.md#table-column)&gt; | Table columns including the selection column.
+tableColumns | Getter | Array&lt;[TableColumn](table-plugin.md#table-column)&gt; | Table columns including the selection column.
 tableBodyRows | Getter | Array&lt;[TableRow](#table-row)&gt; | Body rows to be rendered including the selected ones.

--- a/packages/dx-react-grid/docs/reference/virtual-table.md
+++ b/packages/dx-react-grid/docs/reference/virtual-table.md
@@ -1,12 +1,12 @@
 # VirtualTable Plugin Reference
 
-The plugin extends the [Table](table.md) plugin. It renders a scrollable table instead of a static one.
+The plugin extends the [TablePlugin](table-plugin.md) plugin. It renders a scrollable table instead of a static one.
 
 ## User Reference
 
 ### Dependencies
 
-Same as the [Table](table.md#dependencies)'s.
+Same as the [TablePlugin](table-plugin.md#dependencies)'s.
 
 ### Properties
 
@@ -15,14 +15,14 @@ Name | Type | Default | Description
 height | number | 530 | The virtual table's height.
 estimatedRowHeight | number | `37` for [Bootstrap3](https://www.npmjs.com/package/@devexpress/dx-react-grid-bootstrap3); `48` for [Material UI](https://www.npmjs.com/package/@devexpress/dx-react-grid-material-ui) | An estimated value of the row height. For a table whose rows have a variable height, specify an average value. The more accurately you estimate the row height, the better the virtual table performs.
 
-This plugin also supports the [Table](table.md#properties) plugin's properties.
+This plugin also supports the [TablePlugin](table-plugin.md#properties) plugin's properties.
 
 ## Plugin Developer Reference
 
 ### Imports
 
-Same as the [Table](table.md#imports)'s.
+Same as the [TablePlugin](table-plugin.md#imports)'s.
 
 ### Exports
 
-Same as the [Table](table.md#exports)'s.
+Same as the [TablePlugin](table-plugin.md#exports)'s.

--- a/packages/dx-react-grid/src/components/table-layout/virtual-table-layout.test.jsx
+++ b/packages/dx-react-grid/src/components/table-layout/virtual-table-layout.test.jsx
@@ -52,7 +52,7 @@ const defaultProps = {
   ],
   containerTemplate: props => <div {...props} />,
   headTableTemplate: () => null,
-  tableTemplate: props => <TablePlugin {...props} />,
+  tableTemplate: props => <table {...props} />,
   headTemplate: () => null,
   bodyTemplate: props => <tbody {...props} />,
   rowTemplate: () => null,

--- a/packages/dx-react-grid/src/components/table-layout/virtual-table-layout.test.jsx
+++ b/packages/dx-react-grid/src/components/table-layout/virtual-table-layout.test.jsx
@@ -52,7 +52,7 @@ const defaultProps = {
   ],
   containerTemplate: props => <div {...props} />,
   headTableTemplate: () => null,
-  tableTemplate: props => <table {...props} />,
+  tableTemplate: props => <TablePlugin {...props} />,
   headTemplate: () => null,
   bodyTemplate: props => <tbody {...props} />,
   rowTemplate: () => null,

--- a/packages/dx-react-grid/src/index.js
+++ b/packages/dx-react-grid/src/index.js
@@ -22,7 +22,7 @@ export { DragDropContext } from './plugins/drag-drop-context';
 
 export { TableColumnReordering } from './plugins/table-column-reordering';
 
-export { Table } from './plugins/table';
+export { TablePlugin } from './plugins/table';
 export { TableSelection } from './plugins/table-selection';
 
 export { RowDetailState } from './plugins/row-detail-state';

--- a/packages/dx-react-grid/src/plugins/table.jsx
+++ b/packages/dx-react-grid/src/plugins/table.jsx
@@ -60,7 +60,7 @@ const cellTemplate = params =>
 const rowTemplate = params =>
   <TemplatePlaceholder name="tableRow" params={params} />;
 
-export class Table extends React.PureComponent {
+export class TablePlugin extends React.PureComponent {
   render() {
     const {
       tableLayoutTemplate,
@@ -194,7 +194,7 @@ export class Table extends React.PureComponent {
   }
 }
 
-Table.propTypes = {
+TablePlugin.propTypes = {
   tableLayoutTemplate: PropTypes.func.isRequired,
   tableCellTemplate: PropTypes.func.isRequired,
   tableRowTemplate: PropTypes.func.isRequired,
@@ -205,6 +205,6 @@ Table.propTypes = {
   messages: PropTypes.object,
 };
 
-Table.defaultProps = {
+TablePlugin.defaultProps = {
   messages: {},
 };

--- a/packages/dx-react-grid/src/plugins/table.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table.test.jsx
@@ -11,7 +11,7 @@ import {
   isDataTableRow,
   getMessagesFormatter,
 } from '@devexpress/dx-grid-core';
-import { Table } from './table';
+import { TablePlugin } from './table';
 import { DataTypeProvider } from './data-type-provider';
 import { pluginDepsToComponents, getComputedState } from './test-utils';
 
@@ -47,7 +47,7 @@ const defaultProps = {
   tableNoDataRowTemplate: () => null,
 };
 
-describe('Table', () => {
+describe('TablePlugin', () => {
   let resetConsole;
   beforeAll(() => {
     resetConsole = setupConsole({ ignore: ['validateDOMNesting'] });
@@ -74,7 +74,7 @@ describe('Table', () => {
       const tree = mount((
         <PluginHost>
           {pluginDepsToComponents(defaultDeps)}
-          <Table
+          <TablePlugin
             {...defaultProps}
           />
         </PluginHost>
@@ -90,7 +90,7 @@ describe('Table', () => {
       const tree = mount((
         <PluginHost>
           {pluginDepsToComponents(defaultDeps)}
-          <Table
+          <TablePlugin
             {...defaultProps}
           />
         </PluginHost>
@@ -116,7 +116,7 @@ describe('Table', () => {
     mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <Table
+        <TablePlugin
           {...defaultProps}
           tableLayoutTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableCellTemplate={tableCellTemplate}
@@ -152,7 +152,7 @@ describe('Table', () => {
           formatterTemplate={valueFormatter}
         />
         {pluginDepsToComponents(defaultDeps)}
-        <Table
+        <TablePlugin
           {...defaultProps}
           tableLayoutTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableCellTemplate={tableCellTemplate}
@@ -177,7 +177,7 @@ describe('Table', () => {
     mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <Table
+        <TablePlugin
           {...defaultProps}
           tableLayoutTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableStubCellTemplate={tableStubCellTemplate}
@@ -197,7 +197,7 @@ describe('Table', () => {
     const tree = mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <Table
+        <TablePlugin
           {...defaultProps}
           tableLayoutTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
           tableStubHeaderCellTemplate={tableStubHeaderCellTemplate}
@@ -221,7 +221,7 @@ describe('Table', () => {
     mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <Table
+        <TablePlugin
           {...defaultProps}
           messages={{ noData: 'No data' }}
           tableLayoutTemplate={({ cellTemplate }) => cellTemplate(tableCellArgs)}
@@ -251,7 +251,7 @@ describe('Table', () => {
     mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <Table
+        <TablePlugin
           {...defaultProps}
           tableLayoutTemplate={({ rowTemplate }) => rowTemplate(tableRowArgs)}
           tableRowTemplate={tableRowTemplate}
@@ -278,7 +278,7 @@ describe('Table', () => {
     mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <Table
+        <TablePlugin
           {...defaultProps}
           tableLayoutTemplate={({ rowTemplate }) => rowTemplate(tableRowArgs)}
           tableNoDataRowTemplate={tableNoDataRowTemplate}

--- a/site/_data/docs/navigation.yml
+++ b/site/_data/docs/navigation.yml
@@ -70,8 +70,8 @@ react:
           path: /react/grid/docs/reference/custom-grouping
         - title: LocalPaging
           path: /react/grid/docs/reference/local-paging
-        - title: Table
-          path: /react/grid/docs/reference/table
+        - title: TablePlugin
+          path: /react/grid/docs/reference/table-plugin
         - title: VirtualTable
           path: /react/grid/docs/reference/virtual-table
         - title: TableHeaderRow


### PR DESCRIPTION
BREAKING CHANGE

The `Table` plugin has been renamed to `TablePlugin` within the task of making all plugin names consistent.