### PR TITLE
minColumnWidth isRequired creates warnings

### DIFF
--- a/packages/dx-react-grid/src/plugins/table-column-resizing.jsx
+++ b/packages/dx-react-grid/src/plugins/table-column-resizing.jsx
@@ -92,4 +92,5 @@ TableColumnResizing.defaultProps = {
   defaultColumnWidths: [],
   columnWidths: undefined,
   onColumnWidthsChange: undefined,
+  minColumnWidth: 0,
 };


### PR DESCRIPTION
Fix the issue by defaulting with a initial value.