### PR TITLE
Correct grid reference url

### DIFF
--- a/packages/dx-react-grid/docs/guides/data-types.md
+++ b/packages/dx-react-grid/docs/guides/data-types.md
@@ -20,7 +20,7 @@ const rows = [
 ];
 const columns = [
   { name: 'product', title: 'Product' },
-  { name: 'price', title: 'Sale Price', dataType: 'currency' },
+  { name: 'amount', title: 'Sale Amount', dataType: 'currency' },
 ];
 <Grid
   rows={rows}

--- a/packages/dx-react-grid/docs/guides/data-types.md
+++ b/packages/dx-react-grid/docs/guides/data-types.md
@@ -58,7 +58,7 @@ const columns = [
         value={value}
         onChange={e => onValueChange(e.target.value === 'true')}
       >
-        <option value={false}>No</options>
+        <option value={false}>No</option>
         <option value>Yes</option>
       </select>
     )}

--- a/packages/dx-react-grid/docs/guides/data-types.md
+++ b/packages/dx-react-grid/docs/guides/data-types.md
@@ -20,7 +20,7 @@ const rows = [
 ];
 const columns = [
   { name: 'product', title: 'Product' },
-  { name: 'amount', title: 'Sale Amount', dataType: 'currency' },
+  { name: 'price', title: 'Sale Price', dataType: 'currency' },
 ];
 <Grid
   rows={rows}

--- a/packages/dx-react-grid/docs/guides/data-types.md
+++ b/packages/dx-react-grid/docs/guides/data-types.md
@@ -16,7 +16,7 @@ Assign a function rendering the formatted value to the `DataTypeProvider` plugin
 
 ```js
 const rows = [
-  { product: 'SolarOne', price: '3039' },
+  { product: 'SolarOne', amount: '3039' },
 ];
 const columns = [
   { name: 'product', title: 'Product' },

--- a/packages/dx-react-grid/docs/guides/plugin-overview.md
+++ b/packages/dx-react-grid/docs/guides/plugin-overview.md
@@ -9,7 +9,7 @@ The plugins that provide all the Grid's functionality can be divided into four g
 
 Note that the plugins are composable and can be nested into each other.
 
-Refer to the [Reference](../../reference/grid.md) to see the complete plugin list.
+Refer to the [Reference](../reference/grid.md) to see the complete plugin list.
 
 ## <a name="plugin-order">Plugin Order
 

--- a/packages/dx-react-grid/docs/guides/plugin-overview.md
+++ b/packages/dx-react-grid/docs/guides/plugin-overview.md
@@ -9,7 +9,7 @@ The plugins that provide all the Grid's functionality can be divided into four g
 
 Note that the plugins are composable and can be nested into each other.
 
-Refer to the [Reference](../../reference/grid) to see the complete plugin list.
+Refer to the [Reference](../../reference/grid.md) to see the complete plugin list.
 
 ## <a name="plugin-order">Plugin Order
 


### PR DESCRIPTION
if add .md extension, in the document will get 404 page not found.