### PR TITLE
fix(react-grid-material-ui): rotate grid pagination arrows for RTL layouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # IDE
 .vscode
+.idea
 
 # Node
 **/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # IDE
 .vscode
-.idea
 
 # Node
 **/node_modules

--- a/packages/dx-react-grid-material-ui/src/templates/paging-panel/pagination.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/paging-panel/pagination.jsx
@@ -31,6 +31,7 @@ const styles = theme => ({
     height: theme.spacing.unit * 4,
     display: 'inline-block',
     verticalAlign: 'middle',
+    transform: theme.direction === 'rtl' ? 'rotate(180deg)' : null
   },
   prev: {
     marginRight: 0,

--- a/packages/dx-react-grid-material-ui/src/templates/paging-panel/pagination.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/paging-panel/pagination.jsx
@@ -31,7 +31,7 @@ const styles = theme => ({
     height: theme.spacing.unit * 4,
     display: 'inline-block',
     verticalAlign: 'middle',
-    transform: theme.direction === 'rtl' ? 'rotate(180deg)' : null
+    transform: theme.direction === 'rtl' ? 'rotate(180deg)' : null,
   },
   prev: {
     marginRight: 0,


### PR DESCRIPTION
`dx-react-grid-material-ui`:
Pagination arrows In RTL layouts need to be rotated.