### PR TITLE
add option to have title as object

### DIFF
--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell/sorting-control.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell/sorting-control.jsx
@@ -61,7 +61,7 @@ SortingControlBase.propTypes = {
 SortingControlBase.defaultProps = {
   sortingDirection: undefined,
   disabled: false,
-  columnTitle: ''
+  columnTitle: '',
 };
 
 export const SortingControl = withStyles(styles, { name: 'SortingControl' })(SortingControlBase);

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell/sorting-control.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell/sorting-control.jsx
@@ -50,7 +50,7 @@ SortingControlBase.propTypes = {
   sortingDirection: PropTypes.oneOf(['asc', 'desc', null]),
   columnTitle: PropTypes.oneOfType([
     PropTypes.object.isRequired,
-    PropTypes.string.isRequired
+    PropTypes.string.isRequired,
   ]),
   classes: PropTypes.object.isRequired,
   onClick: PropTypes.func.isRequired,
@@ -61,6 +61,7 @@ SortingControlBase.propTypes = {
 SortingControlBase.defaultProps = {
   sortingDirection: undefined,
   disabled: false,
+  columnTitle: ''
 };
 
 export const SortingControl = withStyles(styles, { name: 'SortingControl' })(SortingControlBase);

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell/sorting-control.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell/sorting-control.jsx
@@ -48,7 +48,10 @@ const SortingControlBase = ({
 SortingControlBase.propTypes = {
   align: PropTypes.string.isRequired,
   sortingDirection: PropTypes.oneOf(['asc', 'desc', null]),
-  columnTitle: PropTypes.string.isRequired,
+  columnTitle: PropTypes.oneOfType([
+    PropTypes.object.isRequired,
+    PropTypes.string.isRequired
+  ]),
   classes: PropTypes.object.isRequired,
   onClick: PropTypes.func.isRequired,
   getMessage: PropTypes.func.isRequired,


### PR DESCRIPTION
i want to be able to create the title as object to have it as div with tooltip node:
```
<div>
         <span data-tip data-for={`test`}>{title}</span>
         <ReactTooltip id={`test`} effect="solid">
                <div style={{lineHeight:1.5}}>
                     <span>Resolution: {resolution}</span>
                     <br/>
                     <span>Name: {title}</span>
                </div>
         </ReactTooltip>
</div>
```