### PR TITLE
refactor(react-grid): extract table column extension

### DIFF
--- a/packages/dx-grid-core/src/index.js
+++ b/packages/dx-grid-core/src/index.js
@@ -71,6 +71,8 @@ export * from './plugins/table-column-visibility/computeds';
 export * from './column-chooser/computeds';
 export * from './column-chooser/reducers';
 
+export { getColumnExtension } from './utils/column';
+
 export {
   getTableRowColumnsWithColSpan,
   getTableColumnGeometries,

--- a/packages/dx-grid-core/src/index.js
+++ b/packages/dx-grid-core/src/index.js
@@ -71,8 +71,6 @@ export * from './plugins/table-column-visibility/computeds';
 export * from './column-chooser/computeds';
 export * from './column-chooser/reducers';
 
-export { getColumnExtension } from './utils/column';
-
 export {
   getTableRowColumnsWithColSpan,
   getTableColumnGeometries,

--- a/packages/dx-grid-core/src/plugins/table/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table/computeds.js
@@ -3,9 +3,10 @@ import { getColumnExtension } from '../../utils/column';
 
 export const tableColumnsWithDataRows = (columns, columnExtensions) =>
   columns.map((column) => {
-    const columnExtension = getColumnExtension(columnExtensions, column.name);
+    const { name } = column;
+    const columnExtension = getColumnExtension(columnExtensions, name);
     return {
-      key: `${TABLE_DATA_TYPE}_${column.name}`,
+      key: `${TABLE_DATA_TYPE}_${name}`,
       type: TABLE_DATA_TYPE,
       width: columnExtension.width,
       align: columnExtension.align,

--- a/packages/dx-grid-core/src/plugins/table/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table/computeds.js
@@ -1,12 +1,17 @@
 import { TABLE_DATA_TYPE, TABLE_NODATA_TYPE } from './constants';
+import { getColumnExtension } from '../../utils/column';
 
-export const tableColumnsWithDataRows = columns =>
-  columns.map(column => ({
-    key: `${TABLE_DATA_TYPE}_${column.name}`,
-    type: TABLE_DATA_TYPE,
-    width: column.width,
-    column,
-  }));
+export const tableColumnsWithDataRows = (columns, columnExtensions) =>
+  columns.map((column) => {
+    const columnExtension = getColumnExtension(columnExtensions, column.name);
+    return {
+      key: `${TABLE_DATA_TYPE}_${column.name}`,
+      type: TABLE_DATA_TYPE,
+      width: columnExtension.width,
+      align: columnExtension.align,
+      column,
+    };
+  });
 
 export const tableRowsWithDataRows = (rows, getRowId) => (
   !rows.length

--- a/packages/dx-grid-core/src/plugins/table/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table/computeds.test.js
@@ -16,11 +16,20 @@ describe('Table Plugin computeds', () => {
         ]);
     });
 
-    it('should copy width', () => {
-      const columns = [{ name: 'a', width: 100 }];
+    it('should set width from columnExtension', () => {
+      const columns = [{ name: 'a' }];
+      const columnExtensions = [{ columnName: 'a', width: 100 }];
 
-      expect(tableColumnsWithDataRows(columns)[0])
+      expect(tableColumnsWithDataRows(columns, columnExtensions)[0])
         .toMatchObject({ width: 100 });
+    });
+
+    it('should set align from columnExtension', () => {
+      const columns = [{ name: 'b' }];
+      const columnExtensions = [{ columnName: 'b', align: 'right' }];
+
+      expect(tableColumnsWithDataRows(columns, columnExtensions)[0])
+        .toMatchObject({ align: 'right' });
     });
   });
 

--- a/packages/dx-grid-core/src/utils/column.js
+++ b/packages/dx-grid-core/src/utils/column.js
@@ -1,0 +1,10 @@
+export const getColumnExtension = (columnExtensions, columnName) => {
+  if (!columnExtensions) {
+    return {};
+  }
+  const columnExtension = columnExtensions.find(extension => extension.columnName === columnName);
+  if (!columnExtension) {
+    return {};
+  }
+  return columnExtension;
+};

--- a/packages/dx-react-demos/src/bootstrap3/basic/table-cell-template.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/basic/table-cell-template.jsx
@@ -38,16 +38,6 @@ HighlightedCell.defaultProps = {
   style: {},
 };
 
-const Cell = (props) => {
-  if (props.column.name === 'amount') {
-    return <HighlightedCell {...props} />;
-  }
-  return <Table.Cell {...props} />;
-};
-Cell.propTypes = {
-  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
-};
-
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -61,11 +51,14 @@ export default class Demo extends React.PureComponent {
         { name: 'product', title: 'Product' },
         { name: 'amount', title: 'Sale Amount' },
       ],
+      tableColumnExtensions: [
+        { columnName: 'amount', cellComponent: HighlightedCell },
+      ],
       rows: generateRows({ columnValues: globalSalesValues, length: 14 }),
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, tableColumnExtensions } = this.state;
 
     return (
       <Grid
@@ -73,7 +66,7 @@ export default class Demo extends React.PureComponent {
         columns={columns}
       >
         <Table
-          cellComponent={Cell}
+          columnExtensions={tableColumnExtensions}
         />
         <TableHeaderRow />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/basic/table-cell-template.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/basic/table-cell-template.jsx
@@ -38,6 +38,16 @@ HighlightedCell.defaultProps = {
   style: {},
 };
 
+const Cell = (props) => {
+  if (props.column.name === 'amount') {
+    return <HighlightedCell {...props} />;
+  }
+  return <Table.Cell {...props} />;
+};
+Cell.propTypes = {
+  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
+};
+
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -51,14 +61,11 @@ export default class Demo extends React.PureComponent {
         { name: 'product', title: 'Product' },
         { name: 'amount', title: 'Sale Amount' },
       ],
-      tableColumnExtensions: [
-        { columnName: 'amount', cellComponent: HighlightedCell },
-      ],
       rows: generateRows({ columnValues: globalSalesValues, length: 14 }),
     };
   }
   render() {
-    const { rows, columns, tableColumnExtensions } = this.state;
+    const { rows, columns } = this.state;
 
     return (
       <Grid
@@ -66,7 +73,7 @@ export default class Demo extends React.PureComponent {
         columns={columns}
       >
         <Table
-          columnExtensions={tableColumnExtensions}
+          cellComponent={Cell}
         />
         <TableHeaderRow />
       </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/column-chooser/basic.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/column-chooser/basic.jsx
@@ -18,9 +18,12 @@ export default class Demo extends React.PureComponent {
     this.state = {
       columns: [
         { name: 'name', title: 'Name' },
-        { name: 'sex', title: 'Sex', width: 100 },
+        { name: 'sex', title: 'Sex' },
         { name: 'city', title: 'City' },
         { name: 'car', title: 'Car' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'sex', width: 100 },
       ],
       rows: generateRows({ length: 6 }),
       hiddenColumns: ['sex', 'car'],
@@ -32,7 +35,10 @@ export default class Demo extends React.PureComponent {
   }
 
   render() {
-    const { columns, rows, hiddenColumns } = this.state;
+    const {
+      columns, rows, tableColumnExtensions, hiddenColumns,
+    } = this.state;
+
     return (
       <Row>
         <Col xs={12} sm={9}>
@@ -40,7 +46,9 @@ export default class Demo extends React.PureComponent {
             rows={rows}
             columns={columns}
           >
-            <Table />
+            <Table
+              columnExtensions={tableColumnExtensions}
+            />
             <TableHeaderRow />
             <TableColumnVisibility
               hiddenColumns={hiddenColumns}

--- a/packages/dx-react-demos/src/bootstrap3/column-reordering/controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/column-reordering/controlled.jsx
@@ -18,9 +18,12 @@ export default class Demo extends React.PureComponent {
     this.state = {
       columns: [
         { name: 'name', title: 'Name' },
-        { name: 'sex', title: 'Sex', width: 100 },
+        { name: 'sex', title: 'Sex' },
         { name: 'city', title: 'City' },
         { name: 'car', title: 'Car' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'sex', width: 100 },
       ],
       rows: generateRows({ length: 6 }),
       columnOrder: ['city', 'sex', 'car', 'name'],
@@ -32,7 +35,9 @@ export default class Demo extends React.PureComponent {
     this.setState({ columnOrder: newOrder });
   }
   render() {
-    const { rows, columns, columnOrder } = this.state;
+    const {
+      rows, columns, tableColumnExtensions, columnOrder,
+    } = this.state;
 
     return (
       <Grid
@@ -40,7 +45,9 @@ export default class Demo extends React.PureComponent {
         columns={columns}
       >
         <DragDropContext />
-        <Table />
+        <Table
+          columnExtensions={tableColumnExtensions}
+        />
         <TableColumnReordering
           order={columnOrder}
           onOrderChange={this.changeColumnOrder}

--- a/packages/dx-react-demos/src/bootstrap3/column-reordering/uncontrolled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/column-reordering/uncontrolled.jsx
@@ -18,15 +18,18 @@ export default class Demo extends React.PureComponent {
     this.state = {
       columns: [
         { name: 'name', title: 'Name' },
-        { name: 'sex', title: 'Sex', width: 100 },
+        { name: 'sex', title: 'Sex' },
         { name: 'city', title: 'City' },
         { name: 'car', title: 'Car' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'sex', width: 100 },
       ],
       rows: generateRows({ length: 6 }),
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, tableColumnExtensions } = this.state;
 
     return (
       <Grid
@@ -34,7 +37,9 @@ export default class Demo extends React.PureComponent {
         columns={columns}
       >
         <DragDropContext />
-        <Table />
+        <Table
+          columnExtensions={tableColumnExtensions}
+        />
         <TableColumnReordering
           defaultOrder={['city', 'sex', 'car', 'name']}
         />

--- a/packages/dx-react-demos/src/bootstrap3/data-types/formatters.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/data-types/formatters.jsx
@@ -51,15 +51,16 @@ export default class Demo extends React.PureComponent {
         { name: 'customer', title: 'Customer' },
         { name: 'product', title: 'Product' },
         { name: 'saleDate', title: 'Sale Date', dataType: 'date' },
-        {
-          name: 'amount', title: 'Sale Amount', dataType: 'currency', align: 'right',
-        },
+        { name: 'amount', title: 'Sale Amount', dataType: 'currency' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'amount', align: 'right' },
       ],
       rows: generateRows({ columnValues: globalSalesValues, length: 14 }),
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, tableColumnExtensions } = this.state;
 
     return (
       <Grid
@@ -68,7 +69,9 @@ export default class Demo extends React.PureComponent {
       >
         <CurrencyTypeProvider />
         <DateTypeProvider />
-        <Table />
+        <Table
+          columnExtensions={tableColumnExtensions}
+        />
         <TableHeaderRow />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/editing/edit-row-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/editing/edit-row-controlled.jsx
@@ -23,11 +23,14 @@ export default class Demo extends React.PureComponent {
 
     this.state = {
       columns: [
-        { name: 'id', title: 'ID', width: 60 },
+        { name: 'id', title: 'ID' },
         { name: 'name', title: 'Name' },
         { name: 'sex', title: 'Sex' },
         { name: 'city', title: 'City' },
         { name: 'car', title: 'Car' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'id', width: 60 },
       ],
       rows: generateRows({
         columnValues: { id: ({ index }) => index, ...defaultColumnValues },
@@ -76,7 +79,7 @@ export default class Demo extends React.PureComponent {
   }
   render() {
     const {
-      rows, columns, editingRows, changedRows, addedRows,
+      rows, columns, tableColumnExtensions, editingRows, changedRows, addedRows,
     } = this.state;
 
     return (
@@ -94,7 +97,9 @@ export default class Demo extends React.PureComponent {
           onAddedRowsChange={this.changeAddedRows}
           onCommitChanges={this.commitChanges}
         />
-        <Table />
+        <Table
+          columnExtensions={tableColumnExtensions}
+        />
         <TableHeaderRow />
         <TableEditRow />
         <TableEditColumn

--- a/packages/dx-react-demos/src/bootstrap3/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-controlled-mode/demo.jsx
@@ -129,19 +129,6 @@ LookupEditCell.defaultProps = {
   value: undefined,
 };
 
-const Cell = (props) => {
-  if (props.column.name === 'discount') {
-    return <ProgressBarCell {...props} />;
-  }
-  if (props.column.name === 'amount') {
-    return <HighlightedCell {...props} />;
-  }
-  return <Table.Cell {...props} />;
-};
-Cell.propTypes = {
-  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
-};
-
 const EditCell = (props) => {
   const availableColumnValues = availableValues[props.column.name];
   if (availableColumnValues) {
@@ -163,10 +150,14 @@ export default class Demo extends React.PureComponent {
       columns: [
         { name: 'product', title: 'Product' },
         { name: 'region', title: 'Region' },
-        { name: 'amount', title: 'Sale Amount', align: 'right' },
+        { name: 'amount', title: 'Sale Amount' },
         { name: 'discount', title: 'Discount' },
         { name: 'saleDate', title: 'Sale Date' },
         { name: 'customer', title: 'Customer' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'amount', align: 'right', cellComponent: HighlightedCell },
+        { columnName: 'discount', cellComponent: ProgressBarCell },
       ],
       rows: generateRows({
         columnValues: { id: ({ index }) => index, ...globalSalesValues },
@@ -234,6 +225,7 @@ export default class Demo extends React.PureComponent {
     const {
       rows,
       columns,
+      tableColumnExtensions,
       sorting,
       editingRows,
       addedRows,
@@ -279,7 +271,7 @@ export default class Demo extends React.PureComponent {
           <DragDropContext />
 
           <Table
-            cellComponent={Cell}
+            columnExtensions={tableColumnExtensions}
           />
 
           <TableColumnReordering
@@ -318,7 +310,7 @@ export default class Demo extends React.PureComponent {
               columns={columns}
             >
               <Table
-                cellComponent={Cell}
+                columnExtensions={tableColumnExtensions}
               />
               <TableHeaderRow />
             </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-controlled-mode/demo.jsx
@@ -129,6 +129,19 @@ LookupEditCell.defaultProps = {
   value: undefined,
 };
 
+const Cell = (props) => {
+  if (props.column.name === 'discount') {
+    return <ProgressBarCell {...props} />;
+  }
+  if (props.column.name === 'amount') {
+    return <HighlightedCell {...props} />;
+  }
+  return <Table.Cell {...props} />;
+};
+Cell.propTypes = {
+  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
+};
+
 const EditCell = (props) => {
   const availableColumnValues = availableValues[props.column.name];
   if (availableColumnValues) {
@@ -156,8 +169,7 @@ export default class Demo extends React.PureComponent {
         { name: 'customer', title: 'Customer' },
       ],
       tableColumnExtensions: [
-        { columnName: 'amount', align: 'right', cellComponent: HighlightedCell },
-        { columnName: 'discount', cellComponent: ProgressBarCell },
+        { columnName: 'amount', align: 'right' },
       ],
       rows: generateRows({
         columnValues: { id: ({ index }) => index, ...globalSalesValues },
@@ -272,6 +284,7 @@ export default class Demo extends React.PureComponent {
 
           <Table
             columnExtensions={tableColumnExtensions}
+            cellComponent={Cell}
           />
 
           <TableColumnReordering
@@ -311,6 +324,7 @@ export default class Demo extends React.PureComponent {
             >
               <Table
                 columnExtensions={tableColumnExtensions}
+                cellComponent={Cell}
               />
               <TableHeaderRow />
             </Grid>

--- a/packages/dx-react-demos/src/bootstrap3/featured-redux-integration/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-redux-integration/demo.jsx
@@ -18,12 +18,31 @@ import {
   employeeTaskValues,
 } from '../../demo-data/generator';
 
+const columns = [
+  { name: 'prefix', title: 'Title' },
+  { name: 'firstName', title: 'First Name' },
+  { name: 'lastName', title: 'Last Name' },
+  { name: 'position', title: 'Position' },
+  { name: 'state', title: 'State' },
+  { name: 'birthDate', title: 'Birth Date' },
+];
+const detailColumns = [
+  { name: 'subject', title: 'Subject' },
+  { name: 'startDate', title: 'Start Date' },
+  { name: 'dueDate', title: 'Due Date' },
+  { name: 'priority', title: 'Priority' },
+  { name: 'status', title: 'Status' },
+];
+const tableDetailColumnExtensions = [
+  { columnName: 'startDate', width: 115 },
+  { columnName: 'dueDate', width: 115 },
+  { columnName: 'priority', width: 100 },
+  { columnName: 'status', width: 125 },
+];
+
 export const GRID_STATE_CHANGE_ACTION = 'GRID_STATE_CHANGE';
 
-const GridDetailContainer = ({
-  detailColumns,
-  row,
-}) => (
+const GridDetailContainer = ({ row }) => (
   <div style={{ margin: '20px' }}>
     <div>
       <h5>{row.firstName} {row.lastName}&apos;s Tasks:</h5>
@@ -32,7 +51,9 @@ const GridDetailContainer = ({
       rows={row.tasks}
       columns={detailColumns}
     >
-      <Table />
+      <Table
+        columnExtensions={tableDetailColumnExtensions}
+      />
       <TableHeaderRow />
     </Grid>
   </div>
@@ -40,15 +61,12 @@ const GridDetailContainer = ({
 
 GridDetailContainer.propTypes = {
   row: PropTypes.object.isRequired,
-  detailColumns: PropTypes.array.isRequired,
 };
 
 const ReduxGridDetailContainer = connect(state => state)(GridDetailContainer);
 
 const GridContainer = ({
   rows,
-  columns,
-
   sorting,
   onSortingChange,
   selection,
@@ -141,7 +159,6 @@ const GridContainer = ({
 
 GridContainer.propTypes = {
   rows: PropTypes.array.isRequired,
-  columns: PropTypes.array.isRequired,
   sorting: PropTypes.array.isRequired,
   onSortingChange: PropTypes.func.isRequired,
   selection: PropTypes.array.isRequired,
@@ -166,23 +183,6 @@ GridContainer.propTypes = {
 };
 
 const gridInitialState = {
-  columns: [
-    { name: 'prefix', title: 'Title' },
-    { name: 'firstName', title: 'First Name' },
-    { name: 'lastName', title: 'Last Name' },
-    { name: 'position', title: 'Position' },
-    { name: 'state', title: 'State' },
-    { name: 'birthDate', title: 'Birth Date' },
-  ],
-  detailColumns: [
-    { name: 'subject', title: 'Subject' },
-    { name: 'startDate', title: 'Start Date', width: 115 },
-    { name: 'dueDate', title: 'Due Date', width: 115 },
-    { name: 'priority', title: 'Priority', width: 100 },
-    {
-      name: 'status', title: 'Status', caption: 'Completed', width: 125,
-    },
-  ],
   rows: generateRows({
     columnValues: {
       ...employeeValues,

--- a/packages/dx-react-demos/src/bootstrap3/featured-remote-data/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-remote-data/demo.jsx
@@ -25,6 +25,16 @@ SaleAmountCell.propTypes = {
   value: PropTypes.any.isRequired,
 };
 
+const Cell = (props) => {
+  if (props.column.name === 'SaleAmount') {
+    return <SaleAmountCell {...props} />;
+  }
+  return <Table.Cell {...props} />;
+};
+Cell.propTypes = {
+  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
+};
+
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -40,7 +50,7 @@ export default class Demo extends React.PureComponent {
       ],
       tableColumnExtensions: [
         { columnName: 'OrderNumber', align: 'right' },
-        { columnName: 'SaleAmount', align: 'right', cellComponent: SaleAmountCell },
+        { columnName: 'SaleAmount', align: 'right' },
       ],
       rows: [],
       sorting: [{ columnName: 'StoreCity', direction: 'asc' }],
@@ -145,6 +155,7 @@ export default class Demo extends React.PureComponent {
           />
           <Table
             columnExtensions={tableColumnExtensions}
+            cellComponent={Cell}
           />
           <TableHeaderRow allowSorting />
           <PagingPanel

--- a/packages/dx-react-demos/src/bootstrap3/featured-remote-data/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-remote-data/demo.jsx
@@ -25,28 +25,22 @@ SaleAmountCell.propTypes = {
   value: PropTypes.any.isRequired,
 };
 
-const Cell = (props) => {
-  if (props.column.name === 'SaleAmount') {
-    return <SaleAmountCell {...props} />;
-  }
-  return <Table.Cell {...props} />;
-};
-Cell.propTypes = {
-  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
-};
-
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
 
     this.state = {
       columns: [
-        { name: 'OrderNumber', title: 'Order #', align: 'right' },
+        { name: 'OrderNumber', title: 'Order #' },
         { name: 'OrderDate', title: 'Order Date' },
         { name: 'StoreCity', title: 'Store City' },
         { name: 'StoreState', title: 'Store State' },
         { name: 'Employee', title: 'Employee' },
-        { name: 'SaleAmount', title: 'Sale Amount', align: 'right' },
+        { name: 'SaleAmount', title: 'Sale Amount' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'OrderNumber', align: 'right' },
+        { columnName: 'SaleAmount', align: 'right', cellComponent: SaleAmountCell },
       ],
       rows: [],
       sorting: [{ columnName: 'StoreCity', direction: 'asc' }],
@@ -123,6 +117,7 @@ export default class Demo extends React.PureComponent {
     const {
       rows,
       columns,
+      tableColumnExtensions,
       sorting,
       pageSize,
       allowedPageSizes,
@@ -149,7 +144,7 @@ export default class Demo extends React.PureComponent {
             totalCount={totalCount}
           />
           <Table
-            cellComponent={Cell}
+            columnExtensions={tableColumnExtensions}
           />
           <TableHeaderRow allowSorting />
           <PagingPanel

--- a/packages/dx-react-demos/src/bootstrap3/featured-theming/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-theming/demo.jsx
@@ -132,11 +132,16 @@ export default class Demo extends React.PureComponent {
 
     this.state = {
       columns: [
-        { name: 'prefix', title: 'Title', width: 100 },
+        { name: 'prefix', title: 'Title' },
         { name: 'firstName', title: 'First Name' },
         { name: 'lastName', title: 'Last Name' },
-        { name: 'position', title: 'Position', width: 170 },
-        { name: 'state', title: 'State', width: 125 },
+        { name: 'position', title: 'Position' },
+        { name: 'state', title: 'State' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'prefix', width: 100 },
+        { columnName: 'position', width: 170 },
+        { columnName: 'state', width: 125 },
       ],
       rows: generateRows({
         columnValues: {
@@ -153,7 +158,9 @@ export default class Demo extends React.PureComponent {
     };
   }
   render() {
-    const { rows, columns, allowedPageSizes } = this.state;
+    const {
+      rows, columns, tableColumnExtensions, allowedPageSizes,
+    } = this.state;
 
     return (
       <Grid
@@ -180,7 +187,9 @@ export default class Demo extends React.PureComponent {
 
         <DragDropContext />
 
-        <Table />
+        <Table
+          columnExtensions={tableColumnExtensions}
+        />
 
         <TableColumnReordering defaultOrder={columns.map(column => column.name)} />
 

--- a/packages/dx-react-demos/src/bootstrap3/featured-uncontrolled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-uncontrolled-mode/demo.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   SortingState, SelectionState, FilteringState, PagingState, GroupingState,
   LocalFiltering, LocalGrouping, LocalPaging, LocalSorting, LocalSelection,
@@ -20,6 +21,19 @@ import {
   globalSalesValues,
 } from '../../demo-data/generator';
 
+const Cell = (props) => {
+  if (props.column.name === 'discount') {
+    return <ProgressBarCell {...props} />;
+  }
+  if (props.column.name === 'amount') {
+    return <HighlightedCell {...props} />;
+  }
+  return <Table.Cell {...props} />;
+};
+Cell.propTypes = {
+  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
+};
+
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -34,8 +48,7 @@ export default class Demo extends React.PureComponent {
         { name: 'customer', title: 'Customer' },
       ],
       tableColumnExtensions: [
-        { columnName: 'amount', align: 'right', cellComponent: HighlightedCell },
-        { columnName: 'discount', cellComponent: ProgressBarCell },
+        { columnName: 'amount', align: 'right' },
       ],
       rows: generateRows({ columnValues: globalSalesValues, length: 1000 }),
       pageSizes: [5, 10, 15],
@@ -82,6 +95,7 @@ export default class Demo extends React.PureComponent {
 
         <Table
           columnExtensions={tableColumnExtensions}
+          cellComponent={Cell}
         />
 
         <TableColumnReordering defaultOrder={columns.map(column => column.name)} />
@@ -94,7 +108,6 @@ export default class Demo extends React.PureComponent {
         <TableSelection showSelectAll />
         <GroupingPanel allowSorting allowDragging />
         <TableGroupRow />
-
       </Grid>
     );
   }

--- a/packages/dx-react-demos/src/bootstrap3/featured-uncontrolled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-uncontrolled-mode/demo.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   SortingState, SelectionState, FilteringState, PagingState, GroupingState,
   LocalFiltering, LocalGrouping, LocalPaging, LocalSorting, LocalSelection,
@@ -21,19 +20,6 @@ import {
   globalSalesValues,
 } from '../../demo-data/generator';
 
-const Cell = (props) => {
-  if (props.column.name === 'discount') {
-    return <ProgressBarCell {...props} />;
-  }
-  if (props.column.name === 'amount') {
-    return <HighlightedCell {...props} />;
-  }
-  return <Table.Cell {...props} />;
-};
-Cell.propTypes = {
-  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
-};
-
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -42,17 +28,23 @@ export default class Demo extends React.PureComponent {
       columns: [
         { name: 'product', title: 'Product' },
         { name: 'region', title: 'Region' },
-        { name: 'amount', title: 'Sale Amount', align: 'right' },
+        { name: 'amount', title: 'Sale Amount' },
         { name: 'discount', title: 'Discount' },
         { name: 'saleDate', title: 'Sale Date' },
         { name: 'customer', title: 'Customer' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'amount', align: 'right', cellComponent: HighlightedCell },
+        { columnName: 'discount', cellComponent: ProgressBarCell },
       ],
       rows: generateRows({ columnValues: globalSalesValues, length: 1000 }),
       allowedPageSizes: [5, 10, 15],
     };
   }
   render() {
-    const { rows, columns, allowedPageSizes } = this.state;
+    const {
+      rows, columns, tableColumnExtensions, allowedPageSizes,
+    } = this.state;
 
     return (
       <Grid
@@ -89,7 +81,7 @@ export default class Demo extends React.PureComponent {
         <DragDropContext />
 
         <Table
-          cellComponent={Cell}
+          columnExtensions={tableColumnExtensions}
         />
 
         <TableColumnReordering defaultOrder={columns.map(column => column.name)} />

--- a/packages/dx-react-demos/src/bootstrap3/featured-virtual-scrolling/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-virtual-scrolling/demo.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   SortingState, SelectionState, FilteringState, GroupingState,
   LocalFiltering, LocalGrouping, LocalSorting, LocalSelection,
@@ -21,19 +20,6 @@ import {
   globalSalesValues,
 } from '../../demo-data/generator';
 
-const Cell = (props) => {
-  if (props.column.name === 'discount') {
-    return <ProgressBarCell {...props} />;
-  }
-  if (props.column.name === 'amount') {
-    return <HighlightedCell {...props} />;
-  }
-  return <VirtualTable.Cell {...props} />;
-};
-Cell.propTypes = {
-  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
-};
-
 const getRowId = row => row.id;
 
 export default class Demo extends React.PureComponent {
@@ -44,10 +30,14 @@ export default class Demo extends React.PureComponent {
       columns: [
         { name: 'product', title: 'Product' },
         { name: 'region', title: 'Region' },
-        { name: 'amount', title: 'Sale Amount', align: 'right' },
+        { name: 'amount', title: 'Sale Amount' },
         { name: 'discount', title: 'Discount' },
         { name: 'saleDate', title: 'Sale Date' },
         { name: 'customer', title: 'Customer' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'amount', align: 'right', cellComponent: HighlightedCell },
+        { columnName: 'discount', cellComponent: ProgressBarCell },
       ],
       rows: generateRows({
         columnValues: { id: ({ index }) => index, ...globalSalesValues },
@@ -56,7 +46,7 @@ export default class Demo extends React.PureComponent {
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, tableColumnExtensions } = this.state;
 
     return (
       <Grid
@@ -87,7 +77,7 @@ export default class Demo extends React.PureComponent {
         <LocalSelection />
 
         <VirtualTable
-          cellComponent={Cell}
+          columnExtensions={tableColumnExtensions}
         />
 
         <TableColumnReordering defaultOrder={columns.map(column => column.name)} />

--- a/packages/dx-react-demos/src/bootstrap3/featured-virtual-scrolling/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-virtual-scrolling/demo.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   SortingState, SelectionState, FilteringState, GroupingState,
   LocalFiltering, LocalGrouping, LocalSorting, LocalSelection,
@@ -22,6 +23,19 @@ import {
 
 const getRowId = row => row.id;
 
+const Cell = (props) => {
+  if (props.column.name === 'discount') {
+    return <ProgressBarCell {...props} />;
+  }
+  if (props.column.name === 'amount') {
+    return <HighlightedCell {...props} />;
+  }
+  return <VirtualTable.Cell {...props} />;
+};
+Cell.propTypes = {
+  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
+};
+
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -36,8 +50,7 @@ export default class Demo extends React.PureComponent {
         { name: 'customer', title: 'Customer' },
       ],
       tableColumnExtensions: [
-        { columnName: 'amount', align: 'right', cellComponent: HighlightedCell },
-        { columnName: 'discount', cellComponent: ProgressBarCell },
+        { columnName: 'amount', align: 'right' },
       ],
       rows: generateRows({
         columnValues: { id: ({ index }) => index, ...globalSalesValues },
@@ -78,6 +91,7 @@ export default class Demo extends React.PureComponent {
 
         <VirtualTable
           columnExtensions={tableColumnExtensions}
+          cellComponent={Cell}
         />
 
         <TableColumnReordering defaultOrder={columns.map(column => column.name)} />

--- a/packages/dx-react-demos/src/bootstrap3/filtering/custom-filter-row.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/filtering/custom-filter-row.jsx
@@ -60,13 +60,16 @@ export default class Demo extends React.PureComponent {
         { name: 'product', title: 'Product' },
         { name: 'region', title: 'Region' },
         { name: 'sector', title: 'Sector' },
-        { name: 'units', title: 'Quantity', align: 'right' },
+        { name: 'units', title: 'Quantity' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'units', align: 'right' },
       ],
       rows: generateRows({ columnValues: globalSalesValues, length: 14 }),
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, tableColumnExtensions } = this.state;
 
     return (
       <Grid
@@ -75,7 +78,9 @@ export default class Demo extends React.PureComponent {
       >
         <FilteringState defaultFilters={[{ columnName: 'units', value: 2 }]} />
         <LocalFiltering />
-        <Table />
+        <Table
+          columnExtensions={tableColumnExtensions}
+        />
         <TableHeaderRow />
         <TableFilterRow
           cellComponent={FilterCell}

--- a/packages/dx-react-demos/src/bootstrap3/sorting/local-custom-sorting.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/sorting/local-custom-sorting.jsx
@@ -38,10 +38,13 @@ export default class Demo extends React.PureComponent {
 
     this.state = {
       columns: [
-        { name: 'subject', title: 'Subject', width: 300 },
+        { name: 'subject', title: 'Subject' },
         { name: 'startDate', title: 'Start Date' },
         { name: 'dueDate', title: 'Due Date' },
         { name: 'priority', title: 'Priority' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'subject', width: 300 },
       ],
       rows: generateRows({
         columnValues: employeeTaskValues,
@@ -50,7 +53,7 @@ export default class Demo extends React.PureComponent {
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, tableColumnExtensions } = this.state;
 
     return (
       <Grid
@@ -61,7 +64,9 @@ export default class Demo extends React.PureComponent {
         <LocalSorting
           getColumnCompare={getColumnCompare}
         />
-        <Table />
+        <Table
+          columnExtensions={tableColumnExtensions}
+        />
         <TableHeaderRow allowSorting />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/templates/highlighted-cell.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/templates/highlighted-cell.jsx
@@ -14,11 +14,11 @@ const getColor = (amount) => {
   return '#c3e2b7';
 };
 
-export const HighlightedCell = ({ column, value, style }) => (
+export const HighlightedCell = ({ tableColumn, value, style }) => (
   <td
     style={{
       backgroundColor: getColor(value),
-      textAlign: column.align,
+      textAlign: tableColumn.align,
       ...style,
     }}
   >
@@ -27,10 +27,10 @@ export const HighlightedCell = ({ column, value, style }) => (
 );
 HighlightedCell.propTypes = {
   value: PropTypes.number.isRequired,
-  column: PropTypes.object,
+  tableColumn: PropTypes.object,
   style: PropTypes.object,
 };
 HighlightedCell.defaultProps = {
   style: {},
-  column: {},
+  tableColumn: {},
 };

--- a/packages/dx-react-demos/src/material-ui/basic/table-cell-template.jsx
+++ b/packages/dx-react-demos/src/material-ui/basic/table-cell-template.jsx
@@ -62,14 +62,11 @@ export default class Demo extends React.PureComponent {
         { name: 'product', title: 'Product' },
         { name: 'amount', title: 'Sale Amount' },
       ],
-      tableColumnExtensions: [
-        { columnName: 'amount', cellComponent: HighlightedCell },
-      ],
       rows: generateRows({ columnValues: globalSalesValues, length: 14 }),
     };
   }
   render() {
-    const { rows, columns, tableColumnExtensions } = this.state;
+    const { rows, columns } = this.state;
 
     return (
       <Paper>
@@ -78,7 +75,7 @@ export default class Demo extends React.PureComponent {
           columns={columns}
         >
           <Table
-            columnExtensions={tableColumnExtensions}
+            cellComponent={Cell}
           />
           <TableHeaderRow />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/basic/table-cell-template.jsx
+++ b/packages/dx-react-demos/src/material-ui/basic/table-cell-template.jsx
@@ -62,11 +62,14 @@ export default class Demo extends React.PureComponent {
         { name: 'product', title: 'Product' },
         { name: 'amount', title: 'Sale Amount' },
       ],
+      tableColumnExtensions: [
+        { columnName: 'amount', cellComponent: HighlightedCell },
+      ],
       rows: generateRows({ columnValues: globalSalesValues, length: 14 }),
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, tableColumnExtensions } = this.state;
 
     return (
       <Paper>
@@ -75,7 +78,7 @@ export default class Demo extends React.PureComponent {
           columns={columns}
         >
           <Table
-            cellComponent={Cell}
+            columnExtensions={tableColumnExtensions}
           />
           <TableHeaderRow />
         </Grid>

--- a/packages/dx-react-demos/src/material-ui/column-chooser/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-chooser/basic.jsx
@@ -21,9 +21,12 @@ export default class Demo extends React.PureComponent {
     this.state = {
       columns: [
         { name: 'name', title: 'Name' },
-        { name: 'sex', title: 'Sex', width: 100 },
+        { name: 'sex', title: 'Sex' },
         { name: 'city', title: 'City' },
         { name: 'car', title: 'Car' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'sex', width: 100 },
       ],
       rows: generateRows({ length: 6 }),
       hiddenColumns: ['sex', 'car'],
@@ -35,7 +38,9 @@ export default class Demo extends React.PureComponent {
   }
 
   render() {
-    const { columns, rows, hiddenColumns } = this.state;
+    const {
+      columns, rows, hiddenColumns, tableColumnExtensions,
+    } = this.state;
     return (
       <MUIGrid container>
         <MUIGrid item xs={12} sm={9}>
@@ -44,7 +49,9 @@ export default class Demo extends React.PureComponent {
               rows={rows}
               columns={columns}
             >
-              <Table />
+              <Table
+                columnExtensions={tableColumnExtensions}
+              />
               <TableHeaderRow />
               <TableColumnVisibility
                 hiddenColumns={hiddenColumns}

--- a/packages/dx-react-demos/src/material-ui/column-reordering/controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-reordering/controlled.jsx
@@ -18,9 +18,12 @@ export default class Demo extends React.PureComponent {
     this.state = {
       columns: [
         { name: 'name', title: 'Name' },
-        { name: 'sex', title: 'Sex', width: 100 },
+        { name: 'sex', title: 'Sex' },
         { name: 'city', title: 'City' },
         { name: 'car', title: 'Car' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'sex', width: 100 },
       ],
       rows: generateRows({ length: 6 }),
       columnOrder: ['city', 'sex', 'car', 'name'],
@@ -32,7 +35,9 @@ export default class Demo extends React.PureComponent {
     this.setState({ columnOrder: newOrder });
   }
   render() {
-    const { rows, columns, columnOrder } = this.state;
+    const {
+      rows, columns, tableColumnExtensions, columnOrder,
+    } = this.state;
 
     return (
       <Paper>
@@ -41,7 +46,9 @@ export default class Demo extends React.PureComponent {
           columns={columns}
         >
           <DragDropContext />
-          <Table />
+          <Table
+            columnExtensions={tableColumnExtensions}
+          />
           <TableColumnReordering
             order={columnOrder}
             onOrderChange={this.changeColumnOrder}

--- a/packages/dx-react-demos/src/material-ui/column-reordering/uncontrolled.jsx
+++ b/packages/dx-react-demos/src/material-ui/column-reordering/uncontrolled.jsx
@@ -18,15 +18,18 @@ export default class Demo extends React.PureComponent {
     this.state = {
       columns: [
         { name: 'name', title: 'Name' },
-        { name: 'sex', title: 'Sex', width: 100 },
+        { name: 'sex', title: 'Sex' },
         { name: 'city', title: 'City' },
         { name: 'car', title: 'Car' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'sex', width: 100 },
       ],
       rows: generateRows({ length: 6 }),
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, tableColumnExtensions } = this.state;
 
     return (
       <Paper>
@@ -35,7 +38,9 @@ export default class Demo extends React.PureComponent {
           columns={columns}
         >
           <DragDropContext />
-          <Table />
+          <Table
+            columnExtensions={tableColumnExtensions}
+          />
           <TableColumnReordering
             defaultOrder={['city', 'sex', 'car', 'name']}
           />

--- a/packages/dx-react-demos/src/material-ui/data-types/formatters.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-types/formatters.jsx
@@ -51,15 +51,16 @@ export default class Demo extends React.PureComponent {
         { name: 'customer', title: 'Customer' },
         { name: 'product', title: 'Product' },
         { name: 'saleDate', title: 'Sale Date', dataType: 'date' },
-        {
-          name: 'amount', title: 'Sale Amount', dataType: 'currency', align: 'right',
-        },
+        { name: 'amount', title: 'Sale Amount', dataType: 'currency' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'amount', align: 'right' },
       ],
       rows: generateRows({ columnValues: globalSalesValues, length: 14 }),
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, tableColumnExtensions } = this.state;
 
     return (
       <Paper>
@@ -69,7 +70,9 @@ export default class Demo extends React.PureComponent {
         >
           <CurrencyTypeProvider />
           <DateTypeProvider />
-          <Table />
+          <Table
+            columnExtensions={tableColumnExtensions}
+          />
           <TableHeaderRow />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/editing/edit-row-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/editing/edit-row-controlled.jsx
@@ -23,11 +23,14 @@ export default class Demo extends React.PureComponent {
 
     this.state = {
       columns: [
-        { name: 'id', title: 'ID', width: 60 },
+        { name: 'id', title: 'ID' },
         { name: 'name', title: 'Name' },
         { name: 'sex', title: 'Sex' },
         { name: 'city', title: 'City' },
         { name: 'car', title: 'Car' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'id', width: 60 },
       ],
       rows: generateRows({
         columnValues: { id: ({ index }) => index, ...defaultColumnValues },
@@ -76,7 +79,7 @@ export default class Demo extends React.PureComponent {
   }
   render() {
     const {
-      rows, columns, editingRows, changedRows, addedRows,
+      rows, columns, tableColumnExtensions, editingRows, changedRows, addedRows,
     } = this.state;
 
     return (
@@ -95,7 +98,9 @@ export default class Demo extends React.PureComponent {
             onAddedRowsChange={this.changeAddedRows}
             onCommitChanges={this.commitChanges}
           />
-          <Table />
+          <Table
+            columnExtensions={tableColumnExtensions}
+          />
           <TableHeaderRow />
           <TableEditRow />
           <TableEditColumn

--- a/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
@@ -167,6 +167,19 @@ LookupEditCellBase.defaultProps = {
 };
 export const LookupEditCell = withStyles(styles, { name: 'ControlledModeDemo' })(LookupEditCellBase);
 
+const Cell = (props) => {
+  if (props.column.name === 'discount') {
+    return <ProgressBarCell {...props} />;
+  }
+  if (props.column.name === 'amount') {
+    return <HighlightedCell {...props} />;
+  }
+  return <Table.Cell {...props} />;
+};
+Cell.propTypes = {
+  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
+};
+
 const EditCell = (props) => {
   const availableColumnValues = availableValues[props.column.name];
   if (availableColumnValues) {
@@ -194,8 +207,7 @@ class DemoBase extends React.PureComponent {
         { name: 'customer', title: 'Customer' },
       ],
       tableColumnExtensions: [
-        { columnName: 'amount', align: 'right', cellComponent: HighlightedCell },
-        { columnName: 'discount', cellComponent: ProgressBarCell },
+        { columnName: 'amount', align: 'right' },
       ],
       rows: generateRows({
         columnValues: { id: ({ index }) => index, ...globalSalesValues },
@@ -313,6 +325,7 @@ class DemoBase extends React.PureComponent {
 
           <Table
             columnExtensions={tableColumnExtensions}
+            cellComponent={Cell}
           />
 
           <TableColumnReordering
@@ -353,6 +366,7 @@ class DemoBase extends React.PureComponent {
               >
                 <Table
                   columnExtensions={tableColumnExtensions}
+                  cellComponent={Cell}
                 />
                 <TableHeaderRow />
               </Grid>

--- a/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
@@ -167,19 +167,6 @@ LookupEditCellBase.defaultProps = {
 };
 export const LookupEditCell = withStyles(styles, { name: 'ControlledModeDemo' })(LookupEditCellBase);
 
-const Cell = (props) => {
-  if (props.column.name === 'discount') {
-    return <ProgressBarCell {...props} />;
-  }
-  if (props.column.name === 'amount') {
-    return <HighlightedCell {...props} />;
-  }
-  return <Table.Cell {...props} />;
-};
-Cell.propTypes = {
-  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
-};
-
 const EditCell = (props) => {
   const availableColumnValues = availableValues[props.column.name];
   if (availableColumnValues) {
@@ -200,13 +187,15 @@ class DemoBase extends React.PureComponent {
     this.state = {
       columns: [
         { name: 'product', title: 'Product' },
-        { name: 'region', title: 'Region', width: 110 },
-        {
-          name: 'amount', title: 'Amount', align: 'right', width: 90,
-        },
-        { name: 'discount', title: 'Discount', width: 110 },
+        { name: 'region', title: 'Region' },
+        { name: 'amount', title: 'Sale Amount' },
+        { name: 'discount', title: 'Discount' },
         { name: 'saleDate', title: 'Sale Date' },
         { name: 'customer', title: 'Customer' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'amount', align: 'right', cellComponent: HighlightedCell },
+        { columnName: 'discount', cellComponent: ProgressBarCell },
       ],
       rows: generateRows({
         columnValues: { id: ({ index }) => index, ...globalSalesValues },
@@ -277,6 +266,7 @@ class DemoBase extends React.PureComponent {
     const {
       rows,
       columns,
+      tableColumnExtensions,
       sorting,
       editingRows,
       addedRows,
@@ -322,7 +312,7 @@ class DemoBase extends React.PureComponent {
           <DragDropContext />
 
           <Table
-            cellComponent={Cell}
+            columnExtensions={tableColumnExtensions}
           />
 
           <TableColumnReordering
@@ -362,7 +352,7 @@ class DemoBase extends React.PureComponent {
                 columns={columns}
               >
                 <Table
-                  cellComponent={Cell}
+                  columnExtensions={tableColumnExtensions}
                 />
                 <TableHeaderRow />
               </Grid>

--- a/packages/dx-react-demos/src/material-ui/featured-redux-integration/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-redux-integration/demo.jsx
@@ -20,6 +20,28 @@ import {
   employeeTaskValues,
 } from '../../demo-data/generator';
 
+const columns = [
+  { name: 'prefix', title: 'Title' },
+  { name: 'firstName', title: 'First Name' },
+  { name: 'lastName', title: 'Last Name' },
+  { name: 'position', title: 'Position' },
+  { name: 'state', title: 'State' },
+  { name: 'birthDate', title: 'Birth Date' },
+];
+const detailColumns = [
+  { name: 'subject', title: 'Subject' },
+  { name: 'startDate', title: 'Start Date' },
+  { name: 'dueDate', title: 'Due Date' },
+  { name: 'priority', title: 'Priority' },
+  { name: 'status', title: 'Status' },
+];
+const tableDetailColumnExtensions = [
+  { columnName: 'startDate', width: 115 },
+  { columnName: 'dueDate', width: 115 },
+  { columnName: 'priority', width: 100 },
+  { columnName: 'status', width: 125 },
+];
+
 const styles = {
   detailContainer: {
     margin: 20,
@@ -28,11 +50,7 @@ const styles = {
 
 export const GRID_STATE_CHANGE_ACTION = 'GRID_STATE_CHANGE';
 
-const GridDetailContainerBase = ({
-  detailColumns,
-  row,
-  classes,
-}) => (
+const GridDetailContainerBase = ({ row, classes }) => (
   <div className={classes.detailContainer}>
     <div>
       <h5>{row.firstName} {row.lastName}&apos;s Tasks:</h5>
@@ -42,7 +60,9 @@ const GridDetailContainerBase = ({
         rows={row.tasks}
         columns={detailColumns}
       >
-        <Table />
+        <Table
+          columnExtensions={tableDetailColumnExtensions}
+        />
         <TableHeaderRow />
       </Grid>
     </Paper>
@@ -50,7 +70,6 @@ const GridDetailContainerBase = ({
 );
 GridDetailContainerBase.propTypes = {
   row: PropTypes.object.isRequired,
-  detailColumns: PropTypes.array.isRequired,
   classes: PropTypes.object.isRequired,
 };
 
@@ -60,8 +79,6 @@ const ReduxGridDetailContainer = connect(state => state)(GridDetailContainer);
 
 const GridContainer = ({
   rows,
-  columns,
-
   sorting,
   onSortingChange,
   selection,
@@ -155,7 +172,6 @@ const GridContainer = ({
 
 GridContainer.propTypes = {
   rows: PropTypes.array.isRequired,
-  columns: PropTypes.array.isRequired,
   sorting: PropTypes.array.isRequired,
   onSortingChange: PropTypes.func.isRequired,
   selection: PropTypes.array.isRequired,
@@ -180,23 +196,6 @@ GridContainer.propTypes = {
 };
 
 const gridInitialState = {
-  columns: [
-    { name: 'prefix', title: 'Title', width: 100 },
-    { name: 'firstName', title: 'First Name' },
-    { name: 'lastName', title: 'Last Name' },
-    { name: 'position', title: 'Position', width: 160 },
-    { name: 'state', title: 'State', width: 125 },
-    { name: 'birthDate', title: 'Birth Date', width: 135 },
-  ],
-  detailColumns: [
-    { name: 'subject', title: 'Subject' },
-    { name: 'startDate', title: 'Start Date', width: 115 },
-    { name: 'dueDate', title: 'Due Date', width: 115 },
-    { name: 'priority', title: 'Priority', width: 100 },
-    {
-      name: 'status', title: 'Status', caption: 'Completed', width: 125,
-    },
-  ],
   rows: generateRows({
     columnValues: {
       ...employeeValues,

--- a/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
@@ -35,28 +35,22 @@ SaleAmountCellBase.propTypes = {
 };
 const SaleAmountCell = withStyles(styles)(SaleAmountCellBase);
 
-const Cell = (props) => {
-  if (props.column.name === 'SaleAmount') {
-    return <SaleAmountCell {...props} />;
-  }
-  return <Table.Cell {...props} />;
-};
-Cell.propTypes = {
-  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
-};
-
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
 
     this.state = {
       columns: [
-        { name: 'OrderNumber', title: 'Order #', align: 'right' },
+        { name: 'OrderNumber', title: 'Order #' },
         { name: 'OrderDate', title: 'Order Date' },
         { name: 'StoreCity', title: 'Store City' },
         { name: 'StoreState', title: 'Store State' },
         { name: 'Employee', title: 'Employee' },
-        { name: 'SaleAmount', title: 'Sale Amount', align: 'right' },
+        { name: 'SaleAmount', title: 'Sale Amount' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'OrderNumber', align: 'right' },
+        { columnName: 'SaleAmount', align: 'right', cellComponent: SaleAmountCell },
       ],
       rows: [],
       sorting: [{ columnName: 'StoreCity', direction: 'asc' }],
@@ -133,6 +127,7 @@ export default class Demo extends React.PureComponent {
     const {
       rows,
       columns,
+      tableColumnExtensions,
       sorting,
       pageSize,
       allowedPageSizes,
@@ -159,7 +154,7 @@ export default class Demo extends React.PureComponent {
             totalCount={totalCount}
           />
           <Table
-            cellComponent={Cell}
+            columnExtensions={tableColumnExtensions}
           />
           <TableHeaderRow allowSorting />
           <PagingPanel

--- a/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
@@ -35,6 +35,16 @@ SaleAmountCellBase.propTypes = {
 };
 const SaleAmountCell = withStyles(styles)(SaleAmountCellBase);
 
+const Cell = (props) => {
+  if (props.column.name === 'SaleAmount') {
+    return <SaleAmountCell {...props} />;
+  }
+  return <Table.Cell {...props} />;
+};
+Cell.propTypes = {
+  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
+};
+
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -50,7 +60,7 @@ export default class Demo extends React.PureComponent {
       ],
       tableColumnExtensions: [
         { columnName: 'OrderNumber', align: 'right' },
-        { columnName: 'SaleAmount', align: 'right', cellComponent: SaleAmountCell },
+        { columnName: 'SaleAmount', align: 'right' },
       ],
       rows: [],
       sorting: [{ columnName: 'StoreCity', direction: 'asc' }],
@@ -155,6 +165,7 @@ export default class Demo extends React.PureComponent {
           />
           <Table
             columnExtensions={tableColumnExtensions}
+            cellComponent={Cell}
           />
           <TableHeaderRow allowSorting />
           <PagingPanel

--- a/packages/dx-react-demos/src/material-ui/featured-theming/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-theming/demo.jsx
@@ -158,11 +158,16 @@ export default class Demo extends React.PureComponent {
 
     this.state = {
       columns: [
-        { name: 'prefix', title: 'Title', width: 100 },
+        { name: 'prefix', title: 'Title' },
         { name: 'firstName', title: 'First Name' },
         { name: 'lastName', title: 'Last Name' },
-        { name: 'position', title: 'Position', width: 170 },
-        { name: 'state', title: 'State', width: 125 },
+        { name: 'position', title: 'Position' },
+        { name: 'state', title: 'State' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'prefix', width: 100 },
+        { columnName: 'position', width: 170 },
+        { columnName: 'state', width: 125 },
       ],
       rows: generateRows({
         columnValues: {
@@ -179,7 +184,9 @@ export default class Demo extends React.PureComponent {
     };
   }
   render() {
-    const { rows, columns, allowedPageSizes } = this.state;
+    const {
+      rows, columns, tableColumnExtensions, allowedPageSizes,
+    } = this.state;
 
     return (
       <Paper>
@@ -207,7 +214,9 @@ export default class Demo extends React.PureComponent {
 
           <DragDropContext />
 
-          <Table />
+          <Table
+            columnExtensions={tableColumnExtensions}
+          />
 
           <TableColumnReordering defaultOrder={columns.map(column => column.name)} />
 

--- a/packages/dx-react-demos/src/material-ui/featured-uncontrolled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-uncontrolled-mode/demo.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Paper from 'material-ui/Paper';
 import {
   SortingState, SelectionState, FilteringState, PagingState, GroupingState,
@@ -22,6 +23,19 @@ import {
   globalSalesValues,
 } from '../../demo-data/generator';
 
+const Cell = (props) => {
+  if (props.column.name === 'discount') {
+    return <ProgressBarCell {...props} />;
+  }
+  if (props.column.name === 'amount') {
+    return <HighlightedCell {...props} />;
+  }
+  return <Table.Cell {...props} />;
+};
+Cell.propTypes = {
+  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
+};
+
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -36,8 +50,7 @@ export default class Demo extends React.PureComponent {
         { name: 'customer', title: 'Customer' },
       ],
       tableColumnExtensions: [
-        { columnName: 'amount', align: 'right', cellComponent: HighlightedCell },
-        { columnName: 'discount', cellComponent: ProgressBarCell },
+        { columnName: 'amount', align: 'right' },
       ],
       rows: generateRows({ columnValues: globalSalesValues, length: 1000 }),
       pageSizes: [5, 10, 15],
@@ -86,6 +99,7 @@ export default class Demo extends React.PureComponent {
 
           <Table
             columnExtensions={tableColumnExtensions}
+            cellComponent={Cell}
           />
           <TableSelection showSelectAll />
 

--- a/packages/dx-react-demos/src/material-ui/featured-uncontrolled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-uncontrolled-mode/demo.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Paper from 'material-ui/Paper';
 import {
   SortingState, SelectionState, FilteringState, PagingState, GroupingState,
@@ -23,19 +22,6 @@ import {
   globalSalesValues,
 } from '../../demo-data/generator';
 
-const Cell = (props) => {
-  if (props.column.name === 'discount') {
-    return <ProgressBarCell {...props} />;
-  }
-  if (props.column.name === 'amount') {
-    return <HighlightedCell {...props} />;
-  }
-  return <Table.Cell {...props} />;
-};
-Cell.propTypes = {
-  column: PropTypes.shape({ name: PropTypes.string }).isRequired,
-};
-
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -44,17 +30,23 @@ export default class Demo extends React.PureComponent {
       columns: [
         { name: 'product', title: 'Product' },
         { name: 'region', title: 'Region' },
-        { name: 'amount', title: 'Sale Amount', align: 'right' },
+        { name: 'amount', title: 'Sale Amount' },
         { name: 'discount', title: 'Discount' },
         { name: 'saleDate', title: 'Sale Date' },
         { name: 'customer', title: 'Customer' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'amount', align: 'right', cellComponent: HighlightedCell },
+        { columnName: 'discount', cellComponent: ProgressBarCell },
       ],
       rows: generateRows({ columnValues: globalSalesValues, length: 1000 }),
       allowedPageSizes: [5, 10, 15],
     };
   }
   render() {
-    const { rows, columns, allowedPageSizes } = this.state;
+    const {
+      rows, columns, tableColumnExtensions, allowedPageSizes,
+    } = this.state;
 
     return (
       <Paper>
@@ -93,7 +85,7 @@ export default class Demo extends React.PureComponent {
           <DragDropContext />
 
           <Table
-            cellComponent={Cell}
+            columnExtensions={tableColumnExtensions}
           />
           <TableSelection showSelectAll />
 

--- a/packages/dx-react-demos/src/material-ui/featured-virtual-scrolling/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-virtual-scrolling/demo.jsx
@@ -52,8 +52,8 @@ export default class Demo extends React.PureComponent {
         { name: 'customer', title: 'Customer' },
       ],
       tableColumnExtensions: [
-        { columnName: 'amount', align: 'right', cellComponent: HighlightedCell },
-        { columnName: 'discount', cellComponent: ProgressBarCell },
+        { columnName: 'amount', align: 'right' },
+        { columnName: 'discount' },
       ],
       rows: generateRows({
         columnValues: { id: ({ index }) => index, ...globalSalesValues },
@@ -95,6 +95,7 @@ export default class Demo extends React.PureComponent {
 
           <VirtualTable
             columnExtensions={tableColumnExtensions}
+            cellComponent={Cell}
           />
           <TableHeaderRow allowSorting allowDragging />
           <TableColumnReordering defaultOrder={columns.map(column => column.name)} />

--- a/packages/dx-react-demos/src/material-ui/featured-virtual-scrolling/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-virtual-scrolling/demo.jsx
@@ -46,10 +46,14 @@ export default class Demo extends React.PureComponent {
       columns: [
         { name: 'product', title: 'Product' },
         { name: 'region', title: 'Region' },
-        { name: 'amount', title: 'Sale Amount', align: 'right' },
+        { name: 'amount', title: 'Sale Amount' },
         { name: 'discount', title: 'Discount' },
         { name: 'saleDate', title: 'Sale Date' },
         { name: 'customer', title: 'Customer' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'amount', align: 'right', cellComponent: HighlightedCell },
+        { columnName: 'discount', cellComponent: ProgressBarCell },
       ],
       rows: generateRows({
         columnValues: { id: ({ index }) => index, ...globalSalesValues },
@@ -58,7 +62,7 @@ export default class Demo extends React.PureComponent {
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, tableColumnExtensions } = this.state;
 
     return (
       <Paper>
@@ -90,7 +94,7 @@ export default class Demo extends React.PureComponent {
           <LocalSelection />
 
           <VirtualTable
-            cellComponent={Cell}
+            columnExtensions={tableColumnExtensions}
           />
           <TableHeaderRow allowSorting allowDragging />
           <TableColumnReordering defaultOrder={columns.map(column => column.name)} />

--- a/packages/dx-react-demos/src/material-ui/filtering/custom-filter-row.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/custom-filter-row.jsx
@@ -81,13 +81,16 @@ export default class Demo extends React.PureComponent {
         { name: 'product', title: 'Product' },
         { name: 'region', title: 'Region' },
         { name: 'sector', title: 'Sector' },
-        { name: 'units', title: 'Quantity', align: 'right' },
+        { name: 'units', title: 'Quantity' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'units', align: 'right' },
       ],
       rows: generateRows({ columnValues: globalSalesValues, length: 14 }),
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, tableColumnExtensions } = this.state;
 
     return (
       <Paper>
@@ -97,7 +100,9 @@ export default class Demo extends React.PureComponent {
         >
           <FilteringState defaultFilters={[{ columnName: 'units', value: 2 }]} />
           <LocalFiltering />
-          <Table />
+          <Table
+            columnExtensions={tableColumnExtensions}
+          />
           <TableHeaderRow />
           <TableFilterRow
             cellComponent={FilterCell}

--- a/packages/dx-react-demos/src/material-ui/sorting/local-custom-sorting.jsx
+++ b/packages/dx-react-demos/src/material-ui/sorting/local-custom-sorting.jsx
@@ -38,10 +38,13 @@ export default class Demo extends React.PureComponent {
 
     this.state = {
       columns: [
-        { name: 'subject', title: 'Subject', width: 300 },
+        { name: 'subject', title: 'Subject' },
         { name: 'startDate', title: 'Start Date' },
         { name: 'dueDate', title: 'Due Date' },
         { name: 'priority', title: 'Priority' },
+      ],
+      tableColumnExtensions: [
+        { columnName: 'subject', width: 300 },
       ],
       rows: generateRows({
         columnValues: employeeTaskValues,
@@ -50,7 +53,7 @@ export default class Demo extends React.PureComponent {
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, tableColumnExtensions } = this.state;
 
     return (
       <Paper>
@@ -62,7 +65,9 @@ export default class Demo extends React.PureComponent {
           <LocalSorting
             getColumnCompare={getColumnCompare}
           />
-          <Table />
+          <Table
+            columnExtensions={tableColumnExtensions}
+          />
           <TableHeaderRow allowSorting />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/templates/highlighted-cell.jsx
+++ b/packages/dx-react-demos/src/material-ui/templates/highlighted-cell.jsx
@@ -25,13 +25,13 @@ const styles = theme => ({
 });
 
 const HighlightedCellBase = ({
-  column, value, classes, style,
+  tableColumn, value, classes, style,
 }) => (
   <TableCell
     className={classes.highlightedCell}
     style={{
       color: getColor(value),
-      textAlign: column.align,
+      textAlign: tableColumn.align,
       ...style,
     }}
   >
@@ -43,11 +43,11 @@ HighlightedCellBase.propTypes = {
   value: PropTypes.number.isRequired,
   classes: PropTypes.object.isRequired,
   style: PropTypes.object,
-  column: PropTypes.object,
+  tableColumn: PropTypes.object,
 };
 HighlightedCellBase.defaultProps = {
   style: {},
-  column: {},
+  tableColumn: {},
 };
 
 export const HighlightedCell = withStyles(styles, { name: 'HighlightedCell' })(HighlightedCellBase);

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-cell.jsx
@@ -11,7 +11,7 @@ export const TableCell = ({
       whiteSpace: 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
-      textAlign: column.align || 'left',
+      textAlign: (tableColumn && tableColumn.align) || 'left',
       ...style,
     }}
     {...restProps}
@@ -36,7 +36,7 @@ TableCell.propTypes = {
 TableCell.defaultProps = {
   style: null,
   value: undefined,
-  column: {},
+  column: undefined,
   row: undefined,
   children: undefined,
   tableRow: undefined,

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-cell.test.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-cell.test.jsx
@@ -3,27 +3,19 @@ import { shallow } from 'enzyme';
 import { TableCell } from './table-cell';
 
 describe('TableCell', () => {
-  const mountTableCell = column =>
-    shallow((
-      <TableCell
-        column={column}
-        value="text"
-      />
-    ));
-
   it('should have correct text alignment', () => {
-    let tree = mountTableCell({});
+    let tree = shallow(<TableCell />);
     expect(tree.find('td').prop('style').textAlign).toBe('left');
 
-    tree = mountTableCell({ align: 'left' });
+    tree = shallow(<TableCell tableColumn={{ align: 'left' }} />);
     expect(tree.find('td').prop('style').textAlign).toBe('left');
 
-    tree = mountTableCell({ align: 'right' });
+    tree = shallow(<TableCell tableColumn={{ align: 'right' }} />);
     expect(tree.find('td').prop('style').textAlign).toBe('right');
   });
 
   it('should have correct text', () => {
-    const tree = mountTableCell({});
+    const tree = shallow(<TableCell value="text" />);
     expect(tree.find('td').text()).toBe('text');
   });
 

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-edit-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-edit-cell.jsx
@@ -19,7 +19,10 @@ export const EditCell = ({
         className="form-control"
         value={value}
         onChange={e => onValueChange(e.target.value)}
-        style={{ width: '100%', textAlign: column.align }}
+        style={{
+          width: '100%',
+          textAlign: tableColumn && tableColumn.align,
+        }}
       />
     )}
   </td>
@@ -38,7 +41,7 @@ EditCell.propTypes = {
   ]),
 };
 EditCell.defaultProps = {
-  column: {},
+  column: undefined,
   row: undefined,
   tableColumn: undefined,
   tableRow: undefined,

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.jsx
@@ -46,8 +46,8 @@ export class TableHeaderCell extends React.PureComponent {
       ...restProps
     } = this.props;
     const { dragging } = this.state;
-    const align = column.align || 'left';
-    const columnTitle = column.title || column.name;
+    const align = (tableColumn && tableColumn.align) || 'left';
+    const columnTitle = column && (column.title || column.name);
 
     const cellLayout = (
       <th
@@ -59,7 +59,7 @@ export class TableHeaderCell extends React.PureComponent {
             WebkitUserSelect: 'none',
           } : {}),
           ...(allowSorting || allowDragging ? { cursor: 'pointer' } : null),
-          ...(dragging || tableColumn.draft ? { opacity: 0.3 } : null),
+          ...(dragging || (tableColumn && tableColumn.draft) ? { opacity: 0.3 } : null),
           padding: '5px',
           ...style,
         }}
@@ -74,7 +74,9 @@ export class TableHeaderCell extends React.PureComponent {
         )}
         <div
           style={{
-            ...(allowGroupingByClick ? { [`margin${column.align === 'right' ? 'Left' : 'Right'}`]: '14px' } : null),
+            ...(allowGroupingByClick
+              ? { [`margin${align === 'right' ? 'Left' : 'Right'}`]: '14px' }
+              : null),
             textAlign: align,
             whiteSpace: 'nowrap',
             overflow: 'hidden',
@@ -118,9 +120,7 @@ export class TableHeaderCell extends React.PureComponent {
 TableHeaderCell.propTypes = {
   tableColumn: PropTypes.object,
   tableRow: PropTypes.object,
-  column: PropTypes.shape({
-    title: PropTypes.string,
-  }).isRequired,
+  column: PropTypes.object,
   style: PropTypes.object,
   allowSorting: PropTypes.bool,
   sortingDirection: PropTypes.oneOf(['asc', 'desc', null]),
@@ -136,7 +136,8 @@ TableHeaderCell.propTypes = {
 };
 
 TableHeaderCell.defaultProps = {
-  tableColumn: {},
+  column: undefined,
+  tableColumn: undefined,
   tableRow: undefined,
   style: null,
   allowSorting: false,

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.test.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.test.jsx
@@ -181,7 +181,7 @@ describe('TableHeaderCell', () => {
   it('should have correct styles when grouping by click is not allowed and column align is right', () => {
     const tree = shallow((
       <TableHeaderCell
-        column={{ align: 'right' }}
+        tableColumn={{ align: 'right' }}
         allowGroupingByClick={false}
       />
     ));
@@ -197,7 +197,7 @@ describe('TableHeaderCell', () => {
   it('should have correct styles when grouping by click is allowed and column align is right', () => {
     const tree = shallow((
       <TableHeaderCell
-        column={{ align: 'right' }}
+        tableColumn={{ align: 'right' }}
         allowGroupingByClick
       />
     ));
@@ -232,7 +232,8 @@ describe('TableHeaderCell', () => {
       const tree = mount((
         <TableHeaderCell
           onSort={onSort}
-          column={{ align: 'right', title: 'test' }}
+          column={{ title: 'test' }}
+          tableColumn={{ align: 'right' }}
           allowSorting
         />
       ));
@@ -258,7 +259,8 @@ describe('TableHeaderCell', () => {
       const tree = mount((
         <TableHeaderCell
           onSort={onSort}
-          column={{ align: 'right', title: 'test' }}
+          column={{ title: 'test' }}
+          tableColumn={{ align: 'right' }}
           allowSorting
         />
       ));
@@ -274,7 +276,8 @@ describe('TableHeaderCell', () => {
       const tree = mount((
         <TableHeaderCell
           onSort={onSort}
-          column={{ align: 'right', title: 'test' }}
+          column={{ title: 'test' }}
+          tableColumn={{ align: 'right' }}
           allowSorting
         />
       ));

--- a/packages/dx-react-grid-material-ui/src/templates/table-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-cell.jsx
@@ -35,7 +35,7 @@ const TableCellBase = ({
     }}
     className={classNames({
       [classes.cell]: true,
-      [classes.cellRightAlign]: column.align === 'right',
+      [classes.cellRightAlign]: tableColumn && tableColumn.align === 'right',
     }, className)}
     {...restProps}
   >
@@ -61,7 +61,7 @@ TableCellBase.propTypes = {
 TableCellBase.defaultProps = {
   style: null,
   value: undefined,
-  column: {},
+  column: undefined,
   row: undefined,
   children: undefined,
   tableRow: undefined,

--- a/packages/dx-react-grid-material-ui/src/templates/table-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-cell.test.jsx
@@ -6,31 +6,24 @@ import { TableCell } from './table-cell';
 describe('TableCell', () => {
   let classes;
   let shallow;
-  const mountTableCell = column =>
-    shallow((
-      <TableCell
-        column={column}
-        value="text"
-      />
-    ));
   beforeAll(() => {
     classes = getClasses(<TableCell />);
     shallow = createShallow({ dive: true });
   });
 
   it('should have correct text alignment', () => {
-    let tree = mountTableCell({});
+    let tree = shallow(<TableCell />);
     expect(tree.find(TableCellMUI).hasClass(classes.cellRightAlign)).toBeFalsy();
 
-    tree = mountTableCell({ align: 'left' });
+    tree = shallow(<TableCell tableColumn={{ align: 'left' }} />);
     expect(tree.find(TableCellMUI).hasClass(classes.cellRightAlign)).toBeFalsy();
 
-    tree = mountTableCell({ align: 'right' });
+    tree = shallow(<TableCell tableColumn={{ align: 'right' }} />);
     expect(tree.find(TableCellMUI).hasClass(classes.cellRightAlign)).toBeTruthy();
   });
 
   it('should have correct text', () => {
-    const tree = mountTableCell({});
+    const tree = shallow(<TableCell value="text" />);
     expect(tree.childAt(0).text()).toBe('text');
   });
 

--- a/packages/dx-react-grid-material-ui/src/templates/table-edit-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-edit-cell.jsx
@@ -28,7 +28,7 @@ const EditCellBase = ({
   row, tableRow, tableColumn, className, ...restProps
 }) => {
   const inputClasses = classNames({
-    [classes.inputRight]: column.align === 'right',
+    [classes.inputRight]: tableColumn && tableColumn.align === 'right',
   });
 
   return (
@@ -66,7 +66,7 @@ EditCellBase.propTypes = {
 };
 
 EditCellBase.defaultProps = {
-  column: {},
+  column: undefined,
   row: undefined,
   tableRow: undefined,
   tableColumn: undefined,

--- a/packages/dx-react-grid-material-ui/src/templates/table-edit-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-edit-cell.test.jsx
@@ -62,7 +62,7 @@ describe('EditCell', () => {
       <EditCell
         value=""
         onValueChange={() => {}}
-        column={{ align: 'right' }}
+        tableColumn={{ align: 'right' }}
       />
     ));
     const inputRoot = tree.find(Input);

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell.jsx
@@ -84,8 +84,8 @@ class TableHeaderCellBase extends React.PureComponent {
     } = this.props;
 
     const { dragging } = this.state;
-    const align = column.align || 'left';
-    const columnTitle = column.title || column.name;
+    const align = (tableColumn && tableColumn.align) || 'left';
+    const columnTitle = column && (column.title || column.name);
     const tooltipText = getMessage('sortingHint');
 
     const tableCellClasses = classNames({
@@ -93,7 +93,7 @@ class TableHeaderCellBase extends React.PureComponent {
       [classes.cellRight]: align === 'right',
       [classes.cellNoUserSelect]: allowDragging || allowSorting,
       [classes.cellDraggable]: allowDragging,
-      [classes.cellDimmed]: dragging || tableColumn.draft,
+      [classes.cellDimmed]: dragging || (tableColumn && tableColumn.draft),
     }, className);
     const cellLayout = (
       <TableCell
@@ -147,9 +147,7 @@ class TableHeaderCellBase extends React.PureComponent {
 TableHeaderCellBase.propTypes = {
   tableColumn: PropTypes.object,
   tableRow: PropTypes.object,
-  column: PropTypes.shape({
-    title: PropTypes.string,
-  }).isRequired,
+  column: PropTypes.object,
   style: PropTypes.object,
   allowSorting: PropTypes.bool,
   sortingDirection: PropTypes.oneOf(['asc', 'desc', null]),
@@ -167,7 +165,8 @@ TableHeaderCellBase.propTypes = {
 };
 
 TableHeaderCellBase.defaultProps = {
-  tableColumn: {},
+  column: undefined,
+  tableColumn: undefined,
   tableRow: undefined,
   style: null,
   allowSorting: false,

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell.test.jsx
@@ -70,7 +70,6 @@ describe('TableHeaderCell', () => {
   it('should have correct styles when user interaction disallowed', () => {
     const tree = shallow((
       <TableHeaderCell
-        column={{}}
         getMessage={jest.fn()}
       />
     ));
@@ -95,7 +94,6 @@ describe('TableHeaderCell', () => {
     const tree = mount((
       <DragDropContext>
         <TableHeaderCell
-          column={{}}
           allowDragging
           getMessage={jest.fn()}
         />
@@ -110,7 +108,6 @@ describe('TableHeaderCell', () => {
     const tree = mount((
       <DragDropContext>
         <TableHeaderCell
-          column={{}}
           allowDragging
           getMessage={jest.fn()}
         />
@@ -133,7 +130,6 @@ describe('TableHeaderCell', () => {
     const onDraftWidthChange = () => {};
     const tree = shallow((
       <TableHeaderCell
-        column={{}}
         allowResizing
         onDraftWidthChange={onDraftWidthChange}
         onWidthChange={onWidthChange}
@@ -153,7 +149,8 @@ describe('TableHeaderCell', () => {
     const tree = mount((
       <TableHeaderCell
         allowSorting
-        column={{ align: 'right', title: 'test' }}
+        tableColumn={{ align: 'right' }}
+        column={{ title: 'test' }}
         getMessage={() => {}}
       />
     ));
@@ -200,7 +197,7 @@ describe('TableHeaderCell', () => {
     it('can not get focus if sorting is not allow', () => {
       const tree = mount((
         <TableHeaderCell
-          column={{ align: 'right', title: 'test' }}
+          column={{ title: 'text' }}
           getMessage={jest.fn()}
         />
       ));
@@ -212,7 +209,7 @@ describe('TableHeaderCell', () => {
     it('can get focus if sorting is allow', () => {
       const tree = mount((
         <TableHeaderCell
-          column={{ align: 'right', title: 'test' }}
+          column={{ title: 'text' }}
           allowSorting
           getMessage={jest.fn()}
         />
@@ -227,7 +224,7 @@ describe('TableHeaderCell', () => {
       const tree = mount((
         <TableHeaderCell
           onSort={onSort}
-          column={{ align: 'right', title: 'test' }}
+          column={{ title: 'text' }}
           allowSorting
           getMessage={jest.fn()}
         />
@@ -254,7 +251,7 @@ describe('TableHeaderCell', () => {
       const tree = mount((
         <TableHeaderCell
           onSort={onSort}
-          column={{ align: 'right', title: 'test' }}
+          column={{ title: 'text' }}
           allowSorting
           getMessage={jest.fn()}
         />
@@ -270,7 +267,7 @@ describe('TableHeaderCell', () => {
       const tree = mount((
         <TableHeaderCell
           onSort={onSort}
-          column={{ align: 'right', title: 'test' }}
+          column={{ title: 'text' }}
           allowSorting
           getMessage={jest.fn()}
         />

--- a/packages/dx-react-grid/docs/reference/table.md
+++ b/packages/dx-react-grid/docs/reference/table.md
@@ -13,7 +13,7 @@ A plugin that renders Grid data as a table. It contains the Table Row and Table 
 
 Name | Type | Default | Description
 -----|------|---------|------------
-columnExtensions | Array&lg;[TableColumnExtension](#tablecolumnextension)&gt; | | An array additional column properties that can be handled by the plugin.
+columnExtensions | Array&lg;[TableColumnExtension](#tablecolumnextension)&gt; | | Additional column properties that the plugin can handle.
 layoutComponent | ElementType&lt;[TableLayoutProps](#tablelayoutprops)&gt; | | A component that renders a table layout.
 cellComponent | ElementType&lt;[TableDataCellProps](#tabledatacellprops)&gt; | | A component that renders a table cell.
 rowComponent | ElementType&lt;[TableDataRowProps](#tabledatarowprops)&gt; | | A component that renders a table row.
@@ -27,15 +27,15 @@ messages | object | | An object that specifies the [localization messages](#loca
 
 ### TableColumnExtension
 
-Describes additional column properties that can be handled by the plugin.
+Describes additional column properties that the plugin can handle.
 
 A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-columnName | string | Specifies the name of the column to extend.
-width? | number | Specifies the table's column width in pixels.
-align? | 'left' &#124; 'right' | Specifies the table's column alignment.
+columnName | string | The name of the column to extend.
+width? | number | The table column width in pixels.
+align? | 'left' &#124; 'right' | The table column alignment.
 
 ### TableLayoutProps
 

--- a/packages/dx-react-grid/docs/reference/table.md
+++ b/packages/dx-react-grid/docs/reference/table.md
@@ -13,7 +13,7 @@ A plugin that renders Grid data as a table. It contains the Table Row and Table 
 
 Name | Type | Default | Description
 -----|------|---------|------------
-columnExtensions | Array&lg;[TableColumnExtension](#tablecolumnextension)&gt; | An array additional column properties that can be handled by the plugin.
+columnExtensions | Array&lg;[TableColumnExtension](#tablecolumnextension)&gt; | | An array additional column properties that can be handled by the plugin.
 layoutComponent | ElementType&lt;[TableLayoutProps](#tablelayoutprops)&gt; | | A component that renders a table layout.
 cellComponent | ElementType&lt;[TableDataCellProps](#tabledatacellprops)&gt; | | A component that renders a table cell.
 rowComponent | ElementType&lt;[TableDataRowProps](#tabledatarowprops)&gt; | | A component that renders a table row.

--- a/packages/dx-react-grid/docs/reference/table.md
+++ b/packages/dx-react-grid/docs/reference/table.md
@@ -13,6 +13,7 @@ A plugin that renders Grid data as a table. It contains the Table Row and Table 
 
 Name | Type | Default | Description
 -----|------|---------|------------
+columnExtensions | Array&lg;[TableColumnExtension](#tablecolumnextension)&gt; | An array additional column properties that can be handled by the plugin.
 layoutComponent | ElementType&lt;[TableLayoutProps](#tablelayoutprops)&gt; | | A component that renders a table layout.
 cellComponent | ElementType&lt;[TableDataCellProps](#tabledatacellprops)&gt; | | A component that renders a table cell.
 rowComponent | ElementType&lt;[TableDataRowProps](#tabledatarowprops)&gt; | | A component that renders a table row.
@@ -24,14 +25,18 @@ messages | object | | An object that specifies the [localization messages](#loca
 
 ## Interfaces
 
-### Column (Extension)
+### TableColumnExtension
 
-A value with a [Column](grid.md#column) shape extended by the following fields:
+Describes additional column properties that can be handled by the plugin.
+
+A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-align? | 'left' &#124; 'right' | Specifies the table's column alignment.
+columnName | string | Specifies the name of the column to extend.
 width? | number | Specifies the table's column width in pixels.
+align? | 'left' &#124; 'right' | Specifies the table's column alignment.
+cellComponent? | ElementType&lt;[TableDataCellProps](#tabledatacellprops)&gt; | | A component that renders a table cell for the table's column.
 
 ### TableLayoutProps
 
@@ -69,8 +74,9 @@ Field | Type | Description
 ------|------|------------
 key | string | A unique table column identifier.
 type | string | Specifies the table column type. The specified value defines which cell template is used to render the column.
-column? | [Column](#column-extension) | Specifies the associated user column.
+column? | [Column](grid.md#column) | Specifies the associated user column.
 width? | number | Specifies the table column width.
+align? | 'left' &#124; 'right' | Specifies the table's column alignment.
 
 ### TableCellProps
 
@@ -95,7 +101,7 @@ Field | Type | Description
 ------|------|------------
 value | any | Specifies a value to be rendered within the cell.
 row | any | Specifies the cell's row.
-column | [Column](#column-extension) | Specifies the cell's column.
+column | [Column](grid.md#column) | Specifies the cell's column.
 
 ### TableNoDataCellProps
 
@@ -155,7 +161,7 @@ If you specify additional properties, they are added to the component's root ele
 Name | Plugin | Type | Description
 -----|--------|------|------------
 rows | Getter | Array&lt;any&gt; | Rows to be rendered by the table view.
-columns | Getter | Array&lt;[Column](#column-extension)&gt; | Columns to be rendered by the table view.
+columns | Getter | Array&lt;[Column](grid.md#column)&gt; | Columns to be rendered by the table view.
 getRowId | Getter | (row: any) => number &#124; string | A function used to get a unique row identifier.
 getCellValue | Getter | (row: any, columnName: string) => any | A function used to get a cell’s value.
 

--- a/packages/dx-react-grid/docs/reference/table.md
+++ b/packages/dx-react-grid/docs/reference/table.md
@@ -36,7 +36,6 @@ Field | Type | Description
 columnName | string | Specifies the name of the column to extend.
 width? | number | Specifies the table's column width in pixels.
 align? | 'left' &#124; 'right' | Specifies the table's column alignment.
-cellComponent? | ElementType&lt;[TableDataCellProps](#tabledatacellprops)&gt; | | A component that renders a table cell for the table's column.
 
 ### TableLayoutProps
 

--- a/packages/dx-react-grid/docs/reference/virtual-table.md
+++ b/packages/dx-react-grid/docs/reference/virtual-table.md
@@ -44,7 +44,7 @@ VirtualTable.NoDataRow | [TableRowProps](table.md#tablerowprops) | Renders a tab
 VirtualTable.StubCell | [TableCellProps](table.md#tablecellprops) | Renders a stub table cell.
 VirtualTable.StubHeaderCell | [TableCellProps](table.md#tablecellprops) | Renders a stub table header cell.
 
-Additional properties are added to the component's root element.
+If you specify additional properties, they are added to the component's root element.
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/virtual-table.md
+++ b/packages/dx-react-grid/docs/reference/virtual-table.md
@@ -15,7 +15,7 @@ Name | Type | Default | Description
 -----|------|---------|------------
 height | number | 530 | The virtual table's height.
 estimatedRowHeight | number | `37` for [Bootstrap3](https://www.npmjs.com/package/@devexpress/dx-react-grid-bootstrap3); `48` for [Material UI](https://www.npmjs.com/package/@devexpress/dx-react-grid-material-ui) | Estimated row height. Specify the average value for a table whose rows have different heights.
-columnExtensions | Array&lg;[TableColumnExtension](table.md#tablecolumnextension)&gt; | An array additional column properties that can be handled by the plugin.
+columnExtensions | Array&lg;[TableColumnExtension](table.md#tablecolumnextension)&gt; | Additional column properties that the plugin can handle.
 layoutComponent | ElementType&lt;[TableLayoutProps](table.md#tablelayoutprops)&gt; | | A component that renders a table layout.
 cellComponent | ElementType&lt;[TableDataCellProps](table.md#tabledatacellprops)&gt; | | A component that renders a table cell.
 rowComponent | ElementType&lt;[TableDataRowProps](table.md#tabledatarowprops)&gt; | | A component that renders a table row.

--- a/packages/dx-react-grid/docs/reference/virtual-table.md
+++ b/packages/dx-react-grid/docs/reference/virtual-table.md
@@ -44,7 +44,7 @@ VirtualTable.NoDataRow | [TableRowProps](table.md#tablerowprops) | Renders a tab
 VirtualTable.StubCell | [TableCellProps](table.md#tablecellprops) | Renders a stub table cell.
 VirtualTable.StubHeaderCell | [TableCellProps](table.md#tablecellprops) | Renders a stub table header cell.
 
-If you specify additional properties, they are added to the component's root element.
+Additional properties are added to the component's root element.
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/virtual-table.md
+++ b/packages/dx-react-grid/docs/reference/virtual-table.md
@@ -15,6 +15,7 @@ Name | Type | Default | Description
 -----|------|---------|------------
 height | number | 530 | The virtual table's height.
 estimatedRowHeight | number | `37` for [Bootstrap3](https://www.npmjs.com/package/@devexpress/dx-react-grid-bootstrap3); `48` for [Material UI](https://www.npmjs.com/package/@devexpress/dx-react-grid-material-ui) | Estimated row height. Specify the average value for a table whose rows have different heights.
+columnExtensions | Array&lg;[TableColumnExtension](table.md#tablecolumnextension)&gt; | An array additional column properties that can be handled by the plugin.
 layoutComponent | ElementType&lt;[TableLayoutProps](table.md#tablelayoutprops)&gt; | | A component that renders a table layout.
 cellComponent | ElementType&lt;[TableDataCellProps](table.md#tabledatacellprops)&gt; | | A component that renders a table cell.
 rowComponent | ElementType&lt;[TableDataRowProps](table.md#tabledatarowprops)&gt; | | A component that renders a table row.
@@ -52,7 +53,7 @@ If you specify additional properties, they are added to the component's root ele
 Name | Plugin | Type | Description
 -----|--------|------|------------
 rows | Getter | Array&lt;any&gt; | Rows to be rendered by the virtual table view.
-columns | Getter | Array&lt;[Column](table.md#column-extension)&gt; | Columns the virtual table view should render.
+columns | Getter | Array&lt;[Column](grid.md#column)&gt; | Columns the virtual table view should render.
 getRowId | Getter | (row: any) => number &#124; string | A function used to get a unique row identifier.
 getCellValue | Getter | (row: any, columnName: string) => any | A function used to get a cell’s value.
 

--- a/packages/dx-react-grid/src/plugins/table.jsx
+++ b/packages/dx-react-grid/src/plugins/table.jsx
@@ -15,6 +15,7 @@ import {
   isHeaderStubTableCell,
   isDataTableRow,
   getMessagesFormatter,
+  getColumnExtension,
 } from '@devexpress/dx-grid-core';
 
 const RowPlaceholder = props =>
@@ -25,22 +26,24 @@ const CellPlaceholder = props =>
 const tableHeaderRows = [];
 const tableBodyRowsComputed = ({ rows, getRowId }) =>
   tableRowsWithDataRows(rows, getRowId);
-const tableColumnsComputed = ({ columns }) => tableColumnsWithDataRows(columns);
 
 export class Table extends React.PureComponent {
   render() {
     const {
       layoutComponent: Layout,
-      cellComponent: Cell,
+      cellComponent: DefaultCell,
       rowComponent: Row,
       noDataRowComponent: NoDataRow,
       noDataCellComponent: NoDataCell,
       stubCellComponent: StubCell,
       stubHeaderCellComponent: StubHeaderCell,
+      columnExtensions,
       messages,
     } = this.props;
 
     const getMessage = getMessagesFormatter(messages);
+    const tableColumnsComputed = ({ columns }) =>
+      tableColumnsWithDataRows(columns, columnExtensions);
 
     return (
       <PluginContainer
@@ -88,7 +91,10 @@ export class Table extends React.PureComponent {
           {params => (
             <TemplateConnector>
               {({ getCellValue }) => {
-                const value = getCellValue(params.tableRow.row, params.tableColumn.column.name);
+                const columnName = params.tableColumn.column.name;
+                const Cell = getColumnExtension(columnExtensions, columnName).cellComponent
+                  || DefaultCell;
+                const value = getCellValue(params.tableRow.row, columnName);
                 return (
                   <TemplatePlaceholder
                     name="valueFormatter"
@@ -150,9 +156,11 @@ Table.propTypes = {
   noDataRowComponent: PropTypes.func.isRequired,
   stubCellComponent: PropTypes.func.isRequired,
   stubHeaderCellComponent: PropTypes.func.isRequired,
+  columnExtensions: PropTypes.array,
   messages: PropTypes.object,
 };
 
 Table.defaultProps = {
+  columnExtensions: undefined,
   messages: {},
 };

--- a/packages/dx-react-grid/src/plugins/table.jsx
+++ b/packages/dx-react-grid/src/plugins/table.jsx
@@ -15,7 +15,6 @@ import {
   isHeaderStubTableCell,
   isDataTableRow,
   getMessagesFormatter,
-  getColumnExtension,
 } from '@devexpress/dx-grid-core';
 
 const RowPlaceholder = props =>
@@ -31,7 +30,7 @@ export class Table extends React.PureComponent {
   render() {
     const {
       layoutComponent: Layout,
-      cellComponent: DefaultCell,
+      cellComponent: Cell,
       rowComponent: Row,
       noDataRowComponent: NoDataRow,
       noDataCellComponent: NoDataCell,
@@ -92,8 +91,6 @@ export class Table extends React.PureComponent {
             <TemplateConnector>
               {({ getCellValue }) => {
                 const columnName = params.tableColumn.column.name;
-                const Cell = getColumnExtension(columnExtensions, columnName).cellComponent
-                  || DefaultCell;
                 const value = getCellValue(params.tableRow.row, columnName);
                 return (
                   <TemplatePlaceholder

--- a/packages/dx-react-grid/src/plugins/table.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table.test.jsx
@@ -86,6 +86,8 @@ describe('Table', () => {
     });
 
     it('should extend tableColumns', () => {
+      const columnExtensions = [{ columnName: 'field', width: 100 }];
+
       const tree = mount((
         <PluginHost>
           {pluginDepsToComponents(defaultDeps)}
@@ -97,7 +99,7 @@ describe('Table', () => {
       ));
 
       expect(tableColumnsWithDataRows)
-        .toBeCalledWith(defaultDeps.getter.columns);
+        .toBeCalledWith(defaultDeps.getter.columns, columnExtensions);
       expect(getComputedState(tree).tableColumns)
         .toBe('tableColumnsWithDataRows');
     });

--- a/packages/dx-react-grid/src/plugins/table.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table.test.jsx
@@ -9,7 +9,6 @@ import {
   isDataTableCell,
   isHeaderStubTableCell,
   isDataTableRow,
-  getColumnExtension,
   getMessagesFormatter,
 } from '@devexpress/dx-grid-core';
 import { Table } from './table';
@@ -22,7 +21,6 @@ jest.mock('@devexpress/dx-grid-core', () => ({
   isDataTableCell: jest.fn(),
   isHeaderStubTableCell: jest.fn(),
   isDataTableRow: jest.fn(),
-  getColumnExtension: jest.fn(),
   getMessagesFormatter: jest.fn(),
 }));
 
@@ -64,7 +62,6 @@ describe('Table', () => {
     isDataTableCell.mockImplementation(() => false);
     isHeaderStubTableCell.mockImplementation(() => false);
     isDataTableRow.mockImplementation(() => false);
-    getColumnExtension.mockImplementation(() => ({}));
     getMessagesFormatter.mockImplementation(messages => key => (messages[key] || key));
   });
   afterEach(() => {
@@ -134,30 +131,6 @@ describe('Table', () => {
         row: tableCellArgs.tableRow.row,
         column: tableCellArgs.tableColumn.column,
       });
-  });
-
-  it('should render data cell on user-defined column and row intersection defined by columnExtension', () => {
-    const cellComponent = () => null;
-    isDataTableCell.mockImplementation(() => true);
-    getColumnExtension.mockImplementation(() => ({ cellComponent }));
-    const tableCellArgs = {
-      tableRow: { row: 'row' },
-      tableColumn: { column: { name: 'a' } },
-      style: {},
-    };
-
-    const tree = mount((
-      <PluginHost>
-        {pluginDepsToComponents(defaultDeps)}
-        <Table
-          {...defaultProps}
-          layoutComponent={({ cellComponent: Cell }) => <Cell {...tableCellArgs} />}
-        />
-      </PluginHost>
-    ));
-
-    expect(tree.find(cellComponent).exists())
-      .toBeTruthy();
   });
 
   it('can render custom formatted data in table cell', () => {


### PR DESCRIPTION
BREAKING CHANGES:

In order to improve API readability, we extracted the `width` and `align` column properties that the Table and VirtualTable plugins handle into a separate property. Now, the `width` and `align` properties in the Grid `columns` are no longer supported. Use a TableColumnExtension instead:

Before:

```js
const columns= [{ name: 'field', width: 100 }, { name: 'field2' }];

<Grid columns={columns}>
  <Table />
</Grid>
```

After:

```js
const columns= [{ name: 'field1' }, { name: 'field2' }];
const tableColumnExtensions = [{ columnName: 'field1', width: 100 }];

<Grid columns={columns}>
  <Table columnExtensions={tableColumnExtensions} />
</Grid>
```