### PR TITLE
 docs(material-ui): Use the official wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -984,7 +984,7 @@ To provide a more convenient and flexible way to render elements that are placed
   </Grid>
   ```
   The related [guide](https://devexpress.github.io/devextreme-reactive/react/grid/docs/guides/immutable-data/) is updated as well.
-* **react-grid-material-ui:** To make Grid for Material UI more flexible we've stopped using the [Paper](https://material-ui-1dab0.firebaseapp.com/demos/paper/) component inside the Grid's layout.
+* **react-grid-material-ui:** To make Grid for Material-UI more flexible we've stopped using the [Paper](https://material-ui.com/demos/paper/) component inside the Grid's layout.
  
 It allows placing our Grid to an existing Paper with other components. For example:
 
@@ -1499,7 +1499,7 @@ The `column` field is no longer present in the GroupRow interface. So, to access
 
 ### Reverts
 
-* fix(react-grid): grid bottom offset in Material UI ([#196](https://github.com/DevExpress/devextreme-reactive/issues/196)) ([e2392ed](https://github.com/DevExpress/devextreme-reactive/commit/e2392ed))
+* fix(react-grid): grid bottom offset in Material-UI ([#196](https://github.com/DevExpress/devextreme-reactive/issues/196)) ([e2392ed](https://github.com/DevExpress/devextreme-reactive/commit/e2392ed))
 
 
 ### BREAKING CHANGES
@@ -1515,8 +1515,8 @@ The `column` field is no longer present in the GroupRow interface. So, to access
 
 ### Bug Fixes
 
-* **react-grid:** add grid bottom offset in Material UI ([#180](https://github.com/DevExpress/devextreme-reactive/issues/180)) ([48f12a2](https://github.com/DevExpress/devextreme-reactive/commit/48f12a2))
-* **react-grid:** add group icon offset in Material UI ([#171](https://github.com/DevExpress/devextreme-reactive/issues/171)) ([43d9da1](https://github.com/DevExpress/devextreme-reactive/commit/43d9da1))
+* **react-grid:** add grid bottom offset in Material-UI ([#180](https://github.com/DevExpress/devextreme-reactive/issues/180)) ([48f12a2](https://github.com/DevExpress/devextreme-reactive/commit/48f12a2))
+* **react-grid:** add group icon offset in Material-UI ([#171](https://github.com/DevExpress/devextreme-reactive/issues/171)) ([43d9da1](https://github.com/DevExpress/devextreme-reactive/commit/43d9da1))
 * **react-grid:** limit filterCellTemplate arguments ([#163](https://github.com/DevExpress/devextreme-reactive/issues/163)) ([2a4f003](https://github.com/DevExpress/devextreme-reactive/commit/2a4f003))
 * **react-grid:** reset a column filter when clearing the filter editor value ([#184](https://github.com/DevExpress/devextreme-reactive/issues/184)) ([83b321c](https://github.com/DevExpress/devextreme-reactive/commit/83b321c)), closes [#136](https://github.com/DevExpress/devextreme-reactive/issues/136)
 * **react-grid:** use MUI Chips for group panel items rendering ([#168](https://github.com/DevExpress/devextreme-reactive/issues/168)) ([45ceb12](https://github.com/DevExpress/devextreme-reactive/commit/45ceb12))
@@ -1530,7 +1530,7 @@ The `column` field is no longer present in the GroupRow interface. So, to access
 ### Features
 
 * **react-grid:** introduce column reordering animation ([#169](https://github.com/DevExpress/devextreme-reactive/issues/169)) ([d5e808b](https://github.com/DevExpress/devextreme-reactive/commit/d5e808b))
-* **react-grid:** introduce Material UI templates (closes [#93](https://github.com/DevExpress/devextreme-reactive/issues/93))
+* **react-grid:** introduce Material-UI templates (closes [#93](https://github.com/DevExpress/devextreme-reactive/issues/93))
 
 
 ### BREAKING CHANGES
@@ -1546,7 +1546,7 @@ The `column` field is no longer present in the GroupRow interface. So, to access
 ### Bug Fixes
 
 * **react-grid:** Add a vertical space between grouping buttons ([#151](https://github.com/DevExpress/devextreme-reactive/issues/151)) ([ec1bd30](https://github.com/DevExpress/devextreme-reactive/commit/ec1bd30))
-* **react-grid:** Add an offset for left column in Material UI ([#156](https://github.com/DevExpress/devextreme-reactive/issues/156)) ([67d0eda](https://github.com/DevExpress/devextreme-reactive/commit/67d0eda))
+* **react-grid:** Add an offset for left column in Material-UI ([#156](https://github.com/DevExpress/devextreme-reactive/issues/156)) ([67d0eda](https://github.com/DevExpress/devextreme-reactive/commit/67d0eda))
 * **react-grid:** Fix incorrect table layout if all columns have fixed width ([#160](https://github.com/DevExpress/devextreme-reactive/issues/160)) ([b933aea](https://github.com/DevExpress/devextreme-reactive/commit/b933aea))
 * **react-grid:** Put the dx-react-grid dependencies in order ([#148](https://github.com/DevExpress/devextreme-reactive/issues/148)) ([fe60801](https://github.com/DevExpress/devextreme-reactive/commit/fe60801))
 * **react-grid:** Update deps (fixes [#134](https://github.com/DevExpress/devextreme-reactive/issues/134)) ([#139](https://github.com/DevExpress/devextreme-reactive/issues/139)) ([5bf504a](https://github.com/DevExpress/devextreme-reactive/commit/5bf504a))
@@ -1586,7 +1586,7 @@ The `column` field is no longer present in the GroupRow interface. So, to access
 
 ### Bug Fixes
 
-* **react-grid:** Cancel sorting by using the Ctrl key in Material UI ([#129](https://github.com/DevExpress/devextreme-reactive/issues/129)) ([2508537](https://github.com/DevExpress/devextreme-reactive/commit/2508537))
+* **react-grid:** Cancel sorting by using the Ctrl key in Material-UI ([#129](https://github.com/DevExpress/devextreme-reactive/issues/129)) ([2508537](https://github.com/DevExpress/devextreme-reactive/commit/2508537))
 * **react-grid:** Treat templates as functions ([#120](https://github.com/DevExpress/devextreme-reactive/issues/120)) ([4b2c490](https://github.com/DevExpress/devextreme-reactive/commit/4b2c490))
 
 
@@ -1597,18 +1597,18 @@ The `column` field is no longer present in the GroupRow interface. So, to access
 
 ### Features
 
-* **react-grid:** Controlled state featured demo for Material UI ([#130](https://github.com/DevExpress/devextreme-reactive/issues/130)) ([2528c67](https://github.com/DevExpress/devextreme-reactive/commit/2528c67))
+* **react-grid:** Controlled state featured demo for Material-UI ([#130](https://github.com/DevExpress/devextreme-reactive/issues/130)) ([2528c67](https://github.com/DevExpress/devextreme-reactive/commit/2528c67))
 * **react-grid:** Implement ColumnOrderState plugin ([#111](https://github.com/DevExpress/devextreme-reactive/issues/111)) ([b3284f0](https://github.com/DevExpress/devextreme-reactive/commit/b3284f0))
 * **react-grid:** Implement DragDropContext plugin ([#117](https://github.com/DevExpress/devextreme-reactive/issues/117)) ([31f6b2d](https://github.com/DevExpress/devextreme-reactive/commit/31f6b2d))
-* **react-grid:** Introduce Material UI templates ([#102](https://github.com/DevExpress/devextreme-reactive/issues/102)) ([70975a7](https://github.com/DevExpress/devextreme-reactive/commit/70975a7))
-* **react-grid:** Material UI detail row ([#115](https://github.com/DevExpress/devextreme-reactive/issues/115)) ([c161c66](https://github.com/DevExpress/devextreme-reactive/commit/c161c66))
-* **react-grid:** Material UI editing ([#124](https://github.com/DevExpress/devextreme-reactive/issues/124)) ([3d9a00b](https://github.com/DevExpress/devextreme-reactive/commit/3d9a00b))
-* **react-grid:** Material UI featured uncontrolled state demo ([#126](https://github.com/DevExpress/devextreme-reactive/issues/126)) ([8e1d80b](https://github.com/DevExpress/devextreme-reactive/commit/8e1d80b))
-* **react-grid:** Material UI filtering ([#109](https://github.com/DevExpress/devextreme-reactive/issues/109)) ([5484942](https://github.com/DevExpress/devextreme-reactive/commit/5484942))
-* **react-grid:** Material UI pager ([#108](https://github.com/DevExpress/devextreme-reactive/issues/108)) ([99f30b6](https://github.com/DevExpress/devextreme-reactive/commit/99f30b6))
+* **react-grid:** Introduce Material-UI templates ([#102](https://github.com/DevExpress/devextreme-reactive/issues/102)) ([70975a7](https://github.com/DevExpress/devextreme-reactive/commit/70975a7))
+* **react-grid:** Material-UI detail row ([#115](https://github.com/DevExpress/devextreme-reactive/issues/115)) ([c161c66](https://github.com/DevExpress/devextreme-reactive/commit/c161c66))
+* **react-grid:** Material-UI editing ([#124](https://github.com/DevExpress/devextreme-reactive/issues/124)) ([3d9a00b](https://github.com/DevExpress/devextreme-reactive/commit/3d9a00b))
+* **react-grid:** Material-UI featured uncontrolled state demo ([#126](https://github.com/DevExpress/devextreme-reactive/issues/126)) ([8e1d80b](https://github.com/DevExpress/devextreme-reactive/commit/8e1d80b))
+* **react-grid:** Material-UI filtering ([#109](https://github.com/DevExpress/devextreme-reactive/issues/109)) ([5484942](https://github.com/DevExpress/devextreme-reactive/commit/5484942))
+* **react-grid:** Material-UI pager ([#108](https://github.com/DevExpress/devextreme-reactive/issues/108)) ([99f30b6](https://github.com/DevExpress/devextreme-reactive/commit/99f30b6))
 * **react-grid:** Mobile-friendly pager ([#125](https://github.com/DevExpress/devextreme-reactive/issues/125)) ([23ec7f0](https://github.com/DevExpress/devextreme-reactive/commit/23ec7f0))
-* **react-grid:** Redux integration demo for Material UI ([#132](https://github.com/DevExpress/devextreme-reactive/issues/132)) ([9988355](https://github.com/DevExpress/devextreme-reactive/commit/9988355))
-* **react-grid:** Remote data featured demo for Material UI ([#131](https://github.com/DevExpress/devextreme-reactive/issues/131)) ([41b64b2](https://github.com/DevExpress/devextreme-reactive/commit/41b64b2))
+* **react-grid:** Redux integration demo for Material-UI ([#132](https://github.com/DevExpress/devextreme-reactive/issues/132)) ([9988355](https://github.com/DevExpress/devextreme-reactive/commit/9988355))
+* **react-grid:** Remote data featured demo for Material-UI ([#131](https://github.com/DevExpress/devextreme-reactive/issues/131)) ([41b64b2](https://github.com/DevExpress/devextreme-reactive/commit/41b64b2))
 * **react-grid:** Use column name if its title is not specified ([#121](https://github.com/DevExpress/devextreme-reactive/issues/121)) ([daef7db](https://github.com/DevExpress/devextreme-reactive/commit/daef7db))
 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ DevExtreme Reactive is a set of business components for React and Vue that deepl
 
 ### Common Features
 
-- [Material UI](https://github.com/callemall/material-ui), [Bootstrap 4](http://reactstrap.github.io) and [Bootstrap 3](https://github.com/react-bootstrap/react-bootstrap) integration with seamless theming
+- [Material-UI](https://github.com/mui-org/material-ui), [Bootstrap 4](http://reactstrap.github.io) and [Bootstrap 3](https://github.com/react-bootstrap/react-bootstrap) integration with seamless theming
 - Controlled (stateless) and uncontrolled (stateful) modes
 - [Redux](https://github.com/reactjs/redux/) integration with state persistence and time-traveling
 

--- a/packages/dx-react-chart-demos/src/theme-registry.js
+++ b/packages/dx-react-chart-demos/src/theme-registry.js
@@ -2,15 +2,15 @@
 
 export const themes = [{
   name: 'material-ui',
-  title: 'Material UI',
+  title: 'Material-UI',
   variants: [{
     name: 'light',
-    title: 'Material UI Light',
+    title: 'Material-UI Light',
     DemoContainer: require('./theme-sources/material-ui/demo-container').default,
     links: ['https://fonts.googleapis.com/css?family=Roboto'],
   }, {
     name: 'dark',
-    title: 'Material UI Dark',
+    title: 'Material-UI Dark',
     DemoContainer: require('./theme-sources/material-ui/demo-container').Dark,
     links: ['https://fonts.googleapis.com/css?family=Roboto'],
   }],

--- a/packages/dx-react-chart-material-ui/README.md
+++ b/packages/dx-react-chart-material-ui/README.md
@@ -1,8 +1,8 @@
-# DevExtreme React Chart Material UI
+# DevExtreme React Chart Material-UI
 
 Project status: **CTP**
 
-A template suite used to render the React Chart based on Material UI components.
+A template suite used to render the React Chart based on Material-UI components.
 
 ## License
 

--- a/packages/dx-react-chart-material-ui/package.json
+++ b/packages/dx-react-chart-material-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@devexpress/dx-react-chart-material-ui",
   "version": "1.8.0",
-  "description": "Material UI templates for DevExtreme React Chart component",
+  "description": "Material-UI templates for DevExtreme React Chart component",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/packages/dx-react-chart/docs/guides/plugin-overview.md
+++ b/packages/dx-react-chart/docs/guides/plugin-overview.md
@@ -45,5 +45,5 @@ Note that the data processing plugin `Scale` should be defined after series and 
 
 The Chart's plugins use special components to render the UI. You can implement your component suite or use a predefined suite:
 
-- [DevExtreme React Chart for Material UI](https://github.com/DevExpress/devextreme-reactive/tree/master/packages/dx-react-chart-material-ui) - renders the Chart's UI elements based on [Material UI](http://www.material-ui.com) components.
+- [DevExtreme React Chart for Material-UI](https://github.com/DevExpress/devextreme-reactive/tree/master/packages/dx-react-chart-material-ui) - renders the Chart's UI elements based on [Material-UI](https://material-ui.com/) components.
 - [DevExtreme React Chart for Bootstrap 4](https://github.com/DevExpress/devextreme-reactive/tree/master/packages/dx-react-chart-bootstrap4) - renders the Chart's UI elements based on [Bootstrap 4](http://getbootstrap.com/) components.

--- a/packages/dx-react-chart/docs/reference/palette.md
+++ b/packages/dx-react-chart/docs/reference/palette.md
@@ -16,4 +16,4 @@ import { Palette } from '@devexpress/dx-react-chart';
 
 Name | Type | Default | Description
 -----|------|---------|------------
-scheme | Array&lt;string&gt; | ['#0070ff', '#d72e3d', '#249d3d', '#ffb90c', '#1698af', '#616a72'] for [Bootstrap4](https://www.npmjs.com/package/@devexpress/dx-react-chart-bootstrap4); ['#40C4FF', '#FF5252', '#00C853', '#FFEB3B', '#FF4081', '#E040FB'] for [Material UI](https://www.npmjs.com/package/@devexpress/dx-react-chart-material-ui); | An array of colors.
+scheme | Array&lt;string&gt; | ['#0070ff', '#d72e3d', '#249d3d', '#ffb90c', '#1698af', '#616a72'] for [Bootstrap4](https://www.npmjs.com/package/@devexpress/dx-react-chart-bootstrap4); ['#40C4FF', '#FF5252', '#00C853', '#FFEB3B', '#FF4081', '#E040FB'] for [Material-UI](https://www.npmjs.com/package/@devexpress/dx-react-chart-material-ui); | An array of colors.

--- a/packages/dx-react-grid-demos/src/theme-registry.js
+++ b/packages/dx-react-grid-demos/src/theme-registry.js
@@ -2,15 +2,15 @@
 
 export const themes = [{
   name: 'material-ui',
-  title: 'Material UI',
+  title: 'Material-UI',
   variants: [{
     name: 'light',
-    title: 'Material UI Light',
+    title: 'Material-UI Light',
     DemoContainer: require('./theme-sources/material-ui/demo-container').default,
     links: ['https://fonts.googleapis.com/css?family=Roboto'],
   }, {
     name: 'dark',
-    title: 'Material UI Dark',
+    title: 'Material-UI Dark',
     DemoContainer: require('./theme-sources/material-ui/demo-container').Dark,
     links: ['https://fonts.googleapis.com/css?family=Roboto'],
   }],

--- a/packages/dx-react-grid-material-ui/README.md
+++ b/packages/dx-react-grid-material-ui/README.md
@@ -1,6 +1,6 @@
-# DevExtreme React Grid Material UI
+# DevExtreme React Grid Material-UI
 
-A template suite used to render the React Grid based on Material UI components.
+A template suite used to render the React Grid based on Material-UI components.
 
 [Website](https://devexpress.github.io/devextreme-reactive/react/grid/)
 |

--- a/packages/dx-react-grid-material-ui/package.json
+++ b/packages/dx-react-grid-material-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@devexpress/dx-react-grid-material-ui",
   "version": "1.8.0",
-  "description": "Material UI templates for DevExtreme React Grid component",
+  "description": "Material-UI templates for DevExtreme React Grid component",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/packages/dx-react-grid/docs/guides/getting-started.md
+++ b/packages/dx-react-grid/docs/guides/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-DevExtreme React Grid is a component that displays table data from a local or remote source. It supports paging, sorting, filtering, grouping and other data shaping options, row selection, and data editing. Support for controlled and uncontrolled state modes allows you to use the Grid in a regular or Redux-based application. The DevExtreme Grid component has a composable and extendable plugin-based architecture and is provided with Twitter Bootstrap and Material UI rendering and theming out of the box.
+DevExtreme React Grid is a component that displays table data from a local or remote source. It supports paging, sorting, filtering, grouping and other data shaping options, row selection, and data editing. Support for controlled and uncontrolled state modes allows you to use the Grid in a regular or Redux-based application. The DevExtreme Grid component has a composable and extendable plugin-based architecture and is provided with Twitter Bootstrap and Material-UI rendering and theming out of the box.
 
 ## Installation
 
@@ -14,9 +14,9 @@ npm i --save @devexpress/dx-react-core.npm-tag() @devexpress/dx-react-grid.npm-t
 
 *Note: [react](https://www.npmjs.com/package/react) >=16.3.0 and [react-dom](https://www.npmjs.com/package/react) >=16.3.0 are peer dependencies.*
 
-This package does not contain visual components. In the examples below, visual components are rendered using the Material UI package. However, you can use any of the following:
+This package does not contain visual components. In the examples below, visual components are rendered using the Material-UI package. However, you can use any of the following:
 
-- Material UI
+- Material-UI
 
   ```
   npm i --save @devexpress/dx-react-grid-material-ui.npm-tag()
