### PR TITLE
refactor(react-grid): rename the deletedRows Getter and dependent properties

### DIFF
--- a/packages/dx-grid-core/src/plugins/editing-state/reducers.js
+++ b/packages/dx-grid-core/src/plugins/editing-state/reducers.js
@@ -44,9 +44,9 @@ export const cancelChanges = (prevChangedRows, { rowIds }) => {
   return result;
 };
 
-export const deleteRows = (deletedRows, { rowIds }) => [...deletedRows, ...rowIds];
+export const deleteRows = (deletedRowIds, { rowIds }) => [...deletedRowIds, ...rowIds];
 
-export const cancelDeletedRows = (deletedRows, { rowIds }) => {
+export const cancelDeletedRows = (deletedRowIds, { rowIds }) => {
   const rowIdSet = new Set(rowIds);
-  return deletedRows.filter(rowId => !rowIdSet.has(rowId));
+  return deletedRowIds.filter(rowId => !rowIdSet.has(rowId));
 };

--- a/packages/dx-grid-core/src/plugins/editing-state/reducers.test.js
+++ b/packages/dx-grid-core/src/plugins/editing-state/reducers.test.js
@@ -97,20 +97,20 @@ describe('EditingState reducers', () => {
   });
   describe('#deleteRows', () => {
     it('should work', () => {
-      const deletedRows = [1];
+      const deletedRowIds = [1];
       const payload = { rowIds: [2] };
 
-      const nextDeletedRows = deleteRows(deletedRows, payload);
-      expect(nextDeletedRows).toEqual([1, 2]);
+      const nextDeletedRowIds = deleteRows(deletedRowIds, payload);
+      expect(nextDeletedRowIds).toEqual([1, 2]);
     });
   });
   describe('#cancelDeletedRows', () => {
     it('should work', () => {
-      const deletedRows = [1, 2];
+      const deletedRowIds = [1, 2];
       const payload = { rowIds: [2] };
 
-      const nextDeletedRows = cancelDeletedRows(deletedRows, payload);
-      expect(nextDeletedRows).toEqual([1]);
+      const nextDeletedRowIds = cancelDeletedRows(deletedRowIds, payload);
+      expect(nextDeletedRowIds).toEqual([1]);
     });
   });
 });

--- a/packages/dx-react-grid/docs/guides/editing.md
+++ b/packages/dx-react-grid/docs/guides/editing.md
@@ -25,7 +25,7 @@ In the [uncontrolled mode](controlled-and-uncontrolled-modes.md), you can specif
 - `defaultEditingRows` - the rows being edited
 - `defaultAddedRows` - the rows being added
 - `defaultChangedRows` - the changed rows
-- `defaultDeletedRows` - the rows being deleted
+- `defaultDeletedRowIds` - the rows being deleted
 
 .embedded-demo(editing/edit-row)
 
@@ -36,7 +36,7 @@ In the [controlled mode](controlled-and-uncontrolled-modes.md), specify the foll
 - `editingRows` and `onEditingRowsChange` - the rows being edited
 - `addedRows` and `onAddedRowsChange` - the rows being added
 - `changedRows` and `onChangedRowsChange` - the changed rows
-- `deletedRows` and `onDeletedRowsChange` - the rows being deleted
+- `deletedRowIds` and `onDeletedRowIdsChange` - the rows being deleted
 
 Note, you can also use the `onAddedRowsChange` event to initialize a created row with default property values.
 

--- a/packages/dx-react-grid/docs/reference/editing-state.md
+++ b/packages/dx-react-grid/docs/reference/editing-state.md
@@ -23,9 +23,9 @@ onAddedRowsChange | (addedRows: Array&lt;any&gt;) => void | | Handles adding or 
 changedRows | { [key: string]: any } | | Specifies changed but not committed rows.
 defaultChangedRows | { [key: string]: any } | | Specifies rows initially added to the `changedRows` array in uncontrolled mode.
 onChangedRowsChange | (changedRows: { [key: string]: any }) => void | | Handles adding or removing a row to/from the `changedRows` array.
