### PR TITLE
refactor(react-grid): rename some group and paging properties

### DIFF
--- a/packages/dx-react-demos/src/bootstrap3/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-controlled-mode/demo.jsx
@@ -179,7 +179,7 @@ export default class Demo extends React.PureComponent {
       currentPage: 0,
       deletingRows: [],
       pageSize: 0,
-      allowedPageSizes: [5, 10, 0],
+      pageSizes: [5, 10, 0],
       columnOrder: ['product', 'region', 'amount', 'discount', 'saleDate', 'customer'],
     };
 
@@ -241,7 +241,7 @@ export default class Demo extends React.PureComponent {
       currentPage,
       deletingRows,
       pageSize,
-      allowedPageSizes,
+      pageSizes,
       columnOrder,
     } = this.state;
 
@@ -299,7 +299,7 @@ export default class Demo extends React.PureComponent {
             commandComponent={Command}
           />
           <PagingPanel
-            allowedPageSizes={allowedPageSizes}
+            pageSizes={pageSizes}
           />
         </Grid>
 

--- a/packages/dx-react-demos/src/bootstrap3/featured-redux-integration/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-redux-integration/demo.jsx
@@ -65,7 +65,7 @@ const GridContainer = ({
   onCurrentPageChange,
   pageSize,
   onPageSizeChange,
-  allowedPageSizes,
+  pageSizes,
   columnOrder,
   onColumnOrderChange,
   columnWidths,
@@ -133,7 +133,7 @@ const GridContainer = ({
     <GroupingPanel allowSorting allowDragging />
     <TableGroupRow />
     <PagingPanel
-      allowedPageSizes={allowedPageSizes}
+      pageSizes={pageSizes}
     />
 
   </Grid>
@@ -158,7 +158,7 @@ GridContainer.propTypes = {
   onCurrentPageChange: PropTypes.func.isRequired,
   pageSize: PropTypes.number.isRequired,
   onPageSizeChange: PropTypes.func.isRequired,
-  allowedPageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
+  pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
   columnOrder: PropTypes.array.isRequired,
   onColumnOrderChange: PropTypes.func.isRequired,
   columnWidths: PropTypes.objectOf(PropTypes.number).isRequired,
@@ -202,7 +202,7 @@ const gridInitialState = {
   filters: [],
   currentPage: 0,
   pageSize: 10,
-  allowedPageSizes: [5, 10, 15],
+  pageSizes: [5, 10, 15],
   columnOrder: ['prefix', 'firstName', 'lastName', 'position', 'state', 'birthDate'],
   columnWidths: {
     prefix: 75,

--- a/packages/dx-react-demos/src/bootstrap3/featured-remote-data/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-remote-data/demo.jsx
@@ -52,7 +52,7 @@ export default class Demo extends React.PureComponent {
       sorting: [{ columnName: 'StoreCity', direction: 'asc' }],
       totalCount: 0,
       pageSize: 10,
-      allowedPageSizes: [5, 10, 15],
+      pageSizes: [5, 10, 15],
       currentPage: 0,
       loading: true,
     };
@@ -125,7 +125,7 @@ export default class Demo extends React.PureComponent {
       columns,
       sorting,
       pageSize,
-      allowedPageSizes,
+      pageSizes,
       currentPage,
       totalCount,
       loading,
@@ -153,7 +153,7 @@ export default class Demo extends React.PureComponent {
           />
           <TableHeaderRow allowSorting />
           <PagingPanel
-            allowedPageSizes={allowedPageSizes}
+            pageSizes={pageSizes}
           />
         </Grid>
         {loading && <Loading />}

--- a/packages/dx-react-demos/src/bootstrap3/featured-theming/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-theming/demo.jsx
@@ -149,11 +149,11 @@ export default class Demo extends React.PureComponent {
         },
         length: 40,
       }),
-      allowedPageSizes: [5, 10, 15],
+      pageSizes: [5, 10, 15],
     };
   }
   render() {
-    const { rows, columns, allowedPageSizes } = this.state;
+    const { rows, columns, pageSizes } = this.state;
 
     return (
       <Grid
@@ -186,7 +186,7 @@ export default class Demo extends React.PureComponent {
 
         <TableHeaderRow allowSorting allowDragging />
         <PagingPanel
-          allowedPageSizes={allowedPageSizes}
+          pageSizes={pageSizes}
         />
         <TableSelection showSelectAll />
         <TableRowDetail

--- a/packages/dx-react-demos/src/bootstrap3/featured-uncontrolled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-uncontrolled-mode/demo.jsx
@@ -48,11 +48,11 @@ export default class Demo extends React.PureComponent {
         { name: 'customer', title: 'Customer' },
       ],
       rows: generateRows({ columnValues: globalSalesValues, length: 1000 }),
-      allowedPageSizes: [5, 10, 15],
+      pageSizes: [5, 10, 15],
     };
   }
   render() {
-    const { rows, columns, allowedPageSizes } = this.state;
+    const { rows, columns, pageSizes } = this.state;
 
     return (
       <Grid
@@ -97,7 +97,7 @@ export default class Demo extends React.PureComponent {
         <TableHeaderRow allowSorting allowDragging />
         <TableFilterRow />
         <PagingPanel
-          allowedPageSizes={allowedPageSizes}
+          pageSizes={pageSizes}
         />
         <TableSelection showSelectAll />
         <GroupingPanel allowSorting allowDragging />

--- a/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-controlled.jsx
@@ -50,7 +50,7 @@ export default class Demo extends React.PureComponent {
         <Table />
         <TableHeaderRow allowDragging showGroupingControls />
         <TableGroupRow />
-        <GroupingPanel allowDragging allowUngroupingByClick />
+        <GroupingPanel allowDragging showGroupingControls />
       </Grid>
     );
   }

--- a/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/grouping/local-grouping-controlled.jsx
@@ -48,7 +48,7 @@ export default class Demo extends React.PureComponent {
         />
         <LocalGrouping />
         <Table />
-        <TableHeaderRow allowDragging allowGroupingByClick />
+        <TableHeaderRow allowDragging showGroupingControls />
         <TableGroupRow />
         <GroupingPanel allowDragging allowUngroupingByClick />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/localization/basic.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/localization/basic.jsx
@@ -105,7 +105,7 @@ export default class Demo extends React.PureComponent {
         />
         <TableGroupRow />
         <PagingPanel
-          allowedPageSizes={[5, 10, 15, 0]}
+          pageSizes={[5, 10, 15, 0]}
           messages={pagingPanelMessages}
         />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/localization/basic.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/localization/basic.jsx
@@ -99,7 +99,7 @@ export default class Demo extends React.PureComponent {
 
         <TableFilterRow />
         <GroupingPanel
-          allowUngroupingByClick
+          showGroupingControls
           allowDragging
           messages={groupingPanelMessages}
         />

--- a/packages/dx-react-demos/src/bootstrap3/paging/local-paging-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/paging/local-paging-controlled.jsx
@@ -28,7 +28,7 @@ export default class Demo extends React.PureComponent {
       rows: generateRows({ length: 14 }),
       currentPage: 0,
       pageSize: 5,
-      allowedPageSizes: [5, 10, 15],
+      pageSizes: [5, 10, 15],
     };
 
     this.changeCurrentPage = currentPage => this.setState({ currentPage });
@@ -36,7 +36,7 @@ export default class Demo extends React.PureComponent {
   }
   render() {
     const {
-      rows, columns, pageSize, allowedPageSizes,
+      rows, columns, pageSize, pageSizes,
     } = this.state;
 
     return (
@@ -54,7 +54,7 @@ export default class Demo extends React.PureComponent {
         <Table />
         <TableHeaderRow />
         <PagingPanel
-          allowedPageSizes={allowedPageSizes}
+          pageSizes={pageSizes}
         />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/paging/page-size-selector.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/paging/page-size-selector.jsx
@@ -24,12 +24,12 @@ export default class Demo extends React.PureComponent {
         { name: 'car', title: 'Car' },
       ],
       rows: generateRows({ length: 60 }),
-      allowedPageSizes: [5, 10, 15, 0],
+      pageSizes: [5, 10, 15, 0],
     };
   }
 
   render() {
-    const { rows, columns, allowedPageSizes } = this.state;
+    const { rows, columns, pageSizes } = this.state;
 
     return (
       <Grid
@@ -44,7 +44,7 @@ export default class Demo extends React.PureComponent {
         <Table />
         <TableHeaderRow />
         <PagingPanel
-          allowedPageSizes={allowedPageSizes}
+          pageSizes={pageSizes}
         />
       </Grid>
     );

--- a/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
@@ -219,7 +219,7 @@ class DemoBase extends React.PureComponent {
       currentPage: 0,
       deletingRows: [],
       pageSize: 0,
-      allowedPageSizes: [5, 10, 0],
+      pageSizes: [5, 10, 0],
       columnOrder: ['product', 'region', 'amount', 'discount', 'saleDate', 'customer'],
     };
 
@@ -284,7 +284,7 @@ class DemoBase extends React.PureComponent {
       currentPage,
       deletingRows,
       pageSize,
-      allowedPageSizes,
+      pageSizes,
       columnOrder,
     } = this.state;
 
@@ -342,7 +342,7 @@ class DemoBase extends React.PureComponent {
             commandComponent={Command}
           />
           <PagingPanel
-            allowedPageSizes={allowedPageSizes}
+            pageSizes={pageSizes}
           />
         </Grid>
 

--- a/packages/dx-react-demos/src/material-ui/featured-redux-integration/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-redux-integration/demo.jsx
@@ -78,7 +78,7 @@ const GridContainer = ({
   onCurrentPageChange,
   pageSize,
   onPageSizeChange,
-  allowedPageSizes,
+  pageSizes,
   columnOrder,
   onColumnOrderChange,
   columnWidths,
@@ -147,7 +147,7 @@ const GridContainer = ({
       <TableGroupRow />
       <GroupingPanel allowSorting allowDragging />
       <PagingPanel
-        allowedPageSizes={allowedPageSizes}
+        pageSizes={pageSizes}
       />
     </Grid>
   </Paper>
@@ -172,7 +172,7 @@ GridContainer.propTypes = {
   onCurrentPageChange: PropTypes.func.isRequired,
   pageSize: PropTypes.number.isRequired,
   onPageSizeChange: PropTypes.func.isRequired,
-  allowedPageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
+  pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
   columnOrder: PropTypes.array.isRequired,
   onColumnOrderChange: PropTypes.func.isRequired,
   columnWidths: PropTypes.objectOf(PropTypes.number).isRequired,
@@ -216,7 +216,7 @@ const gridInitialState = {
   filters: [],
   currentPage: 0,
   pageSize: 10,
-  allowedPageSizes: [5, 10, 15],
+  pageSizes: [5, 10, 15],
   columnOrder: ['prefix', 'firstName', 'lastName', 'position', 'state', 'birthDate'],
   columnWidths: {
     prefix: 75,

--- a/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
@@ -62,7 +62,7 @@ export default class Demo extends React.PureComponent {
       sorting: [{ columnName: 'StoreCity', direction: 'asc' }],
       totalCount: 0,
       pageSize: 10,
-      allowedPageSizes: [5, 10, 15],
+      pageSizes: [5, 10, 15],
       currentPage: 0,
       loading: true,
     };
@@ -135,7 +135,7 @@ export default class Demo extends React.PureComponent {
       columns,
       sorting,
       pageSize,
-      allowedPageSizes,
+      pageSizes,
       currentPage,
       totalCount,
       loading,
@@ -163,7 +163,7 @@ export default class Demo extends React.PureComponent {
           />
           <TableHeaderRow allowSorting />
           <PagingPanel
-            allowedPageSizes={allowedPageSizes}
+            pageSizes={pageSizes}
           />
         </Grid>
         {loading && <Loading />}

--- a/packages/dx-react-demos/src/material-ui/featured-theming/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-theming/demo.jsx
@@ -175,11 +175,11 @@ export default class Demo extends React.PureComponent {
         },
         length: 40,
       }),
-      allowedPageSizes: [5, 10, 15],
+      pageSizes: [5, 10, 15],
     };
   }
   render() {
-    const { rows, columns, allowedPageSizes } = this.state;
+    const { rows, columns, pageSizes } = this.state;
 
     return (
       <Paper>
@@ -213,7 +213,7 @@ export default class Demo extends React.PureComponent {
 
           <TableHeaderRow allowSorting allowDragging />
           <PagingPanel
-            allowedPageSizes={allowedPageSizes}
+            pageSizes={pageSizes}
           />
           <TableSelection showSelectAll />
           <TableRowDetail

--- a/packages/dx-react-demos/src/material-ui/featured-uncontrolled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-uncontrolled-mode/demo.jsx
@@ -50,11 +50,11 @@ export default class Demo extends React.PureComponent {
         { name: 'customer', title: 'Customer' },
       ],
       rows: generateRows({ columnValues: globalSalesValues, length: 1000 }),
-      allowedPageSizes: [5, 10, 15],
+      pageSizes: [5, 10, 15],
     };
   }
   render() {
-    const { rows, columns, allowedPageSizes } = this.state;
+    const { rows, columns, pageSizes } = this.state;
 
     return (
       <Paper>
@@ -102,7 +102,7 @@ export default class Demo extends React.PureComponent {
           <TableHeaderRow allowSorting allowDragging />
           <TableFilterRow />
           <PagingPanel
-            allowedPageSizes={allowedPageSizes}
+            pageSizes={pageSizes}
           />
 
           <TableGroupRow />

--- a/packages/dx-react-demos/src/material-ui/grouping/local-grouping-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/local-grouping-controlled.jsx
@@ -51,7 +51,7 @@ export default class Demo extends React.PureComponent {
           <Table />
           <TableHeaderRow allowDragging showGroupingControls />
           <TableGroupRow />
-          <GroupingPanel allowDragging allowUngroupingByClick />
+          <GroupingPanel allowDragging showGroupingControls />
         </Grid>
       </Paper>
     );

--- a/packages/dx-react-demos/src/material-ui/grouping/local-grouping-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/local-grouping-controlled.jsx
@@ -49,7 +49,7 @@ export default class Demo extends React.PureComponent {
           />
           <LocalGrouping />
           <Table />
-          <TableHeaderRow allowDragging allowGroupingByClick />
+          <TableHeaderRow allowDragging showGroupingControls />
           <TableGroupRow />
           <GroupingPanel allowDragging allowUngroupingByClick />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/localization/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/localization/basic.jsx
@@ -106,7 +106,7 @@ export default class Demo extends React.PureComponent {
             messages={filterRowMessages}
           />
           <GroupingPanel
-            allowUngroupingByClick
+            showGroupingControls
             allowDragging
             messages={groupingPanelMessages}
           />

--- a/packages/dx-react-demos/src/material-ui/localization/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/localization/basic.jsx
@@ -113,7 +113,7 @@ export default class Demo extends React.PureComponent {
 
           <TableGroupRow />
           <PagingPanel
-            allowedPageSizes={[5, 10, 15, 0]}
+            pageSizes={[5, 10, 15, 0]}
             messages={pagingPanelMessages}
           />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/paging/local-paging-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/paging/local-paging-controlled.jsx
@@ -28,7 +28,7 @@ export default class Demo extends React.PureComponent {
       rows: generateRows({ length: 14 }),
       currentPage: 0,
       pageSize: 5,
-      allowedPageSizes: [5, 10, 15],
+      pageSizes: [5, 10, 15],
     };
 
     this.changeCurrentPage = currentPage => this.setState({ currentPage });
@@ -36,7 +36,7 @@ export default class Demo extends React.PureComponent {
   }
   render() {
     const {
-      rows, columns, pageSize, allowedPageSizes,
+      rows, columns, pageSize, pageSizes,
     } = this.state;
 
     return (
@@ -55,7 +55,7 @@ export default class Demo extends React.PureComponent {
           <Table />
           <TableHeaderRow />
           <PagingPanel
-            allowedPageSizes={allowedPageSizes}
+            pageSizes={pageSizes}
           />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/paging/page-size-selector.jsx
+++ b/packages/dx-react-demos/src/material-ui/paging/page-size-selector.jsx
@@ -24,12 +24,12 @@ export default class Demo extends React.PureComponent {
         { name: 'car', title: 'Car' },
       ],
       rows: generateRows({ length: 60 }),
-      allowedPageSizes: [5, 10, 15, 0],
+      pageSizes: [5, 10, 15, 0],
     };
   }
 
   render() {
-    const { rows, columns, allowedPageSizes } = this.state;
+    const { rows, columns, pageSizes } = this.state;
 
     return (
       <Paper>
@@ -45,7 +45,7 @@ export default class Demo extends React.PureComponent {
           <Table />
           <TableHeaderRow />
           <PagingPanel
-            allowedPageSizes={allowedPageSizes}
+            pageSizes={pageSizes}
           />
         </Grid>
       </Paper>

--- a/packages/dx-react-grid-bootstrap3/src/templates/group-panel-item.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/group-panel-item.jsx
@@ -10,7 +10,7 @@ const isActionKey = keyCode => keyCode === ENTER_KEY_CODE || keyCode === SPACE_K
 
 export const GroupPanelItem = ({
   item: { column, draft },
-  onGroup, allowUngroupingByClick,
+  onGroup, showGroupingControls,
   allowSorting, sortingDirection, onSort, className,
   ...restProps
 }) => {
@@ -65,7 +65,7 @@ export const GroupPanelItem = ({
         )}
       </span>
 
-      {allowUngroupingByClick && (
+      {showGroupingControls && (
         <span
           className="btn btn-default"
           onClick={handleUngroup}
@@ -96,7 +96,7 @@ GroupPanelItem.propTypes = {
   className: PropTypes.string,
   onSort: PropTypes.func,
   onGroup: PropTypes.func,
-  allowUngroupingByClick: PropTypes.bool,
+  showGroupingControls: PropTypes.bool,
 };
 
 GroupPanelItem.defaultProps = {
@@ -105,5 +105,5 @@ GroupPanelItem.defaultProps = {
   className: undefined,
   onSort: undefined,
   onGroup: undefined,
-  allowUngroupingByClick: false,
+  showGroupingControls: false,
 };

--- a/packages/dx-react-grid-bootstrap3/src/templates/group-panel-item.test.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/group-panel-item.test.jsx
@@ -21,7 +21,7 @@ describe('GroupPanelItem', () => {
     const tree = shallow((
       <GroupPanelItem
         item={{ column: { name: 'test' } }}
-        allowUngroupingByClick
+        showGroupingControls
       />
     ));
 
@@ -77,7 +77,7 @@ describe('GroupPanelItem', () => {
     const tree = mount((
       <GroupPanelItem
         onGroup={onGroup}
-        allowUngroupingByClick
+        showGroupingControls
         item={{ column: { name: 'test' } }}
       />
     ));

--- a/packages/dx-react-grid-bootstrap3/src/templates/page-size-selector.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/page-size-selector.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 export const PageSizeSelector = ({
   pageSize,
   onPageSizeChange,
-  allowedPageSizes,
+  pageSizes,
   getMessage,
 }) => {
   const showAll = getMessage('showAll');
@@ -16,7 +16,7 @@ export const PageSizeSelector = ({
         value={pageSize}
         onChange={e => onPageSizeChange(parseInt(e.target.value, 10))}
       >
-        {allowedPageSizes.map(val => (
+        {pageSizes.map(val => (
           <option key={val} value={val}>
             {val || showAll}
           </option>
@@ -29,7 +29,7 @@ export const PageSizeSelector = ({
           verticalAlign: 'bottom',
         }}
       >
-        {allowedPageSizes.map(item => (
+        {pageSizes.map(item => (
           <li key={item} className={item === pageSize ? 'active' : ''}>
             <a
               href="#"
@@ -50,7 +50,7 @@ export const PageSizeSelector = ({
 PageSizeSelector.propTypes = {
   pageSize: PropTypes.number.isRequired,
   onPageSizeChange: PropTypes.func.isRequired,
-  allowedPageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
+  pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
   getMessage: PropTypes.func.isRequired,
 };
 

--- a/packages/dx-react-grid-bootstrap3/src/templates/page-size-selector.test.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/page-size-selector.test.jsx
@@ -6,12 +6,12 @@ describe('PageSizeSelector', () => {
   describe('#render', () => {
     const mountPageSizeSelector = ({
       pageSize,
-      allowedPageSizes,
+      pageSizes,
       getMessage = key => key,
       onPageSizeChange = () => {},
     }) => mount(<PageSizeSelector
       pageSize={pageSize}
-      allowedPageSizes={allowedPageSizes}
+      pageSizes={pageSizes}
       getMessage={getMessage}
       onPageSizeChange={onPageSizeChange}
     />);
@@ -19,7 +19,7 @@ describe('PageSizeSelector', () => {
     it('can show info about page sizes', () => {
       const tree = mountPageSizeSelector({
         pageSize: 10,
-        allowedPageSizes: [5, 10],
+        pageSizes: [5, 10],
       });
 
       const mobileSelector = tree.find('select');
@@ -46,7 +46,7 @@ describe('PageSizeSelector', () => {
     it('can render the "All" item', () => {
       const tree = mountPageSizeSelector({
         pageSize: 10,
-        allowedPageSizes: [5, 10, 0],
+        pageSizes: [5, 10, 0],
       });
 
       const mobileSelector = tree.find('select');
@@ -66,7 +66,7 @@ describe('PageSizeSelector', () => {
       const onPageSizeChange = jest.fn();
       const tree = mountPageSizeSelector({
         pageSize: 5,
-        allowedPageSizes: [5, 10],
+        pageSizes: [5, 10],
         onPageSizeChange,
       });
 

--- a/packages/dx-react-grid-bootstrap3/src/templates/pager.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/pager.jsx
@@ -11,7 +11,7 @@ export const Pager = ({
   totalPages,
   pageSize,
   onPageSizeChange,
-  allowedPageSizes,
+  pageSizes,
   totalCount,
   getMessage,
   className,
@@ -25,10 +25,10 @@ export const Pager = ({
       className={classNames('clearfix', className)}
       {...restProps}
     >
-      {!!allowedPageSizes.length && <PageSizeSelector
+      {!!pageSizes.length && <PageSizeSelector
         pageSize={pageSize}
         onPageSizeChange={onPageSizeChange}
-        allowedPageSizes={allowedPageSizes}
+        pageSizes={pageSizes}
         getMessage={getMessage}
       />}
       <Pagination
@@ -76,7 +76,7 @@ Pager.propTypes = {
   totalPages: PropTypes.number.isRequired,
   pageSize: PropTypes.number.isRequired,
   onPageSizeChange: PropTypes.func.isRequired,
-  allowedPageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
+  pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
   totalCount: PropTypes.number.isRequired,
   getMessage: PropTypes.func.isRequired,
   className: PropTypes.string,

--- a/packages/dx-react-grid-bootstrap3/src/templates/pager.test.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/pager.test.jsx
@@ -8,7 +8,7 @@ const defaultProps = {
   totalCount: 96,
   pageSize: 10,
   getMessage: key => key,
-  allowedPageSizes: [],
+  pageSizes: [],
   onCurrentPageChange: () => {},
   onPageSizeChange: () => {},
 };
@@ -98,7 +98,7 @@ describe('Pager', () => {
       const pageSizeSelector = shallow((
         <Pager
           {...defaultProps}
-          allowedPageSizes={[5, 10]}
+          pageSizes={[5, 10]}
         />
       )).find('PageSizeSelector');
 
@@ -108,7 +108,7 @@ describe('Pager', () => {
         .toBe('showAll');
     });
 
-    it('doesn\'t render page selector if the allowedPageSizes option is not defined ', () => {
+    it('doesn\'t render page selector if the pageSizes option is not defined ', () => {
       const pageSizeSelector = shallow((
         <Pager
           {...defaultProps}

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.jsx
@@ -39,7 +39,7 @@ export class TableHeaderCell extends React.PureComponent {
     const {
       style, column, tableColumn,
       allowSorting, sortingDirection,
-      allowGroupingByClick, onGroup,
+      showGroupingControls, onGroup,
       allowDragging, dragPayload,
       allowResizing, onWidthChange, onDraftWidthChange,
       tableRow, getMessage, onSort,
@@ -66,7 +66,7 @@ export class TableHeaderCell extends React.PureComponent {
         onClick={this.onClick}
         {...restProps}
       >
-        {allowGroupingByClick && (
+        {showGroupingControls && (
           <GroupingControl
             align={align}
             onGroup={onGroup}
@@ -74,7 +74,7 @@ export class TableHeaderCell extends React.PureComponent {
         )}
         <div
           style={{
-            ...(allowGroupingByClick ? { [`margin${column.align === 'right' ? 'Left' : 'Right'}`]: '14px' } : null),
+            ...(showGroupingControls ? { [`margin${column.align === 'right' ? 'Left' : 'Right'}`]: '14px' } : null),
             textAlign: align,
             whiteSpace: 'nowrap',
             overflow: 'hidden',
@@ -125,7 +125,7 @@ TableHeaderCell.propTypes = {
   allowSorting: PropTypes.bool,
   sortingDirection: PropTypes.oneOf(['asc', 'desc', null]),
   onSort: PropTypes.func,
-  allowGroupingByClick: PropTypes.bool,
+  showGroupingControls: PropTypes.bool,
   onGroup: PropTypes.func,
   allowDragging: PropTypes.bool,
   dragPayload: PropTypes.any,
@@ -142,7 +142,7 @@ TableHeaderCell.defaultProps = {
   allowSorting: false,
   sortingDirection: undefined,
   onSort: undefined,
-  allowGroupingByClick: false,
+  showGroupingControls: false,
   onGroup: undefined,
   allowDragging: false,
   dragPayload: null,

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.test.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.test.jsx
@@ -149,7 +149,7 @@ describe('TableHeaderCell', () => {
     const tree = shallow((
       <TableHeaderCell
         column={{}}
-        allowGroupingByClick={false}
+        showGroupingControls={false}
       />
     ));
     expect(tree.find('th > div').prop('style'))
@@ -165,7 +165,7 @@ describe('TableHeaderCell', () => {
     const tree = shallow((
       <TableHeaderCell
         column={{}}
-        allowGroupingByClick
+        showGroupingControls
       />
     ));
     expect(tree.find('th > div').prop('style'))
@@ -182,7 +182,7 @@ describe('TableHeaderCell', () => {
     const tree = shallow((
       <TableHeaderCell
         column={{ align: 'right' }}
-        allowGroupingByClick={false}
+        showGroupingControls={false}
       />
     ));
     expect(tree.find('th > div').prop('style'))
@@ -198,7 +198,7 @@ describe('TableHeaderCell', () => {
     const tree = shallow((
       <TableHeaderCell
         column={{ align: 'right' }}
-        allowGroupingByClick
+        showGroupingControls
       />
     ));
     expect(tree.find('th > div').prop('style'))

--- a/packages/dx-react-grid-material-ui/src/templates/group-panel-item.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/group-panel-item.jsx
@@ -34,7 +34,7 @@ const label = (allowSorting, sortingDirection, column) => {
 
 const GroupPanelItemBase = ({
   item: { column, draft },
-  onGroup, allowUngroupingByClick,
+  onGroup, showGroupingControls,
   allowSorting, sortingDirection, onSort,
   classes, className,
   ...restProps
@@ -62,7 +62,7 @@ const GroupPanelItemBase = ({
     <Chip
       label={label(allowSorting, sortingDirection, column)}
       className={chipClassNames}
-      {...allowUngroupingByClick
+      {...showGroupingControls
         ? { onRequestDelete: () => onGroup({ columnName: column.name }) }
         : null}
       onClick={onClick}
@@ -82,7 +82,7 @@ GroupPanelItemBase.propTypes = {
   sortingDirection: PropTypes.oneOf(['asc', 'desc', null]),
   onSort: PropTypes.func,
   onGroup: PropTypes.func,
-  allowUngroupingByClick: PropTypes.bool,
+  showGroupingControls: PropTypes.bool,
   classes: PropTypes.object.isRequired,
   className: PropTypes.string,
 };
@@ -92,7 +92,7 @@ GroupPanelItemBase.defaultProps = {
   sortingDirection: undefined,
   onSort: undefined,
   onGroup: undefined,
-  allowUngroupingByClick: false,
+  showGroupingControls: false,
   className: undefined,
 };
 

--- a/packages/dx-react-grid-material-ui/src/templates/group-panel-item.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/group-panel-item.test.jsx
@@ -75,7 +75,7 @@ describe('GroupPanelItem', () => {
     const tree = mount((
       <GroupPanelItem
         item={{ column: { name: 'test' } }}
-        allowUngroupingByClick
+        showGroupingControls
       />
     ));
     expect(tree.find(Chip).props())

--- a/packages/dx-react-grid-material-ui/src/templates/page-size-selector.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/page-size-selector.jsx
@@ -48,7 +48,7 @@ export const styles = theme => ({
 const PageSizeSelectorBase = ({
   pageSize,
   onPageSizeChange,
-  allowedPageSizes,
+  pageSizes,
   getMessage,
   classes,
 }) => {
@@ -72,7 +72,7 @@ const PageSizeSelectorBase = ({
           />
         }
       >
-        {allowedPageSizes.map(item => (
+        {pageSizes.map(item => (
           <MenuItem key={item} value={item}>
             {item !== 0 ? item : showAll }
           </MenuItem>
@@ -85,7 +85,7 @@ const PageSizeSelectorBase = ({
 PageSizeSelectorBase.propTypes = {
   pageSize: PropTypes.number.isRequired,
   onPageSizeChange: PropTypes.func.isRequired,
-  allowedPageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
+  pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
   classes: PropTypes.object.isRequired,
   getMessage: PropTypes.func.isRequired,
 };

--- a/packages/dx-react-grid-material-ui/src/templates/page-size-selector.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/page-size-selector.test.jsx
@@ -10,7 +10,7 @@ describe('PageSizeSelector', () => {
     mount = createMount();
     classes = getClasses(<PageSizeSelector
       pageSize={0}
-      allowedPageSizes={[]}
+      pageSizes={[]}
       getMessage={() => {}}
       onPageSizeChange={() => {}}
     />);
@@ -22,23 +22,23 @@ describe('PageSizeSelector', () => {
   describe('#render', () => {
     const mountPageSizeSelector = ({
       pageSize,
-      allowedPageSizes,
+      pageSizes,
       onPageSizeChange = () => {},
       getMessage = key => key,
     }) => mount((
       <PageSizeSelector
         pageSize={pageSize}
-        allowedPageSizes={allowedPageSizes}
+        pageSizes={pageSizes}
         getMessage={getMessage}
         onPageSizeChange={onPageSizeChange}
       />
     ));
 
     it('can show info about page sizes', () => {
-      const allowedPageSizes = [5, 10];
+      const pageSizes = [5, 10];
       const pageSizeSelector = mountPageSizeSelector({
         pageSize: 10,
-        allowedPageSizes,
+        pageSizes,
       });
       const select = pageSizeSelector.find(Select);
       const selectItems = select.prop('children');
@@ -46,14 +46,14 @@ describe('PageSizeSelector', () => {
       expect(select).toHaveLength(1);
       expect(select.prop('value')).toBe(10);
       expect(selectItems).toHaveLength(2);
-      expect(selectItems[0].props.value).toBe(allowedPageSizes[0]);
-      expect(selectItems[1].props.value).toBe(allowedPageSizes[1]);
+      expect(selectItems[0].props.value).toBe(pageSizes[0]);
+      expect(selectItems[1].props.value).toBe(pageSizes[1]);
     });
 
     it('can render the "All" item', () => {
       const pageSizeSelector = mountPageSizeSelector({
         pageSize: 0,
-        allowedPageSizes: [5, 10, 0],
+        pageSizes: [5, 10, 0],
       });
       const select = pageSizeSelector.find(Select);
       const selectItems = select.prop('children');
@@ -64,7 +64,7 @@ describe('PageSizeSelector', () => {
     it('should render "Rows per page" text', () => {
       const pageSizeSelector = mountPageSizeSelector({
         pageSize: 0,
-        allowedPageSizes: [5, 10, 15],
+        pageSizes: [5, 10, 15],
       });
       const label = pageSizeSelector.find(`.${classes.label}`);
 
@@ -75,7 +75,7 @@ describe('PageSizeSelector', () => {
       const onPageSizeChange = jest.fn();
       const pageSizeSelector = mountPageSizeSelector({
         pageSize: 5,
-        allowedPageSizes: [5, 10],
+        pageSizes: [5, 10],
         onPageSizeChange,
       });
       const select = pageSizeSelector.find(Select);

--- a/packages/dx-react-grid-material-ui/src/templates/pager.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/pager.jsx
@@ -13,7 +13,7 @@ const styles = {
 
 const PagerBase = ({
   currentPage,
-  allowedPageSizes,
+  pageSizes,
   totalPages,
   pageSize,
   classes,
@@ -36,10 +36,10 @@ const PagerBase = ({
       pageSize={pageSize}
       getMessage={getMessage}
     />
-    {!!allowedPageSizes.length && <PageSizeSelector
+    {!!pageSizes.length && <PageSizeSelector
       pageSize={pageSize}
       onPageSizeChange={onPageSizeChange}
-      allowedPageSizes={allowedPageSizes}
+      pageSizes={pageSizes}
       getMessage={getMessage}
     />}
   </div>
@@ -48,7 +48,7 @@ const PagerBase = ({
 PagerBase.propTypes = {
   currentPage: PropTypes.number.isRequired,
   totalPages: PropTypes.number.isRequired,
-  allowedPageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
+  pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
   pageSize: PropTypes.number.isRequired,
   classes: PropTypes.object.isRequired,
   onCurrentPageChange: PropTypes.func.isRequired,

--- a/packages/dx-react-grid-material-ui/src/templates/pager.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/pager.test.jsx
@@ -10,7 +10,7 @@ const defaultProps = {
   pageSize: 5,
   totalCount: 15,
   getMessage: key => key,
-  allowedPageSizes: [],
+  pageSizes: [],
   onCurrentPageChange: () => {},
   onPageSizeChange: () => {},
 };
@@ -41,7 +41,7 @@ describe('Pager', () => {
       const pager = shallow((
         <Pager
           {...defaultProps}
-          allowedPageSizes={[5, 10]}
+          pageSizes={[5, 10]}
         />
       ));
       const pageSizeSelector = pager.find(PageSizeSelector);
@@ -50,7 +50,7 @@ describe('Pager', () => {
         .toHaveLength(1);
     });
 
-    it('doesn\'t render page size selector if the allowedPageSizes option is not defined', () => {
+    it('doesn\'t render page size selector if the pageSizes option is not defined', () => {
       const pager = shallow((
         <Pager
           {...defaultProps}

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell.jsx
@@ -76,7 +76,7 @@ class TableHeaderCellBase extends React.PureComponent {
     const {
       style, column, tableColumn,
       allowSorting, sortingDirection,
-      allowGroupingByClick, onGroup,
+      showGroupingControls, onGroup,
       allowDragging, dragPayload,
       allowResizing, onWidthChange, onDraftWidthChange,
       classes, getMessage, tableRow, className, onSort,
@@ -102,7 +102,7 @@ class TableHeaderCellBase extends React.PureComponent {
         numeric={align === 'right'}
         {...restProps}
       >
-        {allowGroupingByClick && (
+        {showGroupingControls && (
           <GroupingControl
             align={align}
             onGroup={onGroup}
@@ -114,7 +114,6 @@ class TableHeaderCellBase extends React.PureComponent {
             sortingDirection={sortingDirection}
             columnTitle={columnTitle}
             onClick={this.onClick}
-            allowGroupingByClick={allowGroupingByClick}
             text={tooltipText}
           />
         ) : (
@@ -154,7 +153,7 @@ TableHeaderCellBase.propTypes = {
   allowSorting: PropTypes.bool,
   sortingDirection: PropTypes.oneOf(['asc', 'desc', null]),
   onSort: PropTypes.func,
-  allowGroupingByClick: PropTypes.bool,
+  showGroupingControls: PropTypes.bool,
   onGroup: PropTypes.func,
   allowDragging: PropTypes.bool,
   dragPayload: PropTypes.any,
@@ -173,7 +172,7 @@ TableHeaderCellBase.defaultProps = {
   allowSorting: false,
   sortingDirection: undefined,
   onSort: undefined,
-  allowGroupingByClick: false,
+  showGroupingControls: false,
   onGroup: undefined,
   allowDragging: false,
   dragPayload: null,

--- a/packages/dx-react-grid/docs/guides/grouping.md
+++ b/packages/dx-react-grid/docs/guides/grouping.md
@@ -43,7 +43,7 @@ Use the `GroupPanel` and `TableHeaderRow` plugins in addition to those used for 
  Set the `TableHeaderRow` and `GroupingPanel` plugins' `allowDragging` properties to true.
 
 - Use the corresponding button in a header cell
- Assign true to the `TableHeaderRow` plugin's `showGroupingControls` and the `GroupingPanel` plugin's `allowUngroupingByClick` properties.
+ Assign true to the `TableHeaderRow` plugin's `showGroupingControls` and the `GroupingPanel` plugin's `showGroupingControls` properties.
 
 You can also set the `GroupingPanel` plugin's `allowSorting` option to true to enable sorting data by a grouped column.
 

--- a/packages/dx-react-grid/docs/guides/grouping.md
+++ b/packages/dx-react-grid/docs/guides/grouping.md
@@ -43,7 +43,7 @@ Use the `GroupPanel` and `TableHeaderRow` plugins in addition to those used for 
  Set the `TableHeaderRow` and `GroupingPanel` plugins' `allowDragging` properties to true.
 
 - Use the corresponding button in a header cell
- Assign true to the `TableHeaderRow` plugin's `allowGroupingByClick` and the `GroupingPanel` plugin's `allowUngroupingByClick` properties.
+ Assign true to the `TableHeaderRow` plugin's `showGroupingControls` and the `GroupingPanel` plugin's `allowUngroupingByClick` properties.
 
 You can also set the `GroupingPanel` plugin's `allowSorting` option to true to enable sorting data by a grouped column.
 

--- a/packages/dx-react-grid/docs/guides/paging.md
+++ b/packages/dx-react-grid/docs/guides/paging.md
@@ -26,7 +26,7 @@ In the following example, the page size is specified using the `PagingState` plu
 
 ## Page Size Selection
 
-Assign an array of available page sizes to the `PagingPanel` plugin's `allowedPageSizes` property to enable page size selection via the UI. The Page Size Selector displays the 'All' item if the specified array contains an item whose value is 0. You can specify custom text for this Page Size Selector item using the `messages.showAll` property.
+Assign an array of available page sizes to the `PagingPanel` plugin's `pageSizes` property to enable page size selection via the UI. The Page Size Selector displays the 'All' item if the specified array contains an item whose value is 0. You can specify custom text for this Page Size Selector item using the `messages.showAll` property.
 
 The example below demonstrates the basic configuration for the uncontrolled mode. The `PagingState` plugin's `defaultPageSize` property defines the initial page size.
 
@@ -39,7 +39,7 @@ In the [controlled mode](controlled-and-uncontrolled-modes.md), specify the foll
 - `currentPage` and `onCurrentPageChange` - the currently displayed page's index
 - `pageSize` and `onPageSizeChange` - the page size
 
-Note that the `onPageSizeChange` handler makes sense only if the `allowedPageSizes` option is specified. Otherwise, a user is not able to change the page size.
+Note that the `onPageSizeChange` handler makes sense only if the `pageSizes` option is specified. Otherwise, a user is not able to change the page size.
 
 .embedded-demo(paging/local-paging-controlled)
 

--- a/packages/dx-react-grid/docs/reference/grouping-panel.md
+++ b/packages/dx-react-grid/docs/reference/grouping-panel.md
@@ -18,7 +18,7 @@ Name | Type | Default | Description
 -----|------|---------|------------
 allowSorting | boolean | false | Specifies whether an end-user can sort data by a column. Requires the [SortingState](sorting-state.md) dependency.
 allowDragging | boolean | false | Specifies whether an end-user can change the grouping state by dragging columns between the group panel and the table header. Requires the [DragDropContext](drag-drop-context.md) dependency.
-allowUngroupingByClick | boolean | false | Specifies whether column headers display a button that cancels grouping by that column.
+showGroupingControls | boolean | false | Specifies whether column headers display a button that cancels grouping by that column.
 containerComponent | ElementType&lt;[GroupingPanelContainerProps](#groupingpanelcontainerprops)&gt; | | A component that renders a group panel container.
 itemComponent | ElementType&lt;[GroupingPanelItemProps](#groupingpanelitemprops)&gt; | | A component that renders a group panel item.
 emptyMessageComponent | ElementType&lt;[GroupingPanelEmptyMessageProps](#groupingpanelemptymessageprops)&gt; | | A component that renders an empty group panel message.
@@ -62,7 +62,7 @@ A value with the following shape:
 Field | Type | Description
 ------|------|------------
 item | [GroupingPanelItem](#groupingpanelitem) | The Grouping Panel item.
-allowUngroupingByClick | boolean | Specifies whether to display a button that cancels grouping by the column.
+showGroupingControls | boolean | Specifies whether to display a button that cancels grouping by the column.
 allowSorting | boolean | Specifies whether an end-user can sort data by the column while it is in the grouping panel.
 sortingDirection? | 'asc' &#124; 'desc' | Specifies the sorting direction.
 onSort | ({ keepOther: boolean, cancel: boolean }) => void | An event that initiates changing column's sorting direction. Keeps the current sorting state if `keepOther` is set to true. Cancels sorting by the current column if `cancel` is set to true.

--- a/packages/dx-react-grid/docs/reference/paging-panel.md
+++ b/packages/dx-react-grid/docs/reference/paging-panel.md
@@ -13,7 +13,7 @@ A plugin that renders the paging panel used for navigation through data pages.
 Name | Type | Default | Description
 -----|------|---------|------------
 containerComponent | ElementType&lt;[ContainerProps](#containerprops)&gt; | | A component that renders the paging panel.
-allowedPageSizes | Array&lt;number&gt; | [] | The page sizes that a user can select.
+pageSizes | Array&lt;number&gt; | [] | The page sizes that a user can select.
 messages | object | | An object that specifies the [localization messages](#localization-messages).
 
 ## Interfaces
@@ -31,7 +31,7 @@ currentPage | number | Specifies the current page.
 onCurrentPageChange | (page: number) => void | Handles the current page changes.
 pageSize | number | Specifies the page size.
 onPageSizeChange | (size: number) => void | Handles the page size changes.
-allowedPageSizes | Array&lt;number&gt; | Specifies the page sizes that a user can select.
+pageSizes | Array&lt;number&gt; | Specifies the page sizes that a user can select.
 getMessage | ([messageKey](#localization-messages): string) => string | Returns the paging panel's text.
 
 ## Localization Messages

--- a/packages/dx-react-grid/docs/reference/table-header-row.md
+++ b/packages/dx-react-grid/docs/reference/table-header-row.md
@@ -22,7 +22,7 @@ cellComponent | ElementType&lt;[TableHeaderCellProps](#tableheadercellprops)&gt;
 rowComponent | ElementType&lt;[TableRowProps](table.md#tablerowprops)&gt; | | A component that renders a header row.
 allowSorting | boolean | false | Specifies whether a user can change the column's sorting state. Requires the [SortingState](sorting-state.md) dependency.
 allowDragging | boolean | false | Specifies whether a user can drag a column by the header cell. Requires the [DragDropContext](drag-drop-context.md) dependency.
-allowGroupingByClick | boolean | false | Specifies whether to render controls that toggle the column's grouping state. Requires the [GroupingState](grouping-state.md) dependency.
+showGroupingControls | boolean | false | Specifies whether to render controls that toggle the column's grouping state. Requires the [GroupingState](grouping-state.md) dependency.
 allowResizing | boolean | false | Specifies whether a user can resize columns. Requires the [TableColumnResizing](table-column-resizing.md) dependency.
 messages | object | | An object that specifies [localization messages](#localization-messages).
 
@@ -48,13 +48,13 @@ column | [Column](#column-extension) | A column object associated with the heade
 allowSorting | boolean | Specifies whether a user can change the associated column's sorting state.
 sortingDirection? | 'asc' &#124; 'desc' | Specifies the associated column's sorting direction.
 onSort | ({ keepOther: boolean, cancel: boolean }) | An event that changes the associated column's sorting state. The `keepOther` and `cancel` arguments specify whether to keep existing sorting and cancel sorting by the associated column.
-allowGroupingByClick | boolean | Specifies whether to render a control that toggles the associated column's grouping state.
+showGroupingControls | boolean | Specifies whether to render a control that toggles the associated column's grouping state.
 onGroup | () => void | An event that invokes grouping by the associated column.
 allowDragging | boolean | Specifies whether a user can drag a column by the header cell.
 dragPayload | any | A data object that identifies the associated column in the drag-and-drop context.
 onWidthChange | ({ shift: number }) => void | An event that initiates the column width changing. The initial column width increases by the `shift` value or decreases if `shift` is negative
 onDraftWidthChange | ({ shift: number }) => void | An event that changes the column width used for preview. The initial column width increases by the `shift` value or decreases if `shift` is negative. Setting `shift` to `null` clears the column's draft width.
-getMessage | ([messageKey](#localization-messages): string) => string | Returns the text displayed in a sorting control within the  header cell.
+getMessage | ([messageKey](#localization-messages): string) => string | Returns the text displayed in a sorting control within the header cell.
 
 ## Localization Messages
 

--- a/packages/dx-react-grid/src/plugins/grouping-panel.jsx
+++ b/packages/dx-react-grid/src/plugins/grouping-panel.jsx
@@ -18,7 +18,7 @@ export class GroupingPanel extends React.PureComponent {
       emptyMessageComponent: EmptyMessage,
       allowSorting,
       allowDragging,
-      allowUngroupingByClick,
+      showGroupingControls,
       messages,
     } = this.props;
 
@@ -40,7 +40,7 @@ export class GroupingPanel extends React.PureComponent {
               allowSorting={allowSorting && sorting !== undefined}
               sortingDirection={sorting !== undefined
                 ? getColumnSortingDirection(sorting, columnName) : undefined}
-              allowUngroupingByClick={allowUngroupingByClick}
+              showGroupingControls={showGroupingControls}
               onGroup={() => groupByColumn({ columnName })}
               onSort={({ keepOther, cancel }) =>
                 setColumnSorting({ columnName, keepOther, cancel })}
@@ -87,7 +87,7 @@ export class GroupingPanel extends React.PureComponent {
 GroupingPanel.propTypes = {
   allowSorting: PropTypes.bool,
   allowDragging: PropTypes.bool,
-  allowUngroupingByClick: PropTypes.bool,
+  showGroupingControls: PropTypes.bool,
   layoutComponent: PropTypes.func.isRequired,
   containerComponent: PropTypes.func.isRequired,
   itemComponent: PropTypes.func.isRequired,
@@ -98,6 +98,6 @@ GroupingPanel.propTypes = {
 GroupingPanel.defaultProps = {
   allowSorting: false,
   allowDragging: false,
-  allowUngroupingByClick: false,
+  showGroupingControls: false,
   messages: {},
 };

--- a/packages/dx-react-grid/src/plugins/grouping-panel.test.jsx
+++ b/packages/dx-react-grid/src/plugins/grouping-panel.test.jsx
@@ -114,7 +114,7 @@ describe('GroupingPanel', () => {
           layoutComponent={({ itemComponent: Item }) =>
             <Item item={{ column: { name: 'a' } }} />}
           allowSorting
-          allowUngroupingByClick
+          showGroupingControls
         />
       </PluginHost>
     ));
@@ -122,7 +122,7 @@ describe('GroupingPanel', () => {
     expect(tree.find(defaultProps.itemComponent).props())
       .toMatchObject({
         allowSorting: true,
-        allowUngroupingByClick: true,
+        showGroupingControls: true,
         sortingDirection: getColumnSortingDirection(),
         onGroup: expect.any(Function),
       });

--- a/packages/dx-react-grid/src/plugins/paging-panel.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-panel.jsx
@@ -14,7 +14,7 @@ export class PagingPanel extends React.PureComponent {
   render() {
     const {
       containerComponent: Pager,
-      allowedPageSizes,
+      pageSizes,
       messages,
     } = this.props;
     const getMessage = getMessagesFormatter(messages);
@@ -33,7 +33,7 @@ export class PagingPanel extends React.PureComponent {
                 pageSize={pageSize}
                 totalCount={totalCount}
                 totalPages={pageCount(totalCount, pageSize)}
-                allowedPageSizes={allowedPageSizes}
+                pageSizes={pageSizes}
                 getMessage={getMessage}
                 onCurrentPageChange={setCurrentPage}
                 onPageSizeChange={setPageSize}
@@ -47,12 +47,12 @@ export class PagingPanel extends React.PureComponent {
 }
 
 PagingPanel.propTypes = {
-  allowedPageSizes: PropTypes.arrayOf(PropTypes.number),
+  pageSizes: PropTypes.arrayOf(PropTypes.number),
   containerComponent: PropTypes.func.isRequired,
   messages: PropTypes.object,
 };
 
 PagingPanel.defaultProps = {
-  allowedPageSizes: [],
+  pageSizes: [],
   messages: {},
 };

--- a/packages/dx-react-grid/src/plugins/paging-panel.test.jsx
+++ b/packages/dx-react-grid/src/plugins/paging-panel.test.jsx
@@ -52,7 +52,7 @@ describe('PagingPanel', () => {
         {pluginDepsToComponents(defaultDeps)}
         <PagingPanel
           containerComponent={DefaultPager}
-          allowedPageSizes={[3, 5, 0]}
+          pageSizes={[3, 5, 0]}
         />
       </PluginHost>
     ));
@@ -64,7 +64,7 @@ describe('PagingPanel', () => {
         pageSize: 2,
         totalCount: 21,
         totalPages: 11,
-        allowedPageSizes: [3, 5, 0],
+        pageSizes: [3, 5, 0],
       });
 
     pager.prop('onCurrentPageChange')(3);

--- a/packages/dx-react-grid/src/plugins/table-header-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-header-row.jsx
@@ -17,7 +17,7 @@ export class TableHeaderRow extends React.PureComponent {
   render() {
     const {
       allowSorting,
-      allowGroupingByClick,
+      showGroupingControls,
       allowDragging,
       allowResizing,
       cellComponent: HeaderCell,
@@ -32,7 +32,7 @@ export class TableHeaderRow extends React.PureComponent {
         dependencies={[
           { pluginName: 'Table' },
           { pluginName: 'SortingState', optional: !allowSorting },
-          { pluginName: 'GroupingState', optional: !allowGroupingByClick },
+          { pluginName: 'GroupingState', optional: !showGroupingControls },
           { pluginName: 'DragDropContext', optional: !allowDragging },
           { pluginName: 'TableColumnResizing', optional: !allowResizing },
         ]}
@@ -61,7 +61,7 @@ export class TableHeaderRow extends React.PureComponent {
                     column={params.tableColumn.column}
                     getMessage={getMessage}
                     allowSorting={allowSorting && sorting !== undefined}
-                    allowGroupingByClick={allowGroupingByClick && groupingSupported}
+                    showGroupingControls={showGroupingControls && groupingSupported}
                     allowDragging={allowDragging && (!grouping || groupingSupported)}
                     allowResizing={allowResizing}
                     sortingDirection={allowSorting && sorting !== undefined
@@ -94,7 +94,7 @@ export class TableHeaderRow extends React.PureComponent {
 
 TableHeaderRow.propTypes = {
   allowSorting: PropTypes.bool,
-  allowGroupingByClick: PropTypes.bool,
+  showGroupingControls: PropTypes.bool,
   allowDragging: PropTypes.bool,
   allowResizing: PropTypes.bool,
   cellComponent: PropTypes.func.isRequired,
@@ -104,7 +104,7 @@ TableHeaderRow.propTypes = {
 
 TableHeaderRow.defaultProps = {
   allowSorting: false,
-  allowGroupingByClick: false,
+  showGroupingControls: false,
   allowDragging: false,
   allowResizing: false,
   messages: null,


### PR DESCRIPTION
BREAKING CHANGES:

To simplify working and make consistent API, some plugins properties have been renamed.
- The TableHeaderRow plugin's `allowGroupingByClick` property has been renamed to `showGroupingControls`.
- The GroupingPanel plugin's `allowUngroupingByClick` property has been renamed to `showGroupingControls`.
- The PagingPanel plugin's `allowedPageSizes` property has been renamed to `pageSizes `.