### PR TITLE
chore: remove deprecated theme MUI colors from the project

### DIFF
--- a/packages/dx-react-grid-demos/src/demo-sources/grid-basic/material-ui/table-template.jsx
+++ b/packages/dx-react-grid-demos/src/demo-sources/grid-basic/material-ui/table-template.jsx
@@ -5,6 +5,7 @@ import {
   Table,
   TableHeaderRow,
 } from '@devexpress/dx-react-grid-material-ui';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 import { withStyles } from '@material-ui/core/styles';
 import {
   generateRows,
@@ -14,7 +15,7 @@ import {
 const styles = theme => ({
   tableStriped: {
     '& tbody tr:nth-of-type(odd)': {
-      backgroundColor: theme.palette.primary[50],
+      backgroundColor: fade(theme.palette.primary.main, 0.15),
     },
   },
 });

--- a/packages/dx-react-scheduler-material-ui/src/templates/all-day-panel/cell.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/all-day-panel/cell.jsx
@@ -3,6 +3,7 @@ import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
 import TableCell from '@material-ui/core/TableCell';
 import { withStyles } from '@material-ui/core/styles';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 import { getBorder } from '../utils';
 
 const styles = theme => ({
@@ -12,7 +13,7 @@ const styles = theme => ({
       backgroundColor: theme.palette.action.hover,
     },
     '&:focus': {
-      backgroundColor: theme.palette.primary[100],
+      backgroundColor: fade(theme.palette.primary.main, 0.15),
       outline: 0,
     },
   },

--- a/packages/dx-react-scheduler-material-ui/src/templates/views/horizontal/time-table/cell.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/views/horizontal/time-table/cell.jsx
@@ -3,6 +3,7 @@ import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
 import moment from 'moment';
 import TableCell from '@material-ui/core/TableCell';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 import { withStyles } from '@material-ui/core/styles';
 import { getBorder } from '../../../utils';
 
@@ -16,7 +17,7 @@ const styles = theme => ({
       backgroundColor: theme.palette.action.hover,
     },
     '&:focus': {
-      backgroundColor: theme.palette.primary[100],
+      backgroundColor: fade(theme.palette.primary.main, 0.15),
       outline: 0,
     },
   },

--- a/packages/dx-react-scheduler-material-ui/src/templates/views/vertical/time-table/cell.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/views/vertical/time-table/cell.jsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
 import TableCell from '@material-ui/core/TableCell';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 import { withStyles } from '@material-ui/core/styles';
 import { getBorder } from '../../../utils';
 
@@ -12,7 +13,7 @@ const styles = theme => ({
       backgroundColor: theme.palette.action.hover,
     },
     '&:focus': {
-      backgroundColor: theme.palette.primary[100],
+      backgroundColor: fade(theme.palette.primary.main, 0.15),
       outline: 0,
     },
   },


### PR DESCRIPTION
NOTE: The `fade` function adds an alpha channel to color.