### PR TITLE
refactor(react-grid): rename the EditingState plugin properties

### DIFF
--- a/packages/dx-grid-core/src/plugins/editing-state/reducers.js
+++ b/packages/dx-grid-core/src/plugins/editing-state/reducers.js
@@ -1,9 +1,9 @@
-export const startEditRows = (prevEditingRows, { rowIds }) =>
-  [...prevEditingRows, ...rowIds];
+export const startEditRows = (prevEditingRowIds, { rowIds }) =>
+  [...prevEditingRowIds, ...rowIds];
 
-export const stopEditRows = (prevEditingRows, { rowIds }) => {
+export const stopEditRows = (prevEditingRowIds, { rowIds }) => {
   const rowIdSet = new Set(rowIds);
-  return prevEditingRows.filter(id => !rowIdSet.has(id));
+  return prevEditingRowIds.filter(id => !rowIdSet.has(id));
 };
 
 export const addRow = (addedRows, { row } = { row: {} }) => [...addedRows, row];

--- a/packages/dx-grid-core/src/plugins/editing-state/reducers.test.js
+++ b/packages/dx-grid-core/src/plugins/editing-state/reducers.test.js
@@ -13,20 +13,20 @@ import {
 describe('EditingState reducers', () => {
   describe('#startEditRows', () => {
     it('should work', () => {
-      const editingRows = [1];
+      const editingRowIds = [1];
       const payload = { rowIds: [2, 3] };
 
-      const nextEditingRows = startEditRows(editingRows, payload);
-      expect(nextEditingRows).toEqual([1, 2, 3]);
+      const nextEditingRowIds = startEditRows(editingRowIds, payload);
+      expect(nextEditingRowIds).toEqual([1, 2, 3]);
     });
   });
   describe('#stopEditRows', () => {
     it('should work', () => {
-      const editingRows = [1, 2, 3];
+      const editingRowIds = [1, 2, 3];
       const payload = { rowIds: [2] };
 
-      const nextEditingRows = stopEditRows(editingRows, payload);
-      expect(nextEditingRows).toEqual([1, 3]);
+      const nextEditingRowIds = stopEditRows(editingRowIds, payload);
+      expect(nextEditingRowIds).toEqual([1, 3]);
     });
   });
   describe('#addRow', () => {

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.js
@@ -1,8 +1,8 @@
 import { TABLE_ADDED_TYPE, TABLE_EDIT_TYPE } from './constants';
 import { TABLE_DATA_TYPE } from '../table/constants';
 
-export const tableRowsWithEditing = (tableRows, editingRows, addedRows, rowHeight) => {
-  const rowIds = new Set(editingRows);
+export const tableRowsWithEditing = (tableRows, editingRowIds, addedRows, rowHeight) => {
+  const rowIds = new Set(editingRowIds);
   const editedTableRows = tableRows
     .map(tableRow => (
       tableRow.type === TABLE_DATA_TYPE && rowIds.has(tableRow.rowId)

--- a/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
+++ b/packages/dx-grid-core/src/plugins/table-edit-row/computeds.test.js
@@ -17,10 +17,10 @@ describe('TableEditRow Plugin computeds', () => {
         },
         { type: 'undefined', rowId: 2, row: 'row2' },
       ];
-      const editingRows = [2];
+      const editingRowIds = [2];
       const addedRows = [{ id: 3 }, { id: 4 }];
 
-      expect(tableRowsWithEditing(tableRows, editingRows, addedRows, 100))
+      expect(tableRowsWithEditing(tableRows, editingRowIds, addedRows, 100))
         .toEqual([
           {
             key: `${TABLE_ADDED_TYPE}_1`,

--- a/packages/dx-react-demos/src/bootstrap3/data-types/editors.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/data-types/editors.jsx
@@ -104,7 +104,7 @@ export default class Demo extends React.PureComponent {
         />
         <EditingState
           onCommitChanges={this.commitChanges}
-          defaultEditingRows={[0]}
+          defaultEditingRowIds={[0]}
         />
         <Table />
         <TableHeaderRow />

--- a/packages/dx-react-demos/src/bootstrap3/editing/edit-row-controlled.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/editing/edit-row-controlled.jsx
@@ -36,13 +36,13 @@ export default class Demo extends React.PureComponent {
         columnValues: { id: ({ index }) => index, ...defaultColumnValues },
         length: 14,
       }),
-      editingRows: [],
+      editingRowIds: [],
       addedRows: [],
       changedRows: {},
     };
 
     this.changeAddedRows = this.changeAddedRows.bind(this);
-    this.changeEditingRows = this.changeEditingRows.bind(this);
+    this.changeEditingRowIds = this.changeEditingRowIds.bind(this);
     this.changeChangedRows = this.changeChangedRows.bind(this);
     this.commitChanges = this.commitChanges.bind(this);
   }
@@ -50,8 +50,8 @@ export default class Demo extends React.PureComponent {
     const initialized = addedRows.map(row => (Object.keys(row).length ? row : { city: 'Tokio' }));
     this.setState({ addedRows: initialized });
   }
-  changeEditingRows(editingRows) {
-    this.setState({ editingRows });
+  changeEditingRowIds(editingRowIds) {
+    this.setState({ editingRowIds });
   }
   changeChangedRows(changedRows) {
     this.setState({ changedRows });
@@ -79,7 +79,7 @@ export default class Demo extends React.PureComponent {
   }
   render() {
     const {
-      rows, columns, tableColumnExtensions, editingRows, changedRows, addedRows,
+      rows, columns, tableColumnExtensions, editingRowIds, changedRows, addedRows,
     } = this.state;
 
     return (
@@ -89,8 +89,8 @@ export default class Demo extends React.PureComponent {
         getRowId={getRowId}
       >
         <EditingState
-          editingRows={editingRows}
-          onEditingRowsChange={this.changeEditingRows}
+          editingRowIds={editingRowIds}
+          onEditingRowIdsChange={this.changeEditingRowIds}
           changedRows={changedRows}
           onChangedRowsChange={this.changeChangedRows}
           addedRows={addedRows}

--- a/packages/dx-react-demos/src/bootstrap3/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/bootstrap3/featured-controlled-mode/demo.jsx
@@ -176,7 +176,7 @@ export default class Demo extends React.PureComponent {
         length: 12,
       }),
       sorting: [],
-      editingRows: [],
+      editingRowIds: [],
       addedRows: [],
       changedRows: {},
       currentPage: 0,
@@ -187,7 +187,7 @@ export default class Demo extends React.PureComponent {
     };
 
     this.changeSorting = sorting => this.setState({ sorting });
-    this.changeEditingRows = editingRows => this.setState({ editingRows });
+    this.changeEditingRowIds = editingRowIds => this.setState({ editingRowIds });
     this.changeAddedRows = addedRows => this.setState({
       addedRows: addedRows.map(row => (Object.keys(row).length ? row : {
         amount: 0,
@@ -239,7 +239,7 @@ export default class Demo extends React.PureComponent {
       columns,
       tableColumnExtensions,
       sorting,
-      editingRows,
+      editingRowIds,
       addedRows,
       changedRows,
       currentPage,
@@ -271,8 +271,8 @@ export default class Demo extends React.PureComponent {
           <IntegratedPaging />
 
           <EditingState
-            editingRows={editingRows}
-            onEditingRowsChange={this.changeEditingRows}
+            editingRowIds={editingRowIds}
+            onEditingRowIdsChange={this.changeEditingRowIds}
             changedRows={changedRows}
             onChangedRowsChange={this.changeChangedRows}
             addedRows={addedRows}

--- a/packages/dx-react-demos/src/material-ui/data-types/editors.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-types/editors.jsx
@@ -113,7 +113,7 @@ export default class Demo extends React.PureComponent {
           />
           <EditingState
             onCommitChanges={this.commitChanges}
-            defaultEditingRows={[0]}
+            defaultEditingRowIds={[0]}
           />
           <Table />
           <TableHeaderRow />

--- a/packages/dx-react-demos/src/material-ui/editing/edit-row-controlled.jsx
+++ b/packages/dx-react-demos/src/material-ui/editing/edit-row-controlled.jsx
@@ -36,13 +36,13 @@ export default class Demo extends React.PureComponent {
         columnValues: { id: ({ index }) => index, ...defaultColumnValues },
         length: 14,
       }),
-      editingRows: [],
+      editingRowIds: [],
       addedRows: [],
       changedRows: {},
     };
 
     this.changeAddedRows = this.changeAddedRows.bind(this);
-    this.changeEditingRows = this.changeEditingRows.bind(this);
+    this.changeEditingRowIds = this.changeEditingRowIds.bind(this);
     this.changeChangedRows = this.changeChangedRows.bind(this);
     this.commitChanges = this.commitChanges.bind(this);
   }
@@ -50,8 +50,8 @@ export default class Demo extends React.PureComponent {
     const initialized = addedRows.map(row => (Object.keys(row).length ? row : { city: 'Tokio' }));
     this.setState({ addedRows: initialized });
   }
-  changeEditingRows(editingRows) {
-    this.setState({ editingRows });
+  changeEditingRowIds(editingRowIds) {
+    this.setState({ editingRowIds });
   }
   changeChangedRows(changedRows) {
     this.setState({ changedRows });
@@ -79,7 +79,7 @@ export default class Demo extends React.PureComponent {
   }
   render() {
     const {
-      rows, columns, tableColumnExtensions, editingRows, changedRows, addedRows,
+      rows, columns, tableColumnExtensions, editingRowIds, changedRows, addedRows,
     } = this.state;
 
     return (
@@ -90,8 +90,8 @@ export default class Demo extends React.PureComponent {
           getRowId={getRowId}
         >
           <EditingState
-            editingRows={editingRows}
-            onEditingRowsChange={this.changeEditingRows}
+            editingRowIds={editingRowIds}
+            onEditingRowIdsChange={this.changeEditingRowIds}
             changedRows={changedRows}
             onChangedRowsChange={this.changeChangedRows}
             addedRows={addedRows}

--- a/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
@@ -214,7 +214,7 @@ class DemoBase extends React.PureComponent {
         length: 12,
       }),
       sorting: [],
-      editingRows: [],
+      editingRowIds: [],
       addedRows: [],
       changedRows: {},
       currentPage: 0,
@@ -225,7 +225,7 @@ class DemoBase extends React.PureComponent {
     };
 
     this.changeSorting = sorting => this.setState({ sorting });
-    this.changeEditingRows = editingRows => this.setState({ editingRows });
+    this.changeEditingRowIds = editingRowIds => this.setState({ editingRowIds });
     this.changeAddedRows = addedRows => this.setState({
       addedRows: addedRows.map(row => (Object.keys(row).length ? row : {
         amount: 0,
@@ -280,7 +280,7 @@ class DemoBase extends React.PureComponent {
       columns,
       tableColumnExtensions,
       sorting,
-      editingRows,
+      editingRowIds,
       addedRows,
       changedRows,
       currentPage,
@@ -312,8 +312,8 @@ class DemoBase extends React.PureComponent {
           <IntegratedPaging />
 
           <EditingState
-            editingRows={editingRows}
-            onEditingRowsChange={this.changeEditingRows}
+            editingRowIds={editingRowIds}
+            onEditingRowIdsChange={this.changeEditingRowIds}
             changedRows={changedRows}
             onChangedRowsChange={this.changeChangedRows}
             addedRows={addedRows}

--- a/packages/dx-react-grid/docs/guides/editing.md
+++ b/packages/dx-react-grid/docs/guides/editing.md
@@ -22,7 +22,7 @@ Handle the `EditingState` plugin's `onCommitChanges` event to commit changes mad
 
 In the [uncontrolled mode](controlled-and-uncontrolled-modes.md), you can specify the initial editing state values using the following `EditingState` plugin's properties:
 
-- `defaultEditingRows` - the rows being edited
+- `defaultEditingRowIds` - the rows being edited
 - `defaultAddedRows` - the rows being added
 - `defaultChangedRows` - the changed rows
 - `defaultDeletedRows` - the rows being deleted
@@ -33,7 +33,7 @@ In the [uncontrolled mode](controlled-and-uncontrolled-modes.md), you can specif
 
 In the [controlled mode](controlled-and-uncontrolled-modes.md), specify the following `EditingState` plugin's property pairs to set a state value and handle its changes:
 
-- `editingRows` and `onEditingRowsChange` - the rows being edited
+- `editingRowIds` and `onEditingRowIdsChange` - the rows being edited
 - `addedRows` and `onAddedRowsChange` - the rows being added
 - `changedRows` and `onChangedRowsChange` - the changed rows
 - `deletedRows` and `onDeletedRowsChange` - the rows being deleted

--- a/packages/dx-react-grid/docs/reference/editing-state.md
+++ b/packages/dx-react-grid/docs/reference/editing-state.md
@@ -14,9 +14,9 @@ Name | Type | Default | Description
 -----|------|---------|------------
 createRowChange | (row: any, columnName: string, value: string &#124; number) => any | | A function that returns a row changes object depending on row editor values. This function is called each time the row editor's value changes.
 columnExtensions | Array&lt;[EditingColumnExtension](#editingcolumnextension)&gt; | | Additional column properties that the plugin can handle.
-editingRows | Array&lt;number &#124; string&gt; | | Specifies IDs of the rows being edited.
-defaultEditingRows | Array&lt;number &#124; string&gt; | | Specifies IDs of the rows initially added to the `editingRows` array in uncontrolled mode.
-onEditingRowsChange | (editingRows: Array&lt;number &#124; string&gt;) => void | | Handles adding or removing a row to/from the `editingRows` array.
+editingRowIds | Array&lt;number &#124; string&gt; | | Specifies IDs of the rows being edited.
+defaultEditingRowIds | Array&lt;number &#124; string&gt; | | Specifies IDs of the rows initially added to the `editingRowIds` array in uncontrolled mode.
+onEditingRowIdsChange | (editingRowIds: Array&lt;number &#124; string&gt;) => void | | Handles adding or removing a row to/from the `editingRowIds` array.
 addedRows | Array&lt;any&gt; | | Specifies created but not committed rows.
 defaultAddedRows | Array&lt;any&gt; | | Specifies rows initially added to the `addedRows` array in uncontrolled mode.
 onAddedRowsChange | (addedRows: Array&lt;any&gt;) => void | | Handles adding or removing a row to/from the `addedRows` array.
@@ -63,7 +63,7 @@ none
 
 Name | Plugin | Type | Description
 -----|--------|------|------------
-editingRows | Getter | Array&lt;number &#124; string&gt; | Rows being edited.
+editingRowIds | Getter | Array&lt;number &#124; string&gt; | Rows being edited.
 startEditRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Enables the edit mode for the rows the ID specifies.
 stopEditRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Disables the edit mode for the rows the ID specifies.
 addedRows | Getter | Array&lt;any&gt; | Created but not committed rows.

--- a/packages/dx-react-grid/docs/reference/table-edit-row.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-row.md
@@ -59,7 +59,7 @@ If you specify additional properties, they are added to the component's root ele
 Name | Plugin | Type | Description
 -----|--------|------|------------
 tableBodyRows | Getter | Array&lt;[TableRow](table.md#tablerow)&gt; | Table body rows.
-editingRows | Getter | Array&lt;number &#124; string&gt; | IDs of the rows that are being edited.
+editingRowIds | Getter | Array&lt;number &#124; string&gt; | IDs of the rows that are being edited.
 addedRows | Getter | Array&lt;any&gt; | Created but not committed rows.
 changeAddedRow | Action | ({ rowId: number, change: any }) => void | Applies a change to a created but uncommitted row. Note: `rowId` is a row index within the `addedRows` array.
 changedRows | Getter | { [key: string]: any } | An associative array that stores changes made to existing rows. Each array item specifies changes made to a row. The item's key specifies the associated row's ID.

--- a/packages/dx-react-grid/src/plugins/editing-state.jsx
+++ b/packages/dx-react-grid/src/plugins/editing-state.jsx
@@ -26,7 +26,7 @@ export class EditingState extends React.PureComponent {
     super(props);
 
     this.state = {
-      editingRows: props.defaultEditingRows || [],
+      editingRowIds: props.defaultEditingRowIds || [],
       addedRows: props.defaultAddedRows || [],
       changedRows: props.defaultChangedRows || {},
       deletedRows: props.defaultDeletedRows || [],
@@ -35,9 +35,9 @@ export class EditingState extends React.PureComponent {
     const stateHelper = createStateHelper(this);
 
     this.startEditRows = stateHelper.applyFieldReducer
-      .bind(stateHelper, 'editingRows', startEditRows);
+      .bind(stateHelper, 'editingRowIds', startEditRows);
     this.stopEditRows = stateHelper.applyFieldReducer
-      .bind(stateHelper, 'editingRows', stopEditRows);
+      .bind(stateHelper, 'editingRowIds', stopEditRows);
 
     this.changeRow = stateHelper.applyFieldReducer
       .bind(stateHelper, 'changedRows', changeRow);
@@ -75,17 +75,17 @@ export class EditingState extends React.PureComponent {
   getState() {
     return {
       ...this.state,
-      editingRows: this.props.editingRows || this.state.editingRows,
+      editingRowIds: this.props.editingRowIds || this.state.editingRowIds,
       changedRows: this.props.changedRows || this.state.changedRows,
       addedRows: this.props.addedRows || this.state.addedRows,
       deletedRows: this.props.deletedRows || this.state.deletedRows,
     };
   }
   notifyStateChange(nextState, state) {
-    const { editingRows } = nextState;
-    const { onEditingRowsChange } = this.props;
-    if (onEditingRowsChange && editingRows !== state.editingRows) {
-      onEditingRowsChange(editingRows);
+    const { editingRowIds } = nextState;
+    const { onEditingRowIdsChange } = this.props;
+    if (onEditingRowIdsChange && editingRowIds !== state.editingRowIds) {
+      onEditingRowIdsChange(editingRowIds);
     }
 
     const { changedRows } = nextState;
@@ -109,7 +109,7 @@ export class EditingState extends React.PureComponent {
   render() {
     const { createRowChange, columnExtensions } = this.props;
     const {
-      editingRows, changedRows, addedRows, deletedRows,
+      editingRowIds, changedRows, addedRows, deletedRows,
     } = this.getState();
 
     return (
@@ -121,7 +121,7 @@ export class EditingState extends React.PureComponent {
           value={createRowChangeGetter(createRowChange, columnExtensions)}
         />
 
-        <Getter name="editingRows" value={editingRows} />
+        <Getter name="editingRowIds" value={editingRowIds} />
         <Action name="startEditRows" action={this.startEditRows} />
         <Action name="stopEditRows" action={this.stopEditRows} />
 
@@ -149,9 +149,9 @@ EditingState.propTypes = {
   createRowChange: PropTypes.func,
   columnExtensions: PropTypes.array,
 
-  editingRows: PropTypes.array,
-  defaultEditingRows: PropTypes.array,
-  onEditingRowsChange: PropTypes.func,
+  editingRowIds: PropTypes.array,
+  defaultEditingRowIds: PropTypes.array,
+  onEditingRowIdsChange: PropTypes.func,
 
   addedRows: PropTypes.array,
   defaultAddedRows: PropTypes.array,
@@ -172,9 +172,9 @@ EditingState.defaultProps = {
   createRowChange: undefined,
   columnExtensions: undefined,
 
-  editingRows: undefined,
-  defaultEditingRows: [],
-  onEditingRowsChange: undefined,
+  editingRowIds: undefined,
+  defaultEditingRowIds: [],
+  onEditingRowIdsChange: undefined,
 
   changedRows: undefined,
   defaultChangedRows: {},

--- a/packages/dx-react-grid/src/plugins/editing-state.test.jsx
+++ b/packages/dx-react-grid/src/plugins/editing-state.test.jsx
@@ -105,15 +105,15 @@ describe('EditingState', () => {
     });
 
     it('should correctly work with the several editing action calls in the controlled mode', () => {
-      const changeEditingRows = jest.fn();
+      const changeEditingRowIds = jest.fn();
       const tree = mount((
         <PluginHost>
           {pluginDepsToComponents(defaultDeps)}
           <EditingState
             {...defaultProps}
-            editingRows={[]}
+            editingRowIds={[]}
             changedRows={{}}
-            onEditingRowsChange={changeEditingRows}
+            onEditingRowIdsChange={changeEditingRowIds}
           />
         </PluginHost>
       ));
@@ -124,10 +124,10 @@ describe('EditingState', () => {
         actions.changeRow({ rowIds: [0] });
       });
 
-      expect(changeEditingRows)
+      expect(changeEditingRowIds)
         .toBeCalledWith([]);
 
-      expect(changeEditingRows)
+      expect(changeEditingRowIds)
         .toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/dx-react-grid/src/plugins/table-edit-row.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.jsx
@@ -25,8 +25,8 @@ export class TableEditRow extends React.PureComponent {
       rowHeight,
     } = this.props;
 
-    const tableBodyRowsComputed = ({ tableBodyRows, editingRows, addedRows }) =>
-      tableRowsWithEditing(tableBodyRows, editingRows, addedRows, rowHeight);
+    const tableBodyRowsComputed = ({ tableBodyRows, editingRowIds, addedRows }) =>
+      tableRowsWithEditing(tableBodyRows, editingRowIds, addedRows, rowHeight);
 
     return (
       <PluginContainer

--- a/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
+++ b/packages/dx-react-grid/src/plugins/table-edit-row.test.jsx
@@ -23,7 +23,7 @@ jest.mock('@devexpress/dx-grid-core', () => ({
 const defaultDeps = {
   getter: {
     tableBodyRows: [{ type: 'undefined', rowId: 1 }],
-    editingRows: [1, 2],
+    editingRowIds: [1, 2],
     addedRows: [{ a: 'text' }, {}],
     changedRows: [{ 1: { a: 'text' } }],
     getCellValue: jest.fn(),
@@ -89,7 +89,7 @@ describe('TableEditRow', () => {
       expect(tableRowsWithEditing)
         .toBeCalledWith(
           defaultDeps.getter.tableBodyRows,
-          defaultDeps.getter.editingRows,
+          defaultDeps.getter.editingRowIds,
           defaultDeps.getter.addedRows,
           120,
         );


### PR DESCRIPTION
BREAKING CHANGES:

The following EditingState plugin's properties have been renamed to improve the API consistency:

- `editingRows` => `editingRowIds`
- `defaultEditingRows` => `defaultEditingRowIds`
- `onEditingRowsChange` => `onEditingRowIdsChange`

The `editingRows` getter has been renamed to `editingRowIds`.