### PR TITLE
fix(react-grid-material-ui): use long paths for modules

### DIFF
--- a/packages/dx-react-demos/.eslintrc.json
+++ b/packages/dx-react-demos/.eslintrc.json
@@ -19,6 +19,7 @@
         "jsx-a11y/href-no-hash": "off",
         "jsx-a11y/anchor-is-valid": "off",
         "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.*"]}],
-        "filenames/match-regex": [2, "^[a-z-\\.]+$"]
+        "filenames/match-regex": [2, "^[a-z-\\.]+$"],
+        "no-restricted-imports": ["error", "material-ui", "material-ui-icons"]
     }
 }

--- a/packages/dx-react-demos/src/material-ui/basic/table-cell-template.jsx
+++ b/packages/dx-react-demos/src/material-ui/basic/table-cell-template.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TableCell, Paper } from 'material-ui';
+import Paper from 'material-ui/Paper';
+import { TableCell } from 'material-ui/Table';
 import {
   Grid,
   Table,

--- a/packages/dx-react-demos/src/material-ui/basic/table-row-template.jsx
+++ b/packages/dx-react-demos/src/material-ui/basic/table-row-template.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Paper } from 'material-ui';
+import Paper from 'material-ui/Paper';
 import {
   Grid,
   Table,

--- a/packages/dx-react-demos/src/material-ui/components/loading.jsx
+++ b/packages/dx-react-demos/src/material-ui/components/loading.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CircularProgress } from 'material-ui';
+import { CircularProgress } from 'material-ui/Progress';
 
 import './loading.css';
 

--- a/packages/dx-react-demos/src/material-ui/data-types/editors.jsx
+++ b/packages/dx-react-demos/src/material-ui/data-types/editors.jsx
@@ -11,13 +11,11 @@ import {
   TableEditRow,
   TableEditColumn,
 } from '@devexpress/dx-react-grid-material-ui';
-import {
-  Chip,
-  Input,
-  MenuItem,
-  Paper,
-  Select,
-} from 'material-ui';
+import Paper from 'material-ui/Paper';
+import Chip from 'material-ui/Chip';
+import Input from 'material-ui/Input';
+import Select from 'material-ui/Select';
+import { MenuItem } from 'material-ui/Menu';
 
 import {
   generateRows,

--- a/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-controlled-mode/demo.jsx
@@ -9,20 +9,19 @@ import {
   Table, TableHeaderRow, TableEditRow, TableEditColumn,
   PagingPanel, DragDropProvider, TableColumnReordering,
 } from '@devexpress/dx-react-grid-material-ui';
-import {
-  TableCell,
-  Button,
-  IconButton,
-  Input,
-  Dialog,
+import Paper from 'material-ui/Paper';
+import Dialog, {
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
-  MenuItem,
-  Select,
-  Paper,
-} from 'material-ui';
+} from 'material-ui/Dialog';
+import Button from 'material-ui/Button';
+import IconButton from 'material-ui/IconButton';
+import Input from 'material-ui/Input';
+import Select from 'material-ui/Select';
+import { MenuItem } from 'material-ui/Menu';
+import { TableCell } from 'material-ui/Table';
 
 import DeleteIcon from 'material-ui-icons/Delete';
 import EditIcon from 'material-ui-icons/Edit';

--- a/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
+++ b/packages/dx-react-demos/src/material-ui/featured-remote-data/demo.jsx
@@ -11,7 +11,8 @@ import {
   TableHeaderRow,
   PagingPanel,
 } from '@devexpress/dx-react-grid-material-ui';
-import { TableCell, Paper } from 'material-ui';
+import Paper from 'material-ui/Paper';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 import { Loading } from '../components/loading';
 

--- a/packages/dx-react-demos/src/material-ui/filtering/custom-filter-row.jsx
+++ b/packages/dx-react-demos/src/material-ui/filtering/custom-filter-row.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Input, TableCell, Paper } from 'material-ui';
+import Paper from 'material-ui/Paper';
+import Input from 'material-ui/Input';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 import {
   FilteringState,

--- a/packages/dx-react-demos/src/material-ui/grouping/custom-advanced.jsx
+++ b/packages/dx-react-demos/src/material-ui/grouping/custom-advanced.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Paper } from 'material-ui';
+import Paper from 'material-ui/Paper';
 import {
   GroupingState,
   IntegratedGrouping,

--- a/packages/dx-react-demos/src/material-ui/templates/highlighted-cell.jsx
+++ b/packages/dx-react-demos/src/material-ui/templates/highlighted-cell.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TableCell } from 'material-ui';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
 const getColor = (amount) => {

--- a/packages/dx-react-demos/src/material-ui/templates/progress-bar-cell.jsx
+++ b/packages/dx-react-demos/src/material-ui/templates/progress-bar-cell.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TableCell } from 'material-ui';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({

--- a/packages/dx-react-grid-material-ui/.eslintrc.json
+++ b/packages/dx-react-grid-material-ui/.eslintrc.json
@@ -15,7 +15,8 @@
         "jsx-a11y/click-events-have-key-events": "off",
         "jsx-a11y/href-no-hash": "off",
         "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.*", "**/testing.*"]}],
