### PR TITLE
refactor(react-grid): rename allow* to show*Command in TableEditColumn

### DIFF
--- a/packages/dx-react-demos/src/bootstrap3/data-accessors/custom-data-accessors-in-columns.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/data-accessors/custom-data-accessors-in-columns.jsx
@@ -102,7 +102,7 @@ export default class Demo extends React.PureComponent {
         <Table />
         <TableHeaderRow />
         <TableEditRow />
-        <TableEditColumn allowAdding allowEditing allowDeleting />
+        <TableEditColumn showAddCommand showEditCommand showDeleteCommand />
       </Grid>
     );
   }

--- a/packages/dx-react-demos/src/bootstrap3/data-accessors/custom-data-accessors.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/data-accessors/custom-data-accessors.jsx
@@ -102,7 +102,7 @@ export default class Demo extends React.PureComponent {
         <Table />
         <TableHeaderRow />
         <TableEditRow />
-        <TableEditColumn allowAdding allowEditing allowDeleting />
+        <TableEditColumn showAddCommand showEditCommand showDeleteCommand />
       </Grid>
     );
   }

--- a/packages/dx-react-demos/src/bootstrap3/data-types/editors.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/data-types/editors.jsx
@@ -107,9 +107,9 @@ export default class Demo extends React.PureComponent {
         <TableHeaderRow />
         <TableEditRow />
         <TableEditColumn
-          allowAdding
-          allowEditing
-          allowDeleting
+          showAddCommand
+          showEditCommand
+          showDeleteCommand
         />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/editing/edit-row-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/editing/edit-row-controlled.jsx
@@ -98,9 +98,9 @@ export default class Demo extends React.PureComponent {
         <TableHeaderRow />
         <TableEditRow />
         <TableEditColumn
-          allowAdding={!addedRows.length}
-          allowEditing
-          allowDeleting
+          showAddCommand={!addedRows.length}
+          showEditCommand
+          showDeleteCommand
         />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/editing/edit-row.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/editing/edit-row.jsx
@@ -73,9 +73,9 @@ export default class Demo extends React.PureComponent {
         <TableHeaderRow />
         <TableEditRow />
         <TableEditColumn
-          allowAdding
-          allowEditing
-          allowDeleting
+          showAddCommand
+          showEditCommand
+          showDeleteCommand
         />
       </Grid>
     );

--- a/packages/dx-react-demos/src/bootstrap3/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-controlled-mode/demo.jsx
@@ -293,9 +293,9 @@ export default class Demo extends React.PureComponent {
           />
           <TableEditColumn
             width={100}
-            allowAdding={!this.state.addedRows.length}
-            allowEditing
-            allowDeleting
+            showAddCommand={!this.state.addedRows.length}
+            showEditCommand
+            showDeleteCommand
             commandComponent={Command}
           />
           <PagingPanel

--- a/packages/dx-react-demos/src/bootstrap3/localization/basic.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/localization/basic.jsx
@@ -91,9 +91,9 @@ export default class Demo extends React.PureComponent {
 
         <TableEditRow />
         <TableEditColumn
-          allowAdding
-          allowEditing
-          allowDeleting
+          showAddCommand
+          showEditCommand
+          showDeleteCommand
           width={200}
           messages={editColumnMessages}
         />

--- a/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors-in-columns.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors-in-columns.jsx
@@ -103,7 +103,7 @@ export default class Demo extends React.PureComponent {
           <Table />
           <TableHeaderRow />
           <TableEditRow />
-          <TableEditColumn allowAdding allowEditing allowDeleting />
+          <TableEditColumn showAddCommand showEditCommand showDeleteCommand />
         </Grid>
       </Paper>
     );

--- a/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-accessors/custom-data-accessors.jsx
@@ -103,7 +103,7 @@ export default class Demo extends React.PureComponent {
           <Table />
           <TableHeaderRow />
           <TableEditRow />
-          <TableEditColumn allowAdding allowEditing allowDeleting />
+          <TableEditColumn showAddCommand showEditCommand showDeleteCommand />
         </Grid>
       </Paper>
     );

--- a/packages/dx-react-demos/src/material-ui/data-types/editors.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-types/editors.jsx
@@ -114,9 +114,9 @@ export default class Demo extends React.PureComponent {
           <TableHeaderRow />
           <TableEditRow />
           <TableEditColumn
-            allowAdding
-            allowEditing
-            allowDeleting
+            showAddCommand
+            showEditCommand
+            showDeleteCommand
           />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/editing/edit-row-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/editing/edit-row-controlled.jsx
@@ -99,9 +99,9 @@ export default class Demo extends React.PureComponent {
           <TableHeaderRow />
           <TableEditRow />
           <TableEditColumn
-            allowAdding={!addedRows.length}
-            allowEditing
-            allowDeleting
+            showAddCommand={!addedRows.length}
+            showEditCommand
+            showDeleteCommand
           />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/editing/edit-row.jsx
+++ b/packages/dx-react-demos/src/material-ui/editing/edit-row.jsx
@@ -74,9 +74,9 @@ export default class Demo extends React.PureComponent {
           <TableHeaderRow />
           <TableEditRow />
           <TableEditColumn
-            allowAdding
-            allowEditing
-            allowDeleting
+            showAddCommand
+            showEditCommand
+            showDeleteCommand
           />
         </Grid>
       </Paper>

--- a/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
@@ -336,9 +336,9 @@ class DemoBase extends React.PureComponent {
           />
           <TableEditColumn
             width={120}
-            allowAdding={!this.state.addedRows.length}
-            allowEditing
-            allowDeleting
+            showAddCommand={!this.state.addedRows.length}
+            showEditCommand
+            showDeleteCommand
             commandComponent={Command}
           />
           <PagingPanel

--- a/packages/dx-react-demos/src/material-ui/localization/basic.jsx
+++ b/packages/dx-react-demos/src/material-ui/localization/basic.jsx
@@ -96,9 +96,9 @@ export default class Demo extends React.PureComponent {
 
           <TableEditRow />
           <TableEditColumn
-            allowAdding
-            allowEditing
-            allowDeleting
+            showAddCommand
+            showEditCommand
+            showDeleteCommand
             width={250}
             messages={editColumnMessages}
           />

--- a/packages/dx-react-grid/docs/reference/table-edit-column.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-column.md
@@ -16,9 +16,9 @@ Name | Type | Default | Description
 cellComponent | ElementType&lt;[TableEditColumnCellProps](#tableeditcolumncellprops)&gt; | | A component that renders a command cell within a data row.
 headerCellComponent | ElementType&lt;[TableEditColumnHeaderCellProps](#tableeditcolumnheadercellprops)&gt; | | A component that renders a command cell within the header row.
 commandComponent | ElementType&lt;[EditCommandProps](#editcommandprops)&gt; | | A component that renders command control within a command cell.
-allowAdding | boolean | false | Specifies whether to render the 'New' command within the header row's command cell.
-allowEditing | boolean | false | Specifies whether to render the 'Edit' command within the data row's command cell.
-allowDeleting | boolean | false | Specifies whether to render the 'Delete' command within the data row's command cell.
+showAddCommand | boolean | false | Specifies whether to render the 'New' command within the header row's command cell.
+showEditCommand | boolean | false | Specifies whether to render the 'Edit' command within the data row's command cell.
+showDeleteCommand | boolean | false | Specifies whether to render the 'Delete' command within the data row's command cell.
 width | number &#124; string | | Specifies the command column's width.
 messages | object | | An object that specifies the [localization messages](#localization-messages).
 

--- a/packages/dx-react-grid/src/plugins/table-edit-column.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.jsx
@@ -23,9 +23,9 @@ export class TableEditColumn extends React.PureComponent {
       cellComponent: Cell,
       headerCellComponent: HeaderCell,
       commandComponent: Command,
-      allowAdding,
-      allowEditing,
-      allowDeleting,
+      showAddCommand,
+      showEditCommand,
+      showDeleteCommand,
       width,
       messages,
     } = this.props;
@@ -48,7 +48,7 @@ export class TableEditColumn extends React.PureComponent {
             <TemplateConnector>
               {(getters, actions) => (
                 <HeaderCell {...params}>
-                  {allowAdding && (
+                  {showAddCommand && (
                     <Command
                       id="add"
                       text={getMessage('addCommand')}
@@ -77,14 +77,14 @@ export class TableEditColumn extends React.PureComponent {
                     {...params}
                     row={params.tableRow.row}
                   >
-                    {allowEditing && !isEditing && (
+                    {showEditCommand && !isEditing && (
                       <Command
                         id="edit"
                         text={getMessage('editCommand')}
                         onExecute={() => actions.startEditRows({ rowIds })}
                       />
                     )}
-                    {allowDeleting && !isEditing && (
+                    {showDeleteCommand && !isEditing && (
                       <Command
                         id="delete"
                         text={getMessage('deleteCommand')}
@@ -136,16 +136,16 @@ TableEditColumn.propTypes = {
   cellComponent: PropTypes.func.isRequired,
   headerCellComponent: PropTypes.func.isRequired,
   commandComponent: PropTypes.func.isRequired,
-  allowAdding: PropTypes.bool,
-  allowEditing: PropTypes.bool,
-  allowDeleting: PropTypes.bool,
+  showAddCommand: PropTypes.bool,
+  showEditCommand: PropTypes.bool,
+  showDeleteCommand: PropTypes.bool,
   width: PropTypes.number,
   messages: PropTypes.object,
 };
 TableEditColumn.defaultProps = {
-  allowAdding: false,
-  allowEditing: false,
-  allowDeleting: false,
+  showAddCommand: false,
+  showEditCommand: false,
+  showDeleteCommand: false,
   width: 140,
   messages: {},
 };

--- a/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-column.test.jsx
@@ -125,7 +125,7 @@ describe('TableEditColumn', () => {
         .toBeFalsy();
     });
 
-    it('should render add command when allowAdding is true', () => {
+    it('should render add command when showAddCommand is true', () => {
       isHeadingEditCommandsTableCell.mockImplementation(() => true);
 
       const tree = mount((
@@ -133,7 +133,7 @@ describe('TableEditColumn', () => {
           {pluginDepsToComponents(defaultDeps)}
           <TableEditColumn
             {...defaultProps}
-            allowAdding
+            showAddCommand
           />
         </PluginHost>
       ));
@@ -181,7 +181,7 @@ describe('TableEditColumn', () => {
         .toBeFalsy();
     });
 
-    it('should render edit command when allowEditing is true', () => {
+    it('should render edit command when showEditCommand is true', () => {
       isEditCommandsTableCell.mockImplementation(() => true);
 
       const tree = mount((
@@ -189,7 +189,7 @@ describe('TableEditColumn', () => {
           {pluginDepsToComponents(defaultDeps)}
           <TableEditColumn
             {...defaultProps}
-            allowEditing
+            showEditCommand
           />
         </PluginHost>
       ));
@@ -212,7 +212,7 @@ describe('TableEditColumn', () => {
           {pluginDepsToComponents(defaultDeps)}
           <TableEditColumn
             {...defaultProps}
-            allowEditing
+            showEditCommand
           />
         </PluginHost>
       ));
@@ -230,7 +230,7 @@ describe('TableEditColumn', () => {
           {pluginDepsToComponents(defaultDeps)}
           <TableEditColumn
             {...defaultProps}
-            allowEditing
+            showEditCommand
           />
         </PluginHost>
       ));
@@ -239,7 +239,7 @@ describe('TableEditColumn', () => {
         .toBeFalsy();
     });
 
-    it('should render delete command when allowDeleting is true', () => {
+    it('should render delete command when showDeleteCommand is true', () => {
       isEditCommandsTableCell.mockImplementation(() => true);
 
       const tree = mount((
@@ -247,7 +247,7 @@ describe('TableEditColumn', () => {
           {pluginDepsToComponents(defaultDeps)}
           <TableEditColumn
             {...defaultProps}
-            allowDeleting
+            showDeleteCommand
           />
         </PluginHost>
       ));
@@ -272,7 +272,7 @@ describe('TableEditColumn', () => {
           {pluginDepsToComponents(defaultDeps)}
           <TableEditColumn
             {...defaultProps}
-            allowDeleting
+            showDeleteCommand
           />
         </PluginHost>
       ));
@@ -290,7 +290,7 @@ describe('TableEditColumn', () => {
           {pluginDepsToComponents(defaultDeps)}
           <TableEditColumn
             {...defaultProps}
-            allowDeleting
+            showDeleteCommand
           />
         </PluginHost>
       ));


### PR DESCRIPTION
We renamed the TableEditColumn plugin's  `allowAdding`, `allowEditing`, and `allowDeleting` properties to `showAddCommand`, `showEditCommand`, and `showDeleteCommand` to improve API clarity.

Before:

```js
<Grid>
  <TableEditColumn allowAdding allowEditing allowDeleting />
</Grid>
```

After:

```js
<Grid>
  <TableEditColumn showAddCommand showEditCommand showDeleteCommand />
</Grid>
```
