### PR TITLE
material-ui-icons moved to @material-ui/icons

### DIFF
--- a/packages/dx-react-grid-material-ui/package.json
+++ b/packages/dx-react-grid-material-ui/package.json
@@ -47,6 +47,7 @@
     "@devexpress/dx-react-core": "1.1.0",
     "@devexpress/dx-react-grid": "1.1.0",
     "@devexpress/dx-testing": "1.1.0",
+    "@material-ui/icons": "^1.0.0-beta.42",
     "babel-core": "^6.26.0",
     "babel-jest": "^22.4.1",
     "babel-plugin-external-helpers": "^6.22.0",
@@ -70,7 +71,6 @@
     "jss-preset-default": "^4.3.0",
     "jss-theme-reactor": "^0.11.1",
     "material-ui": "1.0.0-beta.37",
-    "material-ui-icons": "1.0.0-beta.36",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
@@ -87,8 +87,8 @@
     "@devexpress/dx-grid-core": "1.1.0",
     "@devexpress/dx-react-core": "1.1.0",
     "@devexpress/dx-react-grid": "1.1.0",
+    "@material-ui/icons": "^1.0.0-beta.42",
     "material-ui": "1.0.0-beta.37",
-    "material-ui-icons": "1.0.0-beta.36",
     "react": "^16.2.0"
   }
 }

--- a/packages/dx-react-grid-material-ui/src/templates/column-chooser/toggle-button.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/column-chooser/toggle-button.jsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import IconButton from 'material-ui/IconButton';
 import Tooltip from 'material-ui/Tooltip';
-import VisibilityOff from 'material-ui-icons/VisibilityOff';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
 
 export const ToggleButton = ({
   onToggle, getMessage,

--- a/packages/dx-react-grid-material-ui/src/templates/paging-panel/pagination.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/paging-panel/pagination.jsx
@@ -4,8 +4,8 @@ import classNames from 'classnames';
 import Button from 'material-ui/Button';
 import IconButton from 'material-ui/IconButton';
 import { withStyles } from 'material-ui/styles';
-import ChevronLeft from 'material-ui-icons/ChevronLeft';
-import ChevronRight from 'material-ui-icons/ChevronRight';
+import ChevronLeft from '@material-ui/icons/ChevronLeft';
+import ChevronRight from '@material-ui/icons/ChevronRight';
 import { firstRowOnPage, lastRowOnPage } from '@devexpress/dx-grid-core';
 
 const styles = theme => ({

--- a/packages/dx-react-grid-material-ui/src/templates/search-panel-input.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/search-panel-input.jsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import Input, { InputAdornment } from 'material-ui/Input';
-import Search from 'material-ui-icons/Search';
+import Search from '@material-ui/icons/Search';
 
 const styles = theme => ({
   root: {

--- a/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.jsx
@@ -4,8 +4,8 @@ import classNames from 'classnames';
 import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';
 
-import ChevronRight from 'material-ui-icons/ChevronRight';
-import ExpandMore from 'material-ui-icons/ExpandMore';
+import ChevronRight from '@material-ui/icons/ChevronRight';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import IconButton from 'material-ui/IconButton';
 
 const styles = theme => ({

--- a/packages/dx-react-grid-material-ui/src/templates/table-group-row-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-group-row-cell.jsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
-import ChevronRight from 'material-ui-icons/ChevronRight';
-import ExpandMore from 'material-ui-icons/ExpandMore';
+import ChevronRight from '@material-ui/icons/ChevronRight';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import IconButton from 'material-ui/IconButton';
 import { TableCell } from 'material-ui/Table';
 import { withStyles } from 'material-ui/styles';

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell/grouping-control.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell/grouping-control.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
-import List from 'material-ui-icons/List';
+import List from '@material-ui/icons/List';
 import { withStyles } from 'material-ui/styles';
 
 const styles = theme => ({


### PR DESCRIPTION
The icon library has moved to package `@material-ui/icons`, see also:
https://github.com/mui-org/material-ui/releases/tag/v1.0.0-beta.41