### PR TITLE
fix(react-chart): fix errors for BarSeries plugin

### DIFF
--- a/packages/dx-react-chart/src/plugins/bar-series.jsx
+++ b/packages/dx-react-chart/src/plugins/bar-series.jsx
@@ -10,6 +10,7 @@ const Series = ({
     pointComponent: Point,
     coordinates,
     path,
+    barWidth,
     ...restProps
   } = props;
   return (coordinates.map(item => (


### PR DESCRIPTION
Fix [1272](https://github.com/DevExpress/devextreme-reactive/issues/1272)