### PR TITLE
fix(react-grid-material-ui): reverse detail toggle icons

### DIFF
--- a/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.jsx
@@ -46,8 +46,8 @@ const TableDetailToggleCellBase = ({
       >
         {
           expanded
-            ? <ExpandMore />
-            : <ExpandLess />
+            ? <ExpandLess />
+            : <ExpandMore />
         }
       </IconButton>
     </TableCell>

--- a/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.test.jsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { createShallow, getClasses } from 'material-ui/test-utils';
 import IconButton from 'material-ui/IconButton';
 import { TableDetailToggleCell } from './table-detail-toggle-cell';
+import ExpandMore from '@material-ui/icons/ExpandMore';
+import ExpandLess from '@material-ui/icons/ExpandLess';
 
 describe('TableDetailToggleCell', () => {
   let shallow;
@@ -62,5 +64,25 @@ describe('TableDetailToggleCell', () => {
 
     expect(tree.props().data)
       .toMatchObject({ a: 1 });
+  });
+
+  it('should correct render icon', () => {
+    let tree = shallow((
+      <TableDetailToggleCell expanded />
+    ));
+
+    expect(tree.find(ExpandLess).exists())
+      .toBeTruthy();
+    expect(tree.find(ExpandMore).exists())
+      .toBeFalsy();
+
+    tree = shallow((
+      <TableDetailToggleCell />
+    ));
+
+    expect(tree.find(ExpandLess).exists())
+      .toBeFalsy();
+    expect(tree.find(ExpandMore).exists())
+      .toBeTruthy();
   });
 });

--- a/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-detail-toggle-cell.test.jsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { createShallow, getClasses } from 'material-ui/test-utils';
 import IconButton from 'material-ui/IconButton';
-import { TableDetailToggleCell } from './table-detail-toggle-cell';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import ExpandLess from '@material-ui/icons/ExpandLess';
+import { TableDetailToggleCell } from './table-detail-toggle-cell';
 
 describe('TableDetailToggleCell', () => {
   let shallow;


### PR DESCRIPTION
fixes #942