### PR TITLE
refactor(react-grid): switch to column extensions in LocalFiltering

### DIFF
--- a/packages/dx-grid-core/src/index.js
+++ b/packages/dx-grid-core/src/index.js
@@ -71,6 +71,8 @@ export * from './plugins/table-column-visibility/computeds';
 export * from './column-chooser/computeds';
 export * from './column-chooser/reducers';
 
+export { getColumnExtension } from './utils/column';
+
 export {
   getTableRowColumnsWithColSpan,
   getTableColumnGeometries,

--- a/packages/dx-grid-core/src/utils/column.js
+++ b/packages/dx-grid-core/src/utils/column.js
@@ -1,0 +1,10 @@
+export const getColumnExtension = (columnExtensions, columnName) => {
+  if (!columnExtensions) {
+    return {};
+  }
+  const columnExtension = columnExtensions.find(extension => extension.columnName === columnName);
+  if (!columnExtension) {
+    return {};
+  }
+  return columnExtension;
+};

--- a/packages/dx-react-demos/src/bootstrap3/filtering/custom-filtering-algorithm.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/filtering/custom-filtering-algorithm.jsx
@@ -15,8 +15,7 @@ import {
 } from '../../demo-data/generator';
 
 const toLowerCase = value => String(value).toLowerCase();
-const filterByCity = (value, filter) => toLowerCase(value).startsWith(toLowerCase(filter.value));
-const getColumnPredicate = columnName => (columnName === 'city' ? filterByCity : undefined);
+const cityPredicate = (value, filter) => toLowerCase(value).startsWith(toLowerCase(filter.value));
 
 export default class Demo extends React.PureComponent {
   constructor(props) {
@@ -29,11 +28,14 @@ export default class Demo extends React.PureComponent {
         { name: 'city', title: 'City' },
         { name: 'car', title: 'Car' },
       ],
+      localFilteringColumnExtensions: [
+        { columnName: 'city', predicate: cityPredicate },
+      ],
       rows: generateRows({ length: 14 }),
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, localFilteringColumnExtensions } = this.state;
 
     return (
       <Grid
@@ -41,7 +43,7 @@ export default class Demo extends React.PureComponent {
         columns={columns}
       >
         <FilteringState defaultFilters={[{ columnName: 'city', value: 'Paris' }]} />
-        <LocalFiltering getColumnPredicate={getColumnPredicate} />
+        <LocalFiltering columnExtensions={localFilteringColumnExtensions} />
         <Table />
         <TableHeaderRow />
         <TableFilterRow />

--- a/packages/dx-react-demos/src/material-ui/filtering/custom-filtering-algorithm.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/custom-filtering-algorithm.jsx
@@ -15,8 +15,7 @@ import {
 } from '../../demo-data/generator';
 
 const toLowerCase = value => String(value).toLowerCase();
-const filterByCity = (value, filter) => toLowerCase(value).startsWith(toLowerCase(filter.value));
-const getColumnPredicate = columnName => (columnName === 'city' ? filterByCity : undefined);
+const cityPredicate = (value, filter) => toLowerCase(value).startsWith(toLowerCase(filter.value));
 
 export default class Demo extends React.PureComponent {
   constructor(props) {
@@ -29,11 +28,14 @@ export default class Demo extends React.PureComponent {
         { name: 'city', title: 'City' },
         { name: 'car', title: 'Car' },
       ],
+      localFilteringColumnExtensions: [
+        { columnName: 'city', predicate: cityPredicate },
+      ],
       rows: generateRows({ length: 14 }),
     };
   }
   render() {
-    const { rows, columns } = this.state;
+    const { rows, columns, localFilteringColumnExtensions } = this.state;
 
     return (
       <Paper>
@@ -42,7 +44,7 @@ export default class Demo extends React.PureComponent {
           columns={columns}
         >
           <FilteringState defaultFilters={[{ columnName: 'city', value: 'Paris' }]} />
-          <LocalFiltering getColumnPredicate={getColumnPredicate} />
+          <LocalFiltering columnExtensions={localFilteringColumnExtensions} />
           <Table />
           <TableHeaderRow />
           <TableFilterRow />

--- a/packages/dx-react-grid/docs/guides/filtering.md
+++ b/packages/dx-react-grid/docs/guides/filtering.md
@@ -30,7 +30,7 @@ In the [controlled mode](controlled-and-uncontrolled-modes.md), pass the filteri
 
 ### <a name="using-custom-filtering-algorithm"></a>Using Custom Filtering Algorithms
 
-You can also specify a filtering predicate using the `LocalFiltering` plugin's `getColumnPredicate` property to implement a custom filtering logic.
+You can also specify a filtering predicate using the `LocalFiltering` plugin's `columnExtenstions` property to implement a custom filtering logic for specific columns.
 
 .embedded-demo(filtering/custom-filtering-algorithm)
 

--- a/packages/dx-react-grid/docs/guides/filtering.md
+++ b/packages/dx-react-grid/docs/guides/filtering.md
@@ -30,7 +30,7 @@ In the [controlled mode](controlled-and-uncontrolled-modes.md), pass the filteri
 
 ### <a name="using-custom-filtering-algorithm"></a>Using Custom Filtering Algorithms
 
-You can also specify a filtering predicate using the `LocalFiltering` plugin's `columnExtenstions` property to implement a custom filtering logic for specific columns.
+You can also specify a filtering predicate using the `LocalFiltering` plugin's `columnExtenstions` property to implement custom filtering logic for specific columns.
 
 .embedded-demo(filtering/custom-filtering-algorithm)
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,7 +12,7 @@ A plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-columnExtensions | Array&lg;[LocalFilteringColumnExtension](#localfilteringcolumnextension)&gt; | | An array additional column properties that can be handled by the plugin.
+columnExtensions | Array&lg;[LocalFilteringColumnExtension](#localfilteringcolumnextension)&gt; | | Additional column properties that can be handled by the plugin.
 
 ## Interfaces
 
@@ -24,7 +24,7 @@ A value with the following shape:
 
 Field | Type | Description
 ------|------|------------
-columnName | string | Specifies the name of the column to extend.
+columnName | string | The name of a column to extend.
 predicate? | (value: any, filter: Object, row: any) => boolean | A filter predicate. The `filter` parameter accepts an object containing the 'value' field. Note that you can use the [onFilter](table-filter-row.md#tablefiltercellprop) event to extend this object to the fields your filtering algorithm requires.
 
 ## Plugin Developer Reference

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,13 +12,13 @@ A plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-columnExtensions | Array&lg;[LocalFilteringColumnExtension](#localfilteringcolumnextension)&gt; | | Additional column properties that can be handled by the plugin.
+columnExtensions | Array&lg;[LocalFilteringColumnExtension](#localfilteringcolumnextension)&gt; | | Additional column properties that the plugin can handle.
 
 ## Interfaces
 
 ### LocalFilteringColumnExtension
 
-Describes additional column properties that can be handled by the plugin.
+Describes additional column properties that the plugin can handle.
 
 A value with the following shape:
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,13 +12,20 @@ A plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-getColumnPredicate | (columnName: string) => [Predicate](#predicate) &#124; undefined | | A function that applies a filter predicate to a cell depending on its column. See the [Filtering guide](../guides/filtering.md#using-custom-filtering-algorithm) for more information.
+columnExtensions | Array&lg;[LocalFilteringColumnExtension](#localfilteringcolumnextension)&gt; | An array additional column properties that can be handled by the plugin.
 
 ## Interfaces
 
-### <a name="predicate"></a>Predicate
+### LocalFilteringColumnExtension
 
-A function with the `(value: any, filter: Object, row: any) => boolean` signature. The `filter` parameter accepts an object containing the 'value' field. Note that you can use the [onFilter](table-filter-row.md#tablefiltercellprop) event to extend this object to the fields your filtering algorithm requires.
+Describes additional column properties that can be handled by the plugin.
+
+A value with the following shape:
+
+Field | Type | Description
+------|------|------------
+columnName | string | Specifies the name of the column to extend.
+predicate? | (value: any, filter: Object, row: any) => boolean | A filter predicate. The `filter` parameter accepts an object containing the 'value' field. Note that you can use the [onFilter](table-filter-row.md#tablefiltercellprop) event to extend this object to the fields your filtering algorithm requires.
 
 ## Plugin Developer Reference
 

--- a/packages/dx-react-grid/docs/reference/local-filtering.md
+++ b/packages/dx-react-grid/docs/reference/local-filtering.md
@@ -12,7 +12,7 @@ A plugin that performs local data filtering.
 
 Name | Type | Default | Description
 -----|------|---------|------------
-columnExtensions | Array&lg;[LocalFilteringColumnExtension](#localfilteringcolumnextension)&gt; | An array additional column properties that can be handled by the plugin.
+columnExtensions | Array&lg;[LocalFilteringColumnExtension](#localfilteringcolumnextension)&gt; | | An array additional column properties that can be handled by the plugin.
 
 ## Interfaces
 

--- a/packages/dx-react-grid/src/plugins/local-filtering.jsx
+++ b/packages/dx-react-grid/src/plugins/local-filtering.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Getter, PluginContainer } from '@devexpress/dx-react-core';
-import { filteredRows } from '@devexpress/dx-grid-core';
+import { filteredRows, getColumnExtension } from '@devexpress/dx-grid-core';
 
 const pluginDependencies = [
   { pluginName: 'FilteringState' },
@@ -9,7 +9,9 @@ const pluginDependencies = [
 
 export class LocalFiltering extends React.PureComponent {
   render() {
-    const { getColumnPredicate } = this.props;
+    const { columnExtensions } = this.props;
+    const getColumnPredicate = columnName =>
+      getColumnExtension(columnExtensions, columnName).predicate;
 
     const rowsComputed = ({
       rows,
@@ -32,10 +34,10 @@ export class LocalFiltering extends React.PureComponent {
 }
 
 LocalFiltering.propTypes = {
-  getColumnPredicate: PropTypes.func,
+  columnExtensions: PropTypes.array,
 };
 
 LocalFiltering.defaultProps = {
-  getColumnPredicate: undefined,
+  columnExtensions: undefined,
 };
 


### PR DESCRIPTION
BREAKING CHANGES:

In order to improve API consistency, we've decided to replace the `getColumnPredicate` function in the LocalFiltering plugin with the LocalFilteringColumnExtension.

Before:

```js
const columns = [{ name: 'field' }, { name: 'field2' }];
const fieldPredicate = /* custom filtering predicate */;
const getColumnPredicate = (columnName) => {
  if (name === 'field') return fieldPredicate;
};

<Grid columns={columns}>
  <LocalFiltering getColumnPredicate={getColumnPredicate} />
</Grid>
```

After:

```js
const columns= [{ name: 'field' }, { name: 'field2' }];
const fieldPredicate = /* custom filtering predicate */;
const localFilteringColumnExtensions = [
  { columnName: 'field', predicate: fieldPredicate },
];

<Grid columns={columns}>
  <LocalFiltering columnExtensions={localFilteringColumnExtensions} />
</Grid>
```