-        "filenames/match-regex": [2, "^[a-z-\\.]+$"]
+        "filenames/match-regex": [2, "^[a-z-\\.]+$"],
+        "no-restricted-imports": ["error", "material-ui", "material-ui-icons"]
     },
     "env": {
       "jest/globals": true

--- a/packages/dx-react-grid-material-ui/src/templates/column-chooser/container.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/column-chooser/container.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { List } from 'material-ui';
+import List from 'material-ui/List';
 
 export const Container = ({ children, ...restProps }) => (
   <List

--- a/packages/dx-react-grid-material-ui/src/templates/column-chooser/overlay.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/column-chooser/overlay.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Popover } from 'material-ui';
+import Popover from 'material-ui/Popover';
 
 export const Overlay = ({
   visible, onHide,

--- a/packages/dx-react-grid-material-ui/src/templates/column-chooser/overlay.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/column-chooser/overlay.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Popover } from 'material-ui';
+import Popover from 'material-ui/Popover';
 import { Overlay } from './overlay';
 
 describe('Overlay', () => {

--- a/packages/dx-react-grid-material-ui/src/templates/column-chooser/toggle-button.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/column-chooser/toggle-button.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { IconButton, Tooltip } from 'material-ui';
+import IconButton from 'material-ui/IconButton';
+import Tooltip from 'material-ui/Tooltip';
 import VisibilityOff from 'material-ui-icons/VisibilityOff';
 
 export const ToggleButton = ({

--- a/packages/dx-react-grid-material-ui/src/templates/column-chooser/toggle-button.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/column-chooser/toggle-button.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Tooltip } from 'material-ui';
+import Tooltip from 'material-ui/Tooltip';
 import { ToggleButton } from './toggle-button';
 
 const defaultProps = {

--- a/packages/dx-react-grid-material-ui/src/templates/drag-drop.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/drag-drop.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Paper, Typography } from 'material-ui';
+import Paper from 'material-ui/Paper';
+import Typography from 'material-ui/Typography';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({

--- a/packages/dx-react-grid-material-ui/src/templates/drag-drop.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/drag-drop.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Paper } from 'material-ui';
+import Paper from 'material-ui/Paper';
 import { createShallow, getClasses } from 'material-ui/test-utils';
 import { Container, Column } from './drag-drop';
 

--- a/packages/dx-react-grid-material-ui/src/templates/empty-message.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/empty-message.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createShallow } from 'material-ui/test-utils';
-import { Typography } from 'material-ui';
+import Typography from 'material-ui/Typography';
 import { EmptyMessage } from './empty-message';
 
 describe('EmptyMessage', () => {

--- a/packages/dx-react-grid-material-ui/src/templates/group-panel-item.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/group-panel-item.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { TableSortLabel, Chip } from 'material-ui';
+import { TableSortLabel } from 'material-ui/Table';
+import Chip from 'material-ui/Chip';
 import { withStyles } from 'material-ui/styles';
 
 const ENTER_KEY_CODE = 13;

--- a/packages/dx-react-grid-material-ui/src/templates/group-panel-item.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/group-panel-item.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Chip } from 'material-ui';
+import Chip from 'material-ui/Chip';
 import { createMount, createShallow, getClasses } from 'material-ui/test-utils';
 import { GroupPanelItem } from './group-panel-item';
 

--- a/packages/dx-react-grid-material-ui/src/templates/paging-panel/pagination.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/paging-panel/pagination.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Button, IconButton } from 'material-ui';
+import Button from 'material-ui/Button';
+import IconButton from 'material-ui/IconButton';
 import { withStyles } from 'material-ui/styles';
 import ChevronLeft from 'material-ui-icons/ChevronLeft';
 import ChevronRight from 'material-ui-icons/ChevronRight';

--- a/packages/dx-react-grid-material-ui/src/templates/table-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-cell.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-
-import {
-  TableCell as TableCellMUI,
-} from 'material-ui';
+import { TableCell as TableCellMUI } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({

--- a/packages/dx-react-grid-material-ui/src/templates/table-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-cell.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TableCell as TableCellMUI } from 'material-ui';
+import { TableCell as TableCellMUI } from 'material-ui/Table';
 import { createShallow, getClasses } from 'material-ui/test-utils';
 import { TableCell } from './table-cell';
 

--- a/packages/dx-react-grid-material-ui/src/templates/table-detail-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-detail-cell.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { TableCell } from 'material-ui';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({

--- a/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { TableCell } from 'material-ui';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
 import ChevronRight from 'material-ui-icons/ChevronRight';

--- a/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createShallow, getClasses } from 'material-ui/test-utils';
-import { IconButton } from 'material-ui';
+import IconButton from 'material-ui/IconButton';
 import { TableDetailToggleCell } from './table-detail-toggle-cell';
 
 describe('TableDetailToggleCell', () => {

--- a/packages/dx-react-grid-material-ui/src/templates/table-edit-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-edit-cell.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Input from 'material-ui/Input';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
-
-import {
-  TableCell,
-  Input,
-} from 'material-ui';
 
 const styles = theme => ({
   cell: {

--- a/packages/dx-react-grid-material-ui/src/templates/table-edit-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-edit-cell.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Input, TableCell } from 'material-ui';
+import Input from 'material-ui/Input';
+import { TableCell } from 'material-ui/Table';
 import { createShallow, getClasses } from 'material-ui/test-utils';
 import { EditCell } from './table-edit-cell';
 

--- a/packages/dx-react-grid-material-ui/src/templates/table-edit-command-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-edit-command-cell.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Button from 'material-ui/Button';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
-
-import {
-  Button,
-  TableCell,
-} from 'material-ui';
 
 const styles = theme => ({
   button: {

--- a/packages/dx-react-grid-material-ui/src/templates/table-filter-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-filter-cell.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { TableCell, Input } from 'material-ui';
+import Input from 'material-ui/Input';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({

--- a/packages/dx-react-grid-material-ui/src/templates/table-filter-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-filter-cell.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createShallow, getClasses } from 'material-ui/test-utils';
-import { Input } from 'material-ui';
+import Input from 'material-ui/Input';
 import { TableFilterCell } from './table-filter-cell';
 
 describe('TableFilterCell', () => {

--- a/packages/dx-react-grid-material-ui/src/templates/table-group-row-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-group-row-cell.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createMount, createShallow, getClasses } from 'material-ui/test-utils';
-import { TableCell } from 'material-ui';
+import { TableCell } from 'material-ui/Table';
 import { setupConsole } from '@devexpress/dx-testing';
 import { TableGroupCell } from './table-group-row-cell';
 

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import { DragSource } from '@devexpress/dx-react-core';
 
-import { TableCell } from 'material-ui';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
 import { GroupingControl } from './table-header-cell/grouping-control';

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TableCell, TableSortLabel } from 'material-ui';
+import { TableCell, TableSortLabel } from 'material-ui/Table';
 import { createMount, createShallow, getClasses } from 'material-ui/test-utils';
 import { setupConsole } from '@devexpress/dx-testing';
 import { DragDropProvider, DragSource } from '@devexpress/dx-react-core';

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell/sorting-control.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell/sorting-control.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { TableSortLabel, Tooltip } from 'material-ui';
+import { TableSortLabel } from 'material-ui/Table';
+import Tooltip from 'material-ui/Tooltip';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({

--- a/packages/dx-react-grid-material-ui/src/templates/table-layout.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-layout.jsx
@@ -4,10 +4,7 @@ import {
   TableLayout as TableLayoutCore,
   StaticTableLayout,
 } from '@devexpress/dx-react-grid';
-import {
-  TableBody,
-  TableHead,
-} from 'material-ui';
+import { TableBody, TableHead } from 'material-ui/Table';
 import { TableContainer } from './table-container';
 import { Table } from './table';
 

--- a/packages/dx-react-grid-material-ui/src/templates/table-no-data-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-no-data-cell.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-
-import {
-  TableCell,
-} from 'material-ui';
-
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({

--- a/packages/dx-react-grid-material-ui/src/templates/table-row.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-row.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TableRow as TableRowMUI } from 'material-ui';
+import { TableRow as TableRowMUI } from 'material-ui/Table';
 
 export const TableRow = ({
   children,

--- a/packages/dx-react-grid-material-ui/src/templates/table-select-all-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-select-all-cell.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import {
-  Checkbox,
-  TableCell,
-} from 'material-ui';
+import Checkbox from 'material-ui/Checkbox';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({

--- a/packages/dx-react-grid-material-ui/src/templates/table-select-all-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-select-all-cell.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Checkbox } from 'material-ui';
+import Checkbox from 'material-ui/Checkbox';
 import { createMount, createShallow, getClasses } from 'material-ui/test-utils';
 import { setupConsole } from '@devexpress/dx-testing';
 import { TableSelectAllCell } from './table-select-all-cell';

--- a/packages/dx-react-grid-material-ui/src/templates/table-select-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-select-cell.jsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-
-import {
-  Checkbox,
-  TableCell,
-} from 'material-ui';
-
+import Checkbox from 'material-ui/Checkbox';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({

--- a/packages/dx-react-grid-material-ui/src/templates/table-select-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-select-cell.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Checkbox } from 'material-ui';
+import Checkbox from 'material-ui/Checkbox';
 import { createMount, createShallow, getClasses } from 'material-ui/test-utils';
 import { setupConsole } from '@devexpress/dx-testing';
 import { TableSelectCell } from './table-select-cell';

--- a/packages/dx-react-grid-material-ui/src/templates/table-select-row.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-select-row.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TableRow } from 'material-ui';
+import { TableRow } from 'material-ui/Table';
 
 export const TableSelectRow = ({
   selected,

--- a/packages/dx-react-grid-material-ui/src/templates/table-select-row.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-select-row.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TableRow as TableRowMUI } from 'material-ui';
+import { TableRow as TableRowMUI } from 'material-ui/Table';
 import { createMount } from 'material-ui/test-utils';
 import { setupConsole } from '@devexpress/dx-testing';
 import { TableSelectRow } from './table-select-row';

--- a/packages/dx-react-grid-material-ui/src/templates/table-stub-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-stub-cell.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { TableCell } from 'material-ui';
+import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
 const styles = {

--- a/packages/dx-react-grid-material-ui/src/templates/table.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Table as TableMUI } from 'material-ui';
+import TableMUI from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({

--- a/packages/dx-react-grid-material-ui/src/templates/toolbar/toolbar.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/toolbar/toolbar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Toolbar as ToolbarMUI } from 'material-ui';
+import ToolbarMUI from 'material-ui/Toolbar';
 import { withStyles } from 'material-ui/styles';
 import { darken, fade, lighten } from 'material-ui/styles/colorManipulator';
 

--- a/packages/dx-react-grid-material-ui/src/templates/virtual-table-layout.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/virtual-table-layout.jsx
@@ -4,10 +4,7 @@ import {
   TableLayout,
   VirtualTableLayout as VirtualTableLayoutCore,
 } from '@devexpress/dx-react-grid';
-import {
-  TableBody,
-  TableHead,
-} from 'material-ui';
+import { TableBody, TableHead } from 'material-ui/Table';
 import { TableContainer } from './table-container';
 import { Table } from './table';
 


### PR DESCRIPTION
related to #671