### PR TITLE
fix(react-grid-material-ui): import 'VisibilityOff' icon from separat…

### DIFF
--- a/packages/dx-react-grid-material-ui/src/templates/column-chooser/toggle-button.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/column-chooser/toggle-button.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { IconButton, Tooltip } from 'material-ui';
-import { VisibilityOff } from 'material-ui-icons';
+import VisibilityOff from 'material-ui-icons/VisibilityOff';
 
 export const ToggleButton = ({
   onToggle,


### PR DESCRIPTION
Because everyone add `node_modules` to `exclude` option of `babel-loader` when using webpack (So babel plugins can't transform this code to prevent full import)

I've tested this by changes in my project `node_modules`:

from:
```javascript
import { VisibilityOff } from 'material-ui-icons';
```
to:
```javascript
import VisibilityOff from 'material-ui-icons/VisibilityOff';
```
And my bundle have been decreased by ~400kb.

I'm not sure, but perhaps there is a better way to fix tree-shaking?

