### PR TITLE
fix(react-core) check for "Proxy"

### DIFF
--- a/packages/dx-react-core/src/plugin-based/helpers.js
+++ b/packages/dx-react-core/src/plugin-based/helpers.js
@@ -7,7 +7,7 @@ export const getAvailableGetters = (
   const trackedDependencies = {};
 
   let getters;
-  if (Proxy) {
+  if (typeof Proxy !== 'undefined') {
     getters = new Proxy({}, {
       get(target, prop) {
         if (typeof prop !== 'string') return undefined;
@@ -57,7 +57,7 @@ export const getAvailableActions = (
   getAction = actionName => pluginHost.collect(`${actionName}Action`).slice().reverse()[0],
 ) => {
   let actions;
-  if (Proxy) {
+  if (typeof Proxy !== 'undefined') {
     actions = new Proxy({}, {
       get(target, prop) {
         if (typeof prop !== 'string') return undefined;

--- a/packages/dx-vue-core/src/plugin-based/helpers.js
+++ b/packages/dx-vue-core/src/plugin-based/helpers.js
@@ -7,7 +7,7 @@ export const getAvailableGetters = (
   const trackedDependencies = {};
 
   let getters;
-  if (Proxy) {
+  if (typeof Proxy !== 'undefined') {
     getters = new Proxy({}, {
       get(target, prop) {
         if (typeof prop !== 'string') return undefined;
@@ -59,7 +59,7 @@ export const getAvailableActions = (
   getAction = actionName => pluginHost.collect(`${actionName}Action`).slice().reverse()[0],
 ) => {
   let actions;
-  if (Proxy) {
+  if (typeof Proxy !== 'undefined') {
     actions = new Proxy({}, {
       get(target, prop) {
         if (typeof prop !== 'string') return undefined;


### PR DESCRIPTION
There is a difference between a variable being unset and not being declared at all.

```js
var asdf // unset variable

if (asdf) {
  // nope
} else {
  // executed
}


if (ddff) { // using of undeclared variable (exception is thrown)
  // nope
} else {
  // nope
}


if (typeof ddff !== 'undefined') {
  // nope
} else {
  // executed
}
```

I encountered the error in IE11.