### PR TITLE
refactor(react-grid): use 'allRowsSelection' instead of 'selectAll' in Getter and Action names

### DIFF
--- a/packages/dx-react-grid/docs/reference/integrated-selection.md
+++ b/packages/dx-react-grid/docs/reference/integrated-selection.md
@@ -23,7 +23,7 @@ isGroupRow? | Getter | (row: any) => boolean | A function used to identify a gro
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-toggleSelectAll | Action | (select?: boolean) => void | A function that selects/deselects all rows. The `select` argument specifies whether the rows should be selected (true), deselected (false), or their selection status should be set to the opposite value (undefined).
-selectAllAvailable | Getter | boolean | Returns `true` if there are rows that are available for selection.
+toggleAllRowsSelection | Action | (select?: boolean) => void | A function that selects/deselects all rows. The `select` argument specifies whether the rows should be selected (true), deselected (false), or their selection status should be set to the opposite value (undefined).
+allRowsSelectionAvailable | Getter | boolean | Returns `true` if there are rows that are available for selection.
 allSelected | Getter | boolean | Indicates whether all the rows available for selection are selected.
 someSelected | Getter | boolean | Indicates whether some rows are selected. False if all/none rows are selected.

--- a/packages/dx-react-grid/docs/reference/table-selection.md
+++ b/packages/dx-react-grid/docs/reference/table-selection.md
@@ -68,8 +68,8 @@ tableColumns | Getter | Array&lt;[TableColumn](table.md#tablecolumn)&gt; | Table
 tableBodyRows | Getter | Array&lt;[TableRow](#tablerow)&gt; | Body rows to be rendered.
 selection | Getter | Set&lt;number &#124; string&gt; | Selected rows.
 toggleSelection | Action | ({ rowIds: Array&lt;number &#124; string&gt;, selected?: boolean  }) => void | A function that selects/deselects rows. The `selected` argument specifies whether the rows should be selected (true), deselected (false), or their selection status should be set to the opposite value (undefined). In the last case, the function selects unselected rows and deselects selected ones. To select/deselect a single row, pass an array with a single item to the `rowIds` argument.
-toggleSelectAll | Action | (select?: boolean) => void | A function that selects/deselects all rows. The `select` argument specifies whether the rows should be selected (true), deselected (false), or their selection status should be set to the opposite value (undefined). In the last case, the function selects all rows or deselects all selected ones.
-selectAllAvailable | Getter | boolean | Indicates whether there are rows that are available for selection.
+toggleAllRowsSelection | Action | (select?: boolean) => void | A function that selects/deselects all rows. The `select` argument specifies whether the rows should be selected (true), deselected (false), or their selection status should be set to the opposite value (undefined). In the last case, the function selects all rows or deselects all selected ones.
+allRowsSelectionAvailable | Getter | boolean | Indicates whether there are rows that are available for selection.
 allSelected | Getter | boolean | Indicates whether all the rows available for selection are selected.
 someSelected | Getter | boolean | Indicates whether some rows are selected. False if all/none rows are selected.
 tableCell | Template | [TableCellProps](table.md#tablecellprops) | A template that renders a table cell.

--- a/packages/dx-react-grid/src/plugins/integrated-selection.jsx
+++ b/packages/dx-react-grid/src/plugins/integrated-selection.jsx
@@ -16,11 +16,11 @@ export class IntegratedSelection extends React.PureComponent {
 
     this.state = { availableToSelect: [] };
 
-    this.toggleSelectAll = this.toggleSelectAll.bind(this);
+    this.toggleAllRowsSelection = this.toggleAllRowsSelection.bind(this);
     this.availableToSelect = this.availableToSelect.bind(this);
   }
 
-  toggleSelectAll(select, { selection }, { toggleSelection }) {
+  toggleAllRowsSelection(select, { selection }, { toggleSelection }) {
     const { availableToSelect } = this.state;
     if (select === undefined) {
       toggleSelection({ rowIds: availableToSelect });
@@ -50,9 +50,9 @@ export class IntegratedSelection extends React.PureComponent {
         <Getter name="rows" computed={this.availableToSelect} />
         <Getter name="allSelected" computed={allSelectedComputed} />
         <Getter name="someSelected" computed={someSelectedComputed} />
-        <Getter name="selectAllAvailable" value={!!availableToSelect.length} />
+        <Getter name="allRowsSelectionAvailable" value={!!availableToSelect.length} />
 
-        <Action name="toggleSelectAll" action={this.toggleSelectAll} />
+        <Action name="toggleAllRowsSelection" action={this.toggleAllRowsSelection} />
       </PluginContainer>
     );
   }

--- a/packages/dx-react-grid/src/plugins/integrated-selection.test.jsx
+++ b/packages/dx-react-grid/src/plugins/integrated-selection.test.jsx
@@ -96,7 +96,7 @@ describe('IntegratedSelection', () => {
         availableToSelect: [],
       });
   });
-  it('should provide selectAllAvailable getter', () => {
+  it('should provide allRowsSelectionAvailable getter', () => {
     const tree = mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
@@ -104,7 +104,7 @@ describe('IntegratedSelection', () => {
       </PluginHost>
     ));
 
-    expect(getComputedState(tree).selectAllAvailable)
+    expect(getComputedState(tree).allRowsSelectionAvailable)
       .toBe(!!defaultDeps.getter.rows.length);
   });
   it('should provide toggleSelection action', () => {
@@ -115,7 +115,7 @@ describe('IntegratedSelection', () => {
       </PluginHost>
     ));
 
-    executeComputedAction(tree, actions => actions.toggleSelectAll());
+    executeComputedAction(tree, actions => actions.toggleAllRowsSelection());
     expect(defaultDeps.action.toggleSelection.mock.calls.length).toBe(1);
   });
 });

--- a/packages/dx-react-grid/src/plugins/table-selection.jsx
+++ b/packages/dx-react-grid/src/plugins/table-selection.jsx
@@ -47,13 +47,16 @@ export class TableSelection extends React.PureComponent {
           >
             {params => (
               <TemplateConnector>
-                {({ selectAllAvailable, allSelected, someSelected }, { toggleSelectAll }) => (
+                {(
+                  { allRowsSelectionAvailable, allSelected, someSelected },
+                  { toggleAllRowsSelection },
+                ) => (
                   <HeaderCell
                     {...params}
-                    disabled={!selectAllAvailable}
+                    disabled={!allRowsSelectionAvailable}
                     allSelected={allSelected}
                     someSelected={someSelected}
-                    onToggle={select => toggleSelectAll(select)}
+                    onToggle={select => toggleAllRowsSelection(select)}
                   />
                 )}
               </TemplateConnector>


### PR DESCRIPTION
BREAKING CHANGE:

The `toggleSelectAll`Action and the `selectAllAvailable` Getter have been renamed to `toggleAllRowsSelection` and `allRowsSelectionAvailable` respectively.