-deletedRows | Array&lt;number &#124; string&gt; | | Specifies IDs of the rows prepared for deletion.
-defaultDeletedRows | Array&lt;number &#124; string&gt; | | Specifies rows initially added to the `deletedRows` array in uncontrolled mode.
-onDeletedRowsChange | (deletedRows: Array&lt;number &#124; string&gt;) => void | | Handles adding a row to or removing from the `deletedRows` array.
+deletedRowIds | Array&lt;number &#124; string&gt; | | Specifies IDs of the rows prepared for deletion.
+defaultDeletedRowIds | Array&lt;number &#124; string&gt; | | Specifies rows initially added to the `deletedRowIds` array in uncontrolled mode.
+onDeletedRowIdsChange | (deletedRowIds: Array&lt;number &#124; string&gt;) => void | | Handles adding a row to or removing from the `deletedRowIds` array.
 onCommitChanges | (Array&lt;[ChangeSet](#change-set)&gt;) => void | | Handles row changes committing.
 
 ## Interfaces
@@ -75,8 +75,8 @@ changedRows | Getter | { [key: string]: any } | An associated array that stores 
 changeRow | Action | ({ rowId: number &#124; string, change: any }) => void | Adds an item representing changes made to an exsiting row to the `changedRows` array.
 cancelChangedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Removes specified rows' data from the `changedRows` array.
 commitChangedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](#changeset) and removes specified rows from the `changedRows` array.
-deletedRows | Getter | Array&lt;number &#124; string&gt; | Rows prepared for deletion.
-deleteRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Adds rows the ID specifies to the `deletedRows` array.
-cancelDeletedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Removes specified rows from the `deletedRows` array.
-commitDeletedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](#changeset) and removes specified rows from the `deletedRows` array.
+deletedRowIds | Getter | Array&lt;number &#124; string&gt; | Rows prepared for deletion.
+deleteRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Adds rows the ID specifies to the `deletedRowIds` array.
+cancelDeletedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Removes specified rows from the `deletedRowIds` array.
+commitDeletedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](#changeset) and removes specified rows from the `deletedRowIds` array.
 createRowChange | Getter | (row: any, value: any, columnName: string) => any | A function that returns a value that specifies row changes depending on columns editor values for the current row. This function is called each time the editor's value changes.

--- a/packages/dx-react-grid/docs/reference/table-edit-column.md
+++ b/packages/dx-react-grid/docs/reference/table-edit-column.md
@@ -93,8 +93,8 @@ startEditRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void
 stopEditRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Switches rows with the specified ID to the read-only mode.
 cancelChangedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Cancels uncommitted changes in rows with the specified ID.
 commitChangedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](editing-state.md#changeset) and removes specified rows from the `changedRows` array.
-deleteRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Prepares rows with the specified ID for deletion by adding them to the `deletedRows` array.
-commitDeletedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](editing-state.md#changeset) and removes specified rows from the `deletedRows` array.
+deleteRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Prepares rows with the specified ID for deletion by adding them to the `deletedRowIds` array.
+commitDeletedRows | Action | ({ rowIds: Array&lt;number &#124; string&gt; }) => void | Fires the `onCommitChanges` event with the corresponding [ChangeSet](editing-state.md#changeset) and removes specified rows from the `deletedRowIds` array.
 tableCell | Template | [TableCellProps](table.md#tablecellprops) | A template that renders a table cell.
 
 ### Exports

--- a/packages/dx-react-grid/src/plugins/editing-state.jsx
+++ b/packages/dx-react-grid/src/plugins/editing-state.jsx
@@ -29,7 +29,7 @@ export class EditingState extends React.PureComponent {
       editingRows: props.defaultEditingRows || [],
       addedRows: props.defaultAddedRows || [],
       changedRows: props.defaultChangedRows || {},
-      deletedRows: props.defaultDeletedRows || [],
+      deletedRowIds: props.defaultDeletedRowIds || [],
     };
 
     const stateHelper = createStateHelper(this);
@@ -64,9 +64,9 @@ export class EditingState extends React.PureComponent {
     };
 
     this.deleteRows = stateHelper.applyFieldReducer
-      .bind(stateHelper, 'deletedRows', deleteRows);
+      .bind(stateHelper, 'deletedRowIds', deleteRows);
     this.cancelDeletedRows = stateHelper.applyFieldReducer
-      .bind(stateHelper, 'deletedRows', cancelDeletedRows);
+      .bind(stateHelper, 'deletedRowIds', cancelDeletedRows);
     this.commitDeletedRows = ({ rowIds }) => {
       this.props.onCommitChanges({ deleted: rowIds });
       this.cancelDeletedRows({ rowIds });
@@ -78,7 +78,7 @@ export class EditingState extends React.PureComponent {
       editingRows: this.props.editingRows || this.state.editingRows,
       changedRows: this.props.changedRows || this.state.changedRows,
       addedRows: this.props.addedRows || this.state.addedRows,
-      deletedRows: this.props.deletedRows || this.state.deletedRows,
+      deletedRowIds: this.props.deletedRowIds || this.state.deletedRowIds,
     };
   }
   notifyStateChange(nextState, state) {
@@ -100,16 +100,16 @@ export class EditingState extends React.PureComponent {
       onAddedRowsChange(addedRows);
     }
 
-    const { deletedRows } = nextState;
-    const { onDeletedRowsChange } = this.props;
-    if (onDeletedRowsChange && deletedRows !== state.deletedRows) {
-      onDeletedRowsChange(deletedRows);
+    const { deletedRowIds } = nextState;
+    const { onDeletedRowIdsChange } = this.props;
+    if (onDeletedRowIdsChange && deletedRowIds !== state.deletedRowIds) {
+      onDeletedRowIdsChange(deletedRowIds);
     }
   }
   render() {
     const { createRowChange, columnExtensions } = this.props;
     const {
-      editingRows, changedRows, addedRows, deletedRows,
+      editingRows, changedRows, addedRows, deletedRowIds,
     } = this.getState();
 
     return (
@@ -136,7 +136,7 @@ export class EditingState extends React.PureComponent {
         <Action name="cancelAddedRows" action={this.cancelAddedRows} />
         <Action name="commitAddedRows" action={this.commitAddedRows} />
 
-        <Getter name="deletedRows" value={deletedRows} />
+        <Getter name="deletedRowIds" value={deletedRowIds} />
         <Action name="deleteRows" action={this.deleteRows} />
         <Action name="cancelDeletedRows" action={this.cancelDeletedRows} />
         <Action name="commitDeletedRows" action={this.commitDeletedRows} />
@@ -161,9 +161,9 @@ EditingState.propTypes = {
   defaultChangedRows: PropTypes.object,
   onChangedRowsChange: PropTypes.func,
 
-  deletedRows: PropTypes.array,
-  defaultDeletedRows: PropTypes.array,
-  onDeletedRowsChange: PropTypes.func,
+  deletedRowIds: PropTypes.array,
+  defaultDeletedRowIds: PropTypes.array,
+  onDeletedRowIdsChange: PropTypes.func,
 
   onCommitChanges: PropTypes.func.isRequired,
 };
@@ -184,7 +184,7 @@ EditingState.defaultProps = {
   defaultAddedRows: [],
   onAddedRowsChange: undefined,
 
-  deletedRows: undefined,
-  defaultDeletedRows: [],
-  onDeletedRowsChange: undefined,
+  deletedRowIds: undefined,
+  defaultDeletedRowIds: [],
+  onDeletedRowIdsChange: undefined,
 };


### PR DESCRIPTION
BREAKING CHANGES:

The following EditingState plugin's properties have been renamed to improve the API consistency:

- `deletedRows` => `deletedRowIds`
- `defaultDeletedRows` => `defaultDeletedRowIds`
- `onDeletedRowsChange` => `onDeletedRowIdsChange`

The `deletedRows` getter has been renamed to `deletedRowIds`.