### PR TITLE
chore(react-chart): fix relative position in sizer

### DIFF
--- a/packages/dx-react-chart/src/plugins/pane-layout.jsx
+++ b/packages/dx-react-chart/src/plugins/pane-layout.jsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as PropTypes from 'prop-types';
 import {
   Plugin,
   Template,
@@ -7,7 +8,22 @@ import {
   Sizer,
 } from '@devexpress/dx-react-core';
 
-/* eslint-disable-next-line react/prefer-stateless-function */
+const DIV_STYLE = {
+  flex: 1, zIndex: 1, position: 'relative', width: '100%',
+};
+
+const SVG_STYLE = {
+  position: 'absolute', left: 0, top: 0, overflow: 'visible',
+};
+
+const SizerContainer = ({ children }) => (
+  <div style={DIV_STYLE}>{children}</div>
+);
+
+SizerContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
 export class PaneLayout extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -36,21 +52,17 @@ export class PaneLayout extends React.PureComponent {
             <TemplateConnector>
               {(_, { changeBBox }) => (
                 <Sizer
-                  style={{ flex: 1, zIndex: 1 }}
+                  containerComponent={SizerContainer}
                   onSizeChange={size => this.handleSizeUpdate(size, changeBBox)}
                 >
-                  <div style={{ width: '100%' }}>
-                    <svg
-                      {...params}
-                      width={width}
-                      height={height}
-                      style={{
-                        position: 'absolute', left: 0, top: 0, overflow: 'visible',
-                      }}
-                    >
-                      <TemplatePlaceholder name="series" />
-                    </svg>
-                  </div>
+                  <svg
+                    {...params}
+                    width={width}
+                    height={height}
+                    style={SVG_STYLE}
+                  >
+                    <TemplatePlaceholder name="series" />
+                  </svg>
                 </Sizer>
               )}
             </TemplateConnector>

--- a/packages/dx-react-chart/src/plugins/pane-layout.test.jsx
+++ b/packages/dx-react-chart/src/plugins/pane-layout.test.jsx
@@ -20,10 +20,14 @@ describe('PaneLayout', () => {
       </PluginHost>
     ));
 
-    expect(tree.find('svg').props().width)
-      .toEqual(expect.any(Number));
-    expect(tree.find('svg').props().height)
-      .toEqual(expect.any(Number));
+    expect(tree.find('svg').props()).toEqual({
+      width: expect.any(Number),
+      height: expect.any(Number),
+      style: {
+        left: 0, top: 0, overflow: 'visible', position: 'absolute',
+      },
+      children: expect.anything(),
+    });
   });
 
   it('should render Sizer with correct styles', () => {
@@ -35,7 +39,10 @@ describe('PaneLayout', () => {
       </PluginHost>
     ));
 
-    expect(tree.find('Sizer').props().style)
-      .toEqual({ flex: 1, zIndex: 1 });
+    expect(tree.find('Sizer').props()).toEqual({
+      containerComponent: expect.any(Function),
+      onSizeChange: expect.any(Function),
+      children: expect.anything(),
+    });
   });
 });

--- a/packages/dx-react-core/src/sizer.jsx
+++ b/packages/dx-react-core/src/sizer.jsx
@@ -45,8 +45,8 @@ const styles = {
 };
 
 export class Sizer extends React.PureComponent {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.setupListeners = this.setupListeners.bind(this);
   }
@@ -121,10 +121,8 @@ export class Sizer extends React.PureComponent {
 Sizer.propTypes = {
   onSizeChange: PropTypes.func.isRequired,
   containerComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-  style: PropTypes.object,
 };
 
 Sizer.defaultProps = {
   containerComponent: 'div',
-  style: null,
 };


### PR DESCRIPTION
Restores `position: relative` on a `div` containing `svg`.