@@ -24,7 +24,7 @@ This package does not contain visual components. In the examples below, visual c
 
   *Note: [@material-ui/core](https://www.npmjs.com/package/@material-ui/core) >=1.1.0 and [@material-ui/icons](https://www.npmjs.com/package/@material-ui/icons) >=1.1.0 are peer dependencies.*
 
-  Make sure that the [Material UI](https://material-ui.com/) dependencies are installed and properly configured. Check the Material UI's [Getting Started](https://material-ui.com/getting-started/installation) article for configuration details.
+  Make sure that the [Material-UI](https://material-ui.com/) dependencies are installed and properly configured. Check the Material-UI's [Getting Started](https://material-ui.com/getting-started/installation) article for configuration details.
 
 - Bootstrap 4
 
@@ -98,7 +98,7 @@ const App = () => (
 
 Follow the links below to try out the React Grid:
 
-- [CodeSandbox for Material UI](https://codesandbox.io/s/13qvz1qqzl)
+- [CodeSandbox for Material-UI](https://codesandbox.io/s/13qvz1qqzl)
 - [CodeSandbox for Bootstrap4](https://codesandbox.io/s/rymyjlonpq)
 - [CodeSandbox for Bootstrap3](https://codesandbox.io/s/7o46mkowx)
 

--- a/packages/dx-react-grid/docs/guides/plugin-overview.md
+++ b/packages/dx-react-grid/docs/guides/plugin-overview.md
@@ -33,6 +33,6 @@ Refer to the [Reference](../reference/grid.md) to see the complete plugin list.
 
 The Grid's UI plugins use special components to render the UI. You can implement your component suite or use a predefined one:
 
-- [DevExtreme React Grid for Material UI](https://github.com/DevExpress/devextreme-reactive/tree/master/packages/dx-react-grid-material-ui) - renders the Grid's UI elements based on [Material UI](http://www.material-ui.com) components
+- [DevExtreme React Grid for Material-UI](https://github.com/DevExpress/devextreme-reactive/tree/master/packages/dx-react-grid-material-ui) - renders the Grid's UI elements based on [Material-UI](https://material-ui.com/) components
 - [DevExtreme React Grid for Bootstrap 4](https://github.com/DevExpress/devextreme-reactive/tree/master/packages/dx-react-grid-bootstrap4/) - renders the Grid's UI elements based on [Bootstrap 4](http://getbootstrap.com/) components
 - [DevExtreme React Grid for Bootstrap 3](https://github.com/DevExpress/devextreme-reactive/tree/master/packages/dx-react-grid-bootstrap3/) - renders the Grid's UI elements based on [Bootstrap 3](https://getbootstrap.com/docs/3.3/) components

--- a/packages/dx-react-grid/docs/reference/table-column-resizing.md
+++ b/packages/dx-react-grid/docs/reference/table-column-resizing.md
@@ -29,7 +29,7 @@ import { TableColumnResizing } from '@devexpress/dx-react-grid';
 Name | Type | Default | Description
 -----|------|---------|------------
 columnWidths? | Array&lt;[TableColumnWidthInfo](#tablecolumnwidthinfo)&gt; | | Specifies column widths.
-minColumnWidth? | number | `45` for [Bootstrap3](https://www.npmjs.com/package/@devexpress/dx-react-grid-bootstrap3); `55` for [Bootstrap4](https://www.npmjs.com/package/@devexpress/dx-react-grid-bootstrap4); `40` for [Material UI](https://www.npmjs.com/package/@devexpress/dx-react-grid-material-ui); | Specifies a column's minimum width.
+minColumnWidth? | number | `45` for [Bootstrap3](https://www.npmjs.com/package/@devexpress/dx-react-grid-bootstrap3); `55` for [Bootstrap4](https://www.npmjs.com/package/@devexpress/dx-react-grid-bootstrap4); `40` for [Material-UI](https://www.npmjs.com/package/@devexpress/dx-react-grid-material-ui); | Specifies a column's minimum width.
 defaultColumnWidths? | Array&lt;[TableColumnWidthInfo](#tablecolumnwidthinfo)&gt; | [] | Specifies initial column widths in uncontrolled mode.
 onColumnWidthsChange? | (nextColumnWidths: Array&lt;[TableColumnWidthInfo](#tablecolumnwidthinfo)&gt;) => void | | Handles column width changes.
 

--- a/packages/dx-react-grid/docs/reference/virtual-table.md
+++ b/packages/dx-react-grid/docs/reference/virtual-table.md
@@ -23,7 +23,7 @@ import { VirtualTable } from '@devexpress/dx-react-grid-material-ui';
 Name | Type | Default | Description
 -----|------|---------|------------
 height | number &#124; string | 530 | The virtual table's height.
-estimatedRowHeight | number | `49` for [Bootstrap4](https://www.npmjs.com/package/@devexpress/dx-react-grid-bootstrap4); `37` for [Bootstrap](https://www.npmjs.com/package/@devexpress/dx-react-grid-bootstrap3); `48` for [Material UI](https://www.npmjs.com/package/@devexpress/dx-react-grid-material-ui) | Estimated row height. Specify the average value for a table whose rows have different heights.
+estimatedRowHeight | number | `49` for [Bootstrap4](https://www.npmjs.com/package/@devexpress/dx-react-grid-bootstrap4); `37` for [Bootstrap](https://www.npmjs.com/package/@devexpress/dx-react-grid-bootstrap3); `48` for [Material-UI](https://www.npmjs.com/package/@devexpress/dx-react-grid-material-ui) | Estimated row height. Specify the average value for a table whose rows have different heights.
 columnExtensions? | Array&lt;[Table.ColumnExtension](table.md#tablecolumnextension)&gt; | | Additional column properties that the plugin can handle.
 tableComponent | ComponentType&lt;object&gt; | | A component that renders a table.
 headComponent | ComponentType&lt;object&gt; | | A component that renders a table head.

--- a/packages/dx-react-scheduler-demos/src/theme-registry.js
+++ b/packages/dx-react-scheduler-demos/src/theme-registry.js
@@ -2,14 +2,14 @@
 
 export const themes = [{
   name: 'material-ui',
-  title: 'Material UI',
+  title: 'Material-UI',
   variants: [{
     name: 'light',
-    title: 'Material UI Light',
+    title: 'Material-UI Light',
     DemoContainer: require('./theme-sources/material-ui/demo-container').default,
   }, {
     name: 'dark',
-    title: 'Material UI Dark',
+    title: 'Material-UI Dark',
     DemoContainer: require('./theme-sources/material-ui/demo-container').Dark,
   }],
 }];

--- a/packages/dx-react-scheduler-material-ui/README.md
+++ b/packages/dx-react-scheduler-material-ui/README.md
@@ -1,6 +1,6 @@
-# DevExtreme React Scheduler Material UI
+# DevExtreme React Scheduler Material-UI
 
-A template suite used to render the React Scheduler based on Material UI components.
+A template suite used to render the React Scheduler based on Material-UI components.
 
 ## License
 

--- a/packages/dx-react-scheduler-material-ui/package.json
+++ b/packages/dx-react-scheduler-material-ui/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@devexpress/dx-react-scheduler-material-ui",
   "version": "1.8.0",
-  "description": "Material UI templates for DevExtreme React Scheduler component",
+  "description": "Material-UI templates for DevExtreme React Scheduler component",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/site/_posts/2017-01-01-10-react-theming.md
+++ b/site/_posts/2017-01-01-10-react-theming.md
@@ -4,13 +4,13 @@ img: themes.png
 imgAnimated: themes.gif
 cssClass: block-theming
 category: LandingGridReact
-title: Twitter Bootstrap and Material UI<br/>with Seamless Theming
+title: Twitter Bootstrap and Material-UI<br/>with Seamless Theming
 description: |
 ---
 
 **Native Rendering**
 
-Use native Twitter Bootstrap and Material UI renderings and apply themes automatically - without unnecessary configuration.
+Use native Twitter Bootstrap and Material-UI renderings and apply themes automatically - without unnecessary configuration.
 
 **Individual UI Templates**
 

--- a/site/_posts/2017-01-01-40-react-features-set.md
+++ b/site/_posts/2017-01-01-40-react-features-set.md
@@ -13,7 +13,7 @@ description: |
 * Built-in data filtering, selection, and editing
 * Advanced UI elements such as a filter row and record detail row
 * Virtual record scrolling
-* Bootstrap and Material-UI templates
+* Bootstrap and [Material-UI](https://material-ui.com/) templates
 * Column resizing/reordering
 * Column chooser
 * Keyboard navigation

--- a/site/react/grid/overrides/react-grid.html
+++ b/site/react/grid/overrides/react-grid.html
@@ -15,7 +15,7 @@ redirect_from:
 				<div class="col-lg-12">
 					<div class="intro-message">
 						<h1>DevExtreme<span class="break"> </span>React&nbsp;Grid</h1>
-						<h3>for Bootstrap and Material&nbsp;UI</h3>
+						<h3>for Bootstrap and Material-UI</h3>
 						<ul class="list-inline intro-action-buttons">
 							<li>
 								<a href="demos/featured/integrated-data-shaping/" class="btn btn-default btn-lg demos"><span class="action-button">Demos</span></a>


### PR DESCRIPTION
I have recently added a backlink from Material-UI to your project in https://material-ui.netlify.com/demos/tables/#advanced-use-cases. In this process, I could notice some issues with the links and the wording used to refer to Material-UI. I took the time to address them.

I have also done a second commit where I add a backlink from your project to Material-UI. Let me know what you think about it.