### PR TITLE
chore(react-chart): do not pass "restProps" down to series component

### DIFF
--- a/packages/dx-chart-core/src/plugins/axis/computeds.js
+++ b/packages/dx-chart-core/src/plugins/axis/computeds.js
@@ -1,4 +1,4 @@
-import { getWidth } from '../../utils/scale';
+import { fixOffset } from '../../utils/scale';
 import {
   LEFT, BOTTOM, MIDDLE, END, START, ARGUMENT_DOMAIN,
 } from '../../constants';
@@ -8,14 +8,8 @@ const isHorizontal = name => name === ARGUMENT_DOMAIN;
 
 const getTicks = scale => (scale.ticks ? scale.ticks() : scale.domain());
 
-// Same code can be found in series coordinates calculation.
-const fixScaleOffset = (scale) => {
-  const offset = getWidth(scale) / 2;
-  return value => scale(value) + offset;
-};
-
 const createTicks = (scale, callback) => {
-  const fixedScale = fixScaleOffset(scale);
+  const fixedScale = fixOffset(scale);
   return getTicks(scale).map((tick, index) => callback(fixedScale(tick), String(index), tick));
 };
 

--- a/packages/dx-chart-core/src/plugins/axis/computeds.test.js
+++ b/packages/dx-chart-core/src/plugins/axis/computeds.test.js
@@ -1,7 +1,7 @@
 import { axisCoordinates, getGridCoordinates, axesData } from './computeds';
 
 jest.mock('../../utils/scale', () => ({
-  getWidth: jest.fn().mockReturnValue(30),
+  fixOffset: scale => value => scale(value) + 15,
 }));
 
 describe('axisCoordinates', () => {

--- a/packages/dx-chart-core/src/plugins/scale/computeds.js
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.js
@@ -69,7 +69,7 @@ const collectDomains = (seriesList) => {
     const name = getSeriesValueDomainName(seriesItem);
     const domain = domains[name] || { domain: [], orientation: VERTICAL };
     domains[name] = domain;
-    if (seriesItem.isStartedFromZero && domain.domain.length === 0) {
+    if (seriesItem.getPointTransformer.isStartedFromZero && domain.domain.length === 0) {
       domain.domain = [0];
     }
   });

--- a/packages/dx-chart-core/src/plugins/scale/computeds.test.js
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.test.js
@@ -8,6 +8,8 @@ jest.mock('d3-scale', () => ({
 }));
 
 describe('computeDomains', () => {
+  const getPointTransformer = () => null;
+
   it('should always create argument domain', () => {
     const domains = computeDomains([], []);
 
@@ -21,7 +23,7 @@ describe('computeDomains', () => {
   it('should create default value domain', () => {
     const domains = computeDomains(
       [],
-      [{ name: 'series1', points: [{ argument: 1, value: 1 }] }],
+      [{ name: 'series1', getPointTransformer, points: [{ argument: 1, value: 1 }] }],
     );
 
     expect(domains).toEqual({
@@ -39,6 +41,7 @@ describe('computeDomains', () => {
       [],
       [{
         name: 'series1',
+        getPointTransformer,
         points: [
           { argument: 1, value: 9 },
           { argument: 2, value: 2 },
@@ -67,7 +70,7 @@ describe('computeDomains', () => {
     const domains = computeDomains(
       [],
       [{
-        name: 'series1', getValueDomain, points,
+        name: 'series1', getPointTransformer, getValueDomain, points,
       }],
     );
 
@@ -86,7 +89,7 @@ describe('computeDomains', () => {
     const domains = computeDomains(
       [],
       [{
-        name: 'series1', points: [{ argument: 1, value: 9 }, { argument: 2, value: -10 }],
+        name: 'series1', getPointTransformer, points: [{ argument: 1, value: 9 }, { argument: 2, value: -10 }],
       }],
     );
 
@@ -104,7 +107,7 @@ describe('computeDomains', () => {
     const domains = computeDomains(
       [],
       [{
-        name: 'series1', points: [{ argument: 1, value: 0 }, { argument: 2, value: 10 }],
+        name: 'series1', getPointTransformer, points: [{ argument: 1, value: 0 }, { argument: 2, value: 10 }],
       }],
     );
 
@@ -122,7 +125,7 @@ describe('computeDomains', () => {
     const domains = computeDomains(
       [],
       [{
-        name: 'series1', isStartedFromZero: true, points: [{ argument: 1, value: 9 }],
+        name: 'series1', getPointTransformer: { isStartedFromZero: true }, points: [{ argument: 1, value: 9 }],
       }],
     );
 
@@ -141,13 +144,13 @@ describe('computeDomains', () => {
     const domains = computeDomains(
       [],
       [{
-        name: 'series1', points: makePoints([2, 3, 5, 6]),
+        name: 'series1', getPointTransformer, points: makePoints([2, 3, 5, 6]),
       }, {
-        name: 'series2', points: makePoints([-1, -3, 0, 1]), axisName: 'domain1',
+        name: 'series2', getPointTransformer, points: makePoints([-1, -3, 0, 1]), axisName: 'domain1',
       }, {
-        name: 'series3', points: makePoints([1, 2, 3, 1]), axisName: 'domain1',
+        name: 'series3', getPointTransformer, points: makePoints([1, 2, 3, 1]), axisName: 'domain1',
       }, {
-        name: 'series4', points: makePoints([2, 5, 7, 3]),
+        name: 'series4', getPointTransformer, points: makePoints([2, 5, 7, 3]),
       }],
     );
 
@@ -169,6 +172,7 @@ describe('computeDomains', () => {
       [{ name: ARGUMENT_DOMAIN, type: 'band' }],
       [{
         name: 'series1',
+        getPointTransformer,
         points: [
           { argument: 'a', value: 1 },
           { argument: 'b', value: 2 },
@@ -191,7 +195,7 @@ describe('computeDomains', () => {
     const domains = computeDomains(
       [],
       [{
-        name: 'series1', points: [{ argument: 'a', value: 'A' }, { argument: 'b', value: 'B' }],
+        name: 'series1', getPointTransformer, points: [{ argument: 'a', value: 'A' }, { argument: 'b', value: 'B' }],
       }],
     );
 
@@ -211,6 +215,7 @@ describe('computeDomains', () => {
       [{
         name: 'series1',
         axisName: 'domain1',
+        getPointTransformer,
         points: [{ argument: 1, value: 3 }, { argument: 2, value: 14 }],
       }],
     );
@@ -231,6 +236,7 @@ describe('computeDomains', () => {
       [{
         name: 'series1',
         axisName: 'domain1',
+        getPointTransformer,
         points: [{ argument: 1, value: 3 }, { argument: 2, value: 14 }],
       }],
     );
@@ -252,6 +258,7 @@ describe('computeDomains', () => {
       }],
       [{
         name: 'series1',
+        getPointTransformer,
         points: [{ argument: 'one', value: 9 }, { argument: 'two', value: 1 }, { argument: 'three', value: 1 }],
       }],
     );
@@ -273,7 +280,7 @@ describe('computeDomains', () => {
         { name: 'domain2' },
       ],
       [{
-        name: 'series1', axisName: 'domain1', points: [{ argument: 1, value: 9 }],
+        name: 'series1', getPointTransformer, axisName: 'domain1', points: [{ argument: 1, value: 9 }],
       }],
     );
 

--- a/packages/dx-chart-core/src/plugins/series/computeds.js
+++ b/packages/dx-chart-core/src/plugins/series/computeds.js
@@ -153,6 +153,8 @@ getAreaPointTransformer.getTargetElement = ({ x, y }) => {
   };
 };
 
+getLinePointTransformer.getTargetElement = getAreaPointTransformer.getTargetElement;
+
 const createNewUniqueName = name => name.replace(/\d*$/, str => (str ? +str + 1 : 0));
 
 const addItem = (list, item) => (list.find(obj => obj.uniqueName === item.uniqueName)
@@ -196,15 +198,13 @@ export const addSeries = (series, data, palette, props) => {
 // TODO: Memoization is much needed here by the same reason as in "createPoints".
 // Make "scales" persistent first.
 const scalePoints = (series, scales) => {
-  const { getPointTransformer, ...rest } = series;
-  const transform = getPointTransformer({
+  const transform = series.getPointTransformer({
     ...series,
     argumentScale: scales[ARGUMENT_DOMAIN],
     valueScale: scales[getValueDomainName(series.axisName)],
   });
   return {
-    ...rest,
-    getTargetElement: getPointTransformer.getTargetElement, // TODO: remove it when it is possible
+    ...series,
     points: series.points.map(transform),
   };
 };

--- a/packages/dx-chart-core/src/plugins/series/computeds.js
+++ b/packages/dx-chart-core/src/plugins/series/computeds.js
@@ -32,7 +32,7 @@ export const dSpline = line()
   .curve(curveMonotoneX);
 
 export const getPiePointTransformer = ({
-  innerRadius = 0, outerRadius = 1, argumentScale, valueScale, palette, points,
+  argumentScale, valueScale, points, innerRadius, outerRadius, palette,
 }) => {
   const x = Math.max(...argumentScale.range()) / 2;
   const y = Math.max(...valueScale.range()) / 2;

--- a/packages/dx-chart-core/src/plugins/series/computeds.test.js
+++ b/packages/dx-chart-core/src/plugins/series/computeds.test.js
@@ -14,6 +14,7 @@ import {
   pointAttributes,
   dBar,
   getAreaPointTransformer,
+  getLinePointTransformer,
   getBarPointTransformer,
   getPiePointTransformer,
   scaleSeriesPoints,
@@ -155,6 +156,28 @@ describe('getAreaPointTransformer', () => {
       y: 20,
       d: 'symbol path',
     });
+  });
+});
+
+describe('getLinePointTransformer', () => {
+  it('should return data', () => {
+    const argumentScale = jest.fn().mockReturnValue(10);
+    argumentScale.bandwidth = () => 8;
+    const valueScale = jest.fn();
+    valueScale.mockReturnValueOnce(9);
+
+    const transform = getLinePointTransformer({ argumentScale, valueScale });
+    expect(
+      transform({ argument: 'arg', value: 'val', index: 1 }),
+    ).toEqual({
+      argument: 'arg',
+      value: 'val',
+      index: 1,
+      x: 14,
+      y: 9,
+    });
+    expect(argumentScale.mock.calls).toEqual([['arg']]);
+    expect(valueScale.mock.calls).toEqual([['val']]);
   });
 });
 

--- a/packages/dx-chart-core/src/plugins/stack/computeds.js
+++ b/packages/dx-chart-core/src/plugins/stack/computeds.js
@@ -79,7 +79,7 @@ const buildStackedSeries = (series, dataItems) => {
     ...series,
     points,
   };
-  if (series.isStartedFromZero) {
+  if (series.getPointTransformer.isStartedFromZero) {
     stackedSeries.getPointTransformer = getStackedPointTransformer(series.getPointTransformer);
     stackedSeries.getValueDomain = getValueDomain;
   }

--- a/packages/dx-chart-core/src/plugins/stack/computeds.test.js
+++ b/packages/dx-chart-core/src/plugins/stack/computeds.test.js
@@ -190,15 +190,17 @@ describe('Stack', () => {
     it('should wrap *getPointTransformer* for starting from zero series', () => {
       mockStack.mockReturnValue([]);
       const getPointTransformer = () => null;
-      getPointTransformer.a = 'A';
-      getPointTransformer.b = 'B';
+      const getPointTransformerWithZero = () => null;
+      getPointTransformerWithZero.isStartedFromZero = true;
+      getPointTransformerWithZero.a = 'A';
+      getPointTransformerWithZero.b = 'B';
 
       const result = getStackedSeries([
         makeSeries('1', { getPointTransformer }),
         makeSeries('2', { getPointTransformer }),
-        makeSeries('3', { getPointTransformer, isStartedFromZero: true }),
-        makeSeries('4', { getPointTransformer, isStartedFromZero: true }),
-        makeSeries('5', { getPointTransformer, isStartedFromZero: true }),
+        makeSeries('3', { getPointTransformer: getPointTransformerWithZero }),
+        makeSeries('4', { getPointTransformer: getPointTransformerWithZero }),
+        makeSeries('5', { getPointTransformer: getPointTransformerWithZero }),
       ], 'test-data', {
         stacks: makeStacks('1', '2', '3', '4', '5'),
         offset: 'test-offset',
@@ -207,14 +209,17 @@ describe('Stack', () => {
 
       expect(result[0].getPointTransformer).toBe(getPointTransformer);
       expect(result[1].getPointTransformer).toBe(getPointTransformer);
-      expect(result[2].getPointTransformer).not.toBe(getPointTransformer);
-      expect(result[3].getPointTransformer).not.toBe(getPointTransformer);
-      expect(result[4].getPointTransformer).not.toBe(getPointTransformer);
+      expect(result[2].getPointTransformer).not.toBe(getPointTransformerWithZero);
+      expect(result[3].getPointTransformer).not.toBe(getPointTransformerWithZero);
+      expect(result[4].getPointTransformer).not.toBe(getPointTransformerWithZero);
 
+      expect(result[2].getPointTransformer.isStartedFromZero).toEqual(true);
       expect(result[2].getPointTransformer.a).toEqual('A');
       expect(result[2].getPointTransformer.b).toEqual('B');
+      expect(result[3].getPointTransformer.isStartedFromZero).toEqual(true);
       expect(result[3].getPointTransformer.a).toEqual('A');
       expect(result[3].getPointTransformer.b).toEqual('B');
+      expect(result[4].getPointTransformer.isStartedFromZero).toEqual(true);
       expect(result[4].getPointTransformer.a).toEqual('A');
       expect(result[4].getPointTransformer.b).toEqual('B');
 
@@ -229,11 +234,12 @@ describe('Stack', () => {
     it('should update *y1* in wrapped *getPointTransformer*', () => {
       mockStack.mockReturnValue([]);
       const mock = jest.fn().mockReturnValue(point => ({ ...point, tag: '#t' }));
+      mock.isStartedFromZero = true;
       const valueScale = value => `${value}#`;
 
       const result = getStackedSeries([
-        makeSeries('1', { getPointTransformer: mock, isStartedFromZero: true }),
-        makeSeries('2', { getPointTransformer: mock, isStartedFromZero: true }),
+        makeSeries('1', { getPointTransformer: mock }),
+        makeSeries('2', { getPointTransformer: mock }),
       ], 'test-data', {
         stacks: makeStacks('1', '2'),
         offset: 'test-offset',
@@ -258,10 +264,12 @@ describe('Stack', () => {
     // TODO: Temporary - see note for *getValueDomainCalculator*.
     it('should collect values in *getValueDomain*', () => {
       mockStack.mockReturnValue([]);
+      const getPointTransformer = () => null;
+      getPointTransformer.isStartedFromZero = true;
 
       const result = getStackedSeries([
-        makeSeries('1', { isStartedFromZero: true }),
-        makeSeries('2', { isStartedFromZero: true }),
+        makeSeries('1', { getPointTransformer }),
+        makeSeries('2', { getPointTransformer }),
       ], 'test-data', {
         stacks: makeStacks('1', '2'),
         offset: 'test-offset',

--- a/packages/dx-chart-core/src/plugins/tooltip/computeds.js
+++ b/packages/dx-chart-core/src/plugins/tooltip/computeds.js
@@ -3,7 +3,10 @@ import { processPointerMove } from '../../utils/hover-state';
 export const getParameters = (series, target) => {
   const currentSeries = series.find(({ name }) => target.series === name);
   const item = currentSeries.points.find(point => point.index === target.point);
-  return { element: currentSeries.getTargetElement(item), text: `${item.value}` };
+  return {
+    element: currentSeries.getPointTransformer.getTargetElement(item),
+    text: `${item.value}`,
+  };
 };
 
 export const processHandleTooltip = (targets, currentTarget, onTargetItemChange) => {

--- a/packages/dx-chart-core/src/plugins/tooltip/computeds.test.js
+++ b/packages/dx-chart-core/src/plugins/tooltip/computeds.test.js
@@ -14,7 +14,7 @@ describe('#getParameters', () => {
   const createSeries = name => ({
     name,
     points: [{ index: 0, value: 10 }, { index: 1, value: 20 }, { index: 2, value: 30 }],
-    getTargetElement: jest.fn(() => 'parameters'),
+    getPointTransformer: { getTargetElement: jest.fn(() => 'parameters') },
   });
   const series = [createSeries('s1'), createSeries('s2'), createSeries('s3')];
 

--- a/packages/dx-chart-core/src/utils/scale.js
+++ b/packages/dx-chart-core/src/utils/scale.js
@@ -14,3 +14,8 @@ export const createScale = (
 export const getWidth = scale => (scale.bandwidth ? scale.bandwidth() : 0);
 
 export const getValueDomainName = name => name || VALUE_DOMAIN;
+
+export const fixOffset = (scale) => {
+  const offset = getWidth(scale) / 2;
+  return offset > 0 ? value => scale(value) + offset : scale;
+};

--- a/packages/dx-chart-core/src/utils/scale.test.js
+++ b/packages/dx-chart-core/src/utils/scale.test.js
@@ -1,4 +1,6 @@
-import { createScale, getWidth, getValueDomainName } from './scale';
+import {
+  createScale, getWidth, getValueDomainName, fixOffset,
+} from './scale';
 
 const domainOptions = { domain: [0, 100], type: 'linear', orientation: 'horizontal' };
 const width = 500;
@@ -65,5 +67,21 @@ describe('getValueDomainName', () => {
 
   it('should return default value', () => {
     expect(getValueDomainName()).toEqual('value-domain');
+  });
+});
+
+describe('fixOffset', () => {
+  it('should return original linear scale', () => {
+    const mock = () => 0;
+    expect(fixOffset(mock)).toBe(mock);
+  });
+
+  it('should return wrapped band scale', () => {
+    const mock = x => x * 2;
+    mock.bandwidth = () => 4;
+    const wrapped = fixOffset(mock);
+    expect(wrapped).not.toBe(mock);
+    expect(wrapped(0)).toEqual(2);
+    expect(wrapped(3)).toEqual(8);
   });
 });

--- a/packages/dx-react-chart/src/plugins/area-series.jsx
+++ b/packages/dx-react-chart/src/plugins/area-series.jsx
@@ -9,7 +9,6 @@ import { Area as Path } from '../templates/series/area';
 export const AreaSeries = declareSeries('AreaSeries', {
   components: { Path },
   path,
-  isStartedFromZero: true,
   getPointTransformer,
   createHitTester,
 });

--- a/packages/dx-react-chart/src/plugins/area-series.test.jsx
+++ b/packages/dx-react-chart/src/plugins/area-series.test.jsx
@@ -32,16 +32,20 @@ describe('Area series', () => {
 
   findSeriesByName.mockReturnValue({
     ...defaultProps,
+    index: 1,
     points: coords,
     seriesComponent: SeriesComponent,
     path: dArea,
-    customProperty: 'custom',
+    color: 'color',
   });
 
   const defaultDeps = {
     getter: {
       layouts: { pane: {} },
-      scales: {},
+      scales: {
+        test_argument_domain: 'arg-scale',
+        test_value_domain: 'val-scale',
+      },
     },
     template: {
       series: {},
@@ -58,16 +62,15 @@ describe('Area series', () => {
         />
       </PluginHost>
     ));
-    const {
-      coordinates: seriesCoordinates, path, ...restProps
-    } = tree.find(SeriesComponent).props();
 
-    expect(seriesCoordinates).toBe(coords);
-    expect(path).toBe(dArea);
-    expect(restProps).toEqual({
-      customProperty: 'custom',
+    expect(tree.find(SeriesComponent).props()).toEqual({
+      pointComponent: undefined,
+      index: 1,
+      coordinates: coords,
+      path: dArea,
+      color: 'color',
       getAnimatedStyle: undefined,
-      scales: {},
+      scales: { xScale: 'arg-scale', yScale: 'val-scale' },
     });
   });
 });

--- a/packages/dx-react-chart/src/plugins/bar-series.jsx
+++ b/packages/dx-react-chart/src/plugins/bar-series.jsx
@@ -8,7 +8,6 @@ import { Bar as Point } from '../templates/series/bar';
 
 export const BarSeries = declareSeries('BarSeries', {
   components: { Path, Point },
-  isStartedFromZero: true,
   getPointTransformer,
   createHitTester,
 });

--- a/packages/dx-react-chart/src/plugins/bar-series.test.jsx
+++ b/packages/dx-react-chart/src/plugins/bar-series.test.jsx
@@ -4,7 +4,6 @@ import { PluginHost } from '@devexpress/dx-react-core';
 import { findSeriesByName } from '@devexpress/dx-chart-core';
 import { pluginDepsToComponents } from '@devexpress/dx-react-core/test-utils';
 import { BarSeries } from './bar-series';
-import { BarCollection } from '../templates/series/bar-collection';
 
 jest.mock('@devexpress/dx-chart-core', () => ({
   dBar: jest.fn(),
@@ -15,6 +14,7 @@ jest.mock('@devexpress/dx-chart-core', () => ({
 }));
 
 describe('Bar series', () => {
+  const SeriesComponent = () => null;
   const PointComponent = () => null;
 
   const coords = [
@@ -36,19 +36,17 @@ describe('Bar series', () => {
 
   findSeriesByName.mockReturnValue({
     ...defaultProps,
+    index: 1,
     points: coords,
-    stack: 'stack',
-    barWidth: 0.3,
-    styles: 'styles',
-    seriesComponent: BarCollection,
+    seriesComponent: SeriesComponent,
     pointComponent: PointComponent,
+    color: 'color',
   });
 
   const defaultDeps = {
     getter: {
       layouts: { pane: {} },
-      scales: {},
-      getAnimatedStyle: jest.fn(),
+      scales: { test_argument_domain: 'arg-scale', test_value_domain: 'val-scale' },
     },
     template: {
       series: {},
@@ -66,15 +64,14 @@ describe('Bar series', () => {
       </PluginHost>
     ));
 
-    expect(tree.find(PointComponent)).toHaveLength(coords.length);
-
-    coords.forEach((coord, index) => {
-      const {
-        x, y, y1,
-      } = tree.find(PointComponent).get(index).props;
-      expect(x).toBe(coords[index].x);
-      expect(y).toBe(coords[index].y);
-      expect(y1).toBe(coords[index].y1);
+    expect(tree.find(SeriesComponent).props()).toEqual({
+      pointComponent: PointComponent,
+      index: 1,
+      color: 'color',
+      coordinates: coords,
+      path: undefined,
+      getAnimatedStyle: undefined,
+      scales: { xScale: 'arg-scale', yScale: 'val-scale' },
     });
   });
 });

--- a/packages/dx-react-chart/src/plugins/grid.jsx
+++ b/packages/dx-react-chart/src/plugins/grid.jsx
@@ -13,11 +13,7 @@ import { withPatchedProps } from '../utils';
 
 class RawGrid extends React.PureComponent {
   render() {
-    const {
-      name,
-      lineComponent: LineComponent,
-      ...restProps
-    } = this.props;
+    const { name, lineComponent: LineComponent } = this.props;
     return (
       <Plugin name="Grid">
         <Template name="series">
@@ -42,7 +38,6 @@ class RawGrid extends React.PureComponent {
                       x2={x + dx * width}
                       y1={y}
                       y2={y + dy * height}
-                      {...restProps}
                     />
                   ))}
                 </React.Fragment>

--- a/packages/dx-react-chart/src/plugins/grid.test.jsx
+++ b/packages/dx-react-chart/src/plugins/grid.test.jsx
@@ -46,7 +46,6 @@ describe('Grid', () => {
   const defaultProps = {
     name: 'domain1',
     lineComponent: LineComponent,
-    styles: 'styles',
   };
 
   it('should render ticks', () => {
@@ -64,14 +63,12 @@ describe('Grid', () => {
       x2: 31,
       y1: 12,
       y2: 72,
-      styles: 'styles',
     });
     expect(tree.find(LineComponent).get(1).props).toEqual({
       x1: 21,
       x2: 81,
       y1: 22,
       y2: 142,
-      styles: 'styles',
     });
     expect(getGridCoordinates).toBeCalledWith({ name: 'domain1', scale: 'test-scale' });
   });

--- a/packages/dx-react-chart/src/plugins/line-series.jsx
+++ b/packages/dx-react-chart/src/plugins/line-series.jsx
@@ -1,6 +1,6 @@
 import {
   dLine as path,
-  getAreaPointTransformer as getPointTransformer,
+  getLinePointTransformer as getPointTransformer,
   createLineHitTester as createHitTester,
 } from '@devexpress/dx-chart-core';
 import { declareSeries } from '../utils';

--- a/packages/dx-react-chart/src/plugins/line-series.test.jsx
+++ b/packages/dx-react-chart/src/plugins/line-series.test.jsx
@@ -32,16 +32,17 @@ describe('Line series', () => {
 
   findSeriesByName.mockReturnValue({
     ...defaultProps,
+    index: 1,
     points: coords,
     seriesComponent: SeriesComponent,
     path: dLine,
-    customProperty: 'custom',
+    color: 'color',
   });
 
   const defaultDeps = {
     getter: {
       layouts: { pane: {} },
-      scales: {},
+      scales: { test_argument_domain: 'arg-scale', test_value_domain: 'val-scale' },
     },
     template: {
       series: {},
@@ -58,16 +59,15 @@ describe('Line series', () => {
         />
       </PluginHost>
     ));
-    const {
-      coordinates: seriesCoordinates, path, ...restProps
-    } = tree.find(SeriesComponent).props();
 
-    expect(seriesCoordinates).toBe(coords);
-    expect(path).toBe(dLine);
-    expect(restProps).toEqual({
-      customProperty: 'custom',
+    expect(tree.find(SeriesComponent).props()).toEqual({
+      pointComponent: undefined,
+      index: 1,
+      coordinates: coords,
+      path: dLine,
+      color: 'color',
       getAnimatedStyle: undefined,
-      scales: {},
+      scales: { xScale: 'arg-scale', yScale: 'val-scale' },
     });
   });
 });

--- a/packages/dx-react-chart/src/plugins/pie-series.jsx
+++ b/packages/dx-react-chart/src/plugins/pie-series.jsx
@@ -11,3 +11,8 @@ export const PieSeries = declareSeries('PieSeries', {
   getPointTransformer,
   createHitTester,
 });
+
+PieSeries.defaultProps = {
+  innerRadius: 0,
+  outerRadius: 1,
+};

--- a/packages/dx-react-chart/src/plugins/pie-series.test.jsx
+++ b/packages/dx-react-chart/src/plugins/pie-series.test.jsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
-import { setupConsole } from '@devexpress/dx-testing';
 import { PluginHost } from '@devexpress/dx-react-core';
 import { findSeriesByName } from '@devexpress/dx-chart-core';
 import { pluginDepsToComponents } from '@devexpress/dx-react-core/test-utils';
 import { PieSeries } from './pie-series';
-import { SliceCollection } from '../templates/series/slice-collection';
 
 jest.mock('@devexpress/dx-chart-core', () => ({
   findSeriesByName: jest.fn(),
@@ -15,13 +13,7 @@ jest.mock('@devexpress/dx-chart-core', () => ({
 }));
 
 describe('Pie series', () => {
-  let resetConsole;
-  beforeAll(() => {
-    resetConsole = setupConsole({ ignore: ['<%s>'] });
-  });
-  afterAll(() => {
-    resetConsole();
-  });
+  const SeriesComponent = () => null;
   const PointComponent = () => null;
 
   const defaultProps = {
@@ -29,52 +21,36 @@ describe('Pie series', () => {
     argumentField: 'argumentField',
   };
 
+  const coords = [
+    {
+      value: 'value1', data: { argumentField: 'argument1' }, index: 'value1', x: 1, y: 2,
+    },
+    {
+      value: 'value2', data: { argumentField: 'argument2' }, index: 'value2', x: 1, y: 2,
+    },
+    {
+      value: 'value3', data: { argumentField: 'argument3' }, index: 'value3', x: 1, y: 2,
+    },
+  ];
+
   findSeriesByName.mockReturnValue({
     ...defaultProps,
-    points: [
-      {
-        value: 'value1', data: { argumentField: 'argument1' }, index: 'value1', x: 1, y: 2,
-      },
-      {
-        value: 'value2', data: { argumentField: 'argument2' }, index: 'value2', x: 1, y: 2,
-      },
-      {
-        value: 'value3', data: { argumentField: 'argument3' }, index: 'value3', x: 1, y: 2,
-      },
-    ],
-    style: { opacity: 0.4 },
-    seriesComponent: SliceCollection,
+    index: 1,
+    points: coords,
+    seriesComponent: SeriesComponent,
     pointComponent: PointComponent,
+    color: 'color',
   });
 
   const defaultDeps = {
     getter: {
-      layouts: { pane: { width: 200, height: 100 } },
-      scales: {},
-      getAnimatedStyle: jest.fn(style => style),
+      layouts: { pane: { } },
+      scales: { test_argument_domain: 'arg-scale', test_value_domain: 'val-scale' },
     },
     template: {
       series: {},
     },
   };
-
-  it('should render root element', () => {
-    const tree = mount((
-      <PluginHost>
-        {pluginDepsToComponents(defaultDeps)}
-
-        <PieSeries
-          {...defaultProps}
-        />
-      </PluginHost>
-    ));
-
-    const g = tree.find('g');
-    const { transform } = g.props();
-
-    expect(transform)
-      .toBe('translate(1 2)');
-  });
 
   it('should render points', () => {
     const tree = mount((
@@ -87,16 +63,14 @@ describe('Pie series', () => {
       </PluginHost>
     ));
 
-    tree.find(PointComponent).forEach((point, index) => {
-      const pointIndex = index + 1;
-      expect(point.props()).toEqual({
-        data: { argumentField: `argument${pointIndex}` },
-        value: `value${pointIndex}`,
-        style: { opacity: 0.4 },
-        index: `value${pointIndex}`,
-        x: 1,
-        y: 2,
-      });
+    expect(tree.find(SeriesComponent).props()).toEqual({
+      pointComponent: PointComponent,
+      index: 1,
+      color: 'color',
+      coordinates: coords,
+      path: undefined,
+      getAnimatedStyle: undefined,
+      scales: { xScale: 'arg-scale', yScale: 'val-scale' },
     });
   });
 });

--- a/packages/dx-react-chart/src/plugins/scatter-series.jsx
+++ b/packages/dx-react-chart/src/plugins/scatter-series.jsx
@@ -1,5 +1,5 @@
 import {
-  getAreaPointTransformer as getPointTransformer,
+  getLinePointTransformer as getPointTransformer,
   createScatterHitTester as createHitTester,
 } from '@devexpress/dx-chart-core';
 import { declareSeries } from '../utils';

--- a/packages/dx-react-chart/src/plugins/scatter-series.test.jsx
+++ b/packages/dx-react-chart/src/plugins/scatter-series.test.jsx
@@ -4,7 +4,6 @@ import { PluginHost } from '@devexpress/dx-react-core';
 import { pointAttributes, findSeriesByName } from '@devexpress/dx-chart-core';
 import { pluginDepsToComponents } from '@devexpress/dx-react-core/test-utils';
 import { ScatterSeries } from './scatter-series';
-import { PointCollection } from '../templates/series/point-collection';
 
 jest.mock('@devexpress/dx-chart-core', () => ({
   pointAttributes: jest.fn(),
@@ -16,6 +15,7 @@ jest.mock('@devexpress/dx-chart-core', () => ({
 }));
 
 describe('Scatter series', () => {
+  const SeriesComponent = () => null;
   const PointComponent = () => null;
 
   const coords = [
@@ -39,18 +39,17 @@ describe('Scatter series', () => {
 
   findSeriesByName.mockReturnValue({
     ...defaultProps,
+    index: 1,
     points: coords,
-    styles: 'styles',
-    point: { size: 5 },
-    seriesComponent: PointCollection,
+    seriesComponent: SeriesComponent,
     pointComponent: PointComponent,
+    color: 'color',
   });
 
   const defaultDeps = {
     getter: {
       layouts: { pane: {} },
-      scales: {},
-      getAnimatedStyle: jest.fn(),
+      scales: { test_argument_domain: 'arg-scale', test_value_domain: 'val-scale' },
     },
     template: {
       series: {},
@@ -67,16 +66,14 @@ describe('Scatter series', () => {
         />
       </PluginHost>));
 
-    expect(tree.find(PointComponent)).toHaveLength(coords.length);
-
-    coords.forEach((coord, index) => {
-      const {
-        d, x, y, styles,
-      } = tree.find(PointComponent).get(index).props;
-      expect(d).toBe('M12 12');
-      expect(x).toBe(index + 1);
-      expect(y).toBe(index + 11);
-      expect(styles).toBe('styles');
+    expect(tree.find(SeriesComponent).props()).toEqual({
+      pointComponent: PointComponent,
+      index: 1,
+      color: 'color',
+      coordinates: coords,
+      path: undefined,
+      getAnimatedStyle: undefined,
+      scales: { xScale: 'arg-scale', yScale: 'val-scale' },
     });
   });
 });

--- a/packages/dx-react-chart/src/plugins/spline-series.jsx
+++ b/packages/dx-react-chart/src/plugins/spline-series.jsx
@@ -1,6 +1,6 @@
 import {
   dSpline as path,
-  getAreaPointTransformer as getPointTransformer,
+  getLinePointTransformer as getPointTransformer,
   createSplineHitTester as createHitTester,
 } from '@devexpress/dx-chart-core';
 import { declareSeries } from '../utils';

--- a/packages/dx-react-chart/src/plugins/spline-series.test.jsx
+++ b/packages/dx-react-chart/src/plugins/spline-series.test.jsx
@@ -33,16 +33,17 @@ describe('Spline series', () => {
 
   findSeriesByName.mockReturnValue({
     ...defaultProps,
+    index: 1,
     points: coords,
     seriesComponent: SeriesComponent,
     path: dSpline,
-    customProperty: 'custom',
+    color: 'color',
   });
 
   const defaultDeps = {
     getter: {
       layouts: { pane: {} },
-      scales: {},
+      scales: { test_argument_domain: 'arg-scale', test_value_domain: 'val-scale' },
     },
     template: {
       series: {},
@@ -59,16 +60,15 @@ describe('Spline series', () => {
         />
       </PluginHost>
     ));
-    const {
-      coordinates: seriesCoordinates, path, ...restProps
-    } = tree.find(SeriesComponent).props();
 
-    expect(seriesCoordinates).toBe(coords);
-    expect(path).toBe(dSpline);
-    expect(restProps).toEqual({
-      customProperty: 'custom',
+    expect(tree.find(SeriesComponent).props()).toEqual({
+      pointComponent: undefined,
+      index: 1,
+      coordinates: coords,
+      path: dSpline,
+      color: 'color',
       getAnimatedStyle: undefined,
-      scales: {},
+      scales: { xScale: 'arg-scale', yScale: 'val-scale' },
     });
   });
 });

--- a/packages/dx-react-chart/src/templates/series/area.jsx
+++ b/packages/dx-react-chart/src/templates/series/area.jsx
@@ -7,6 +7,7 @@ import { withPattern } from '../../utils/with-pattern';
 class RawArea extends React.PureComponent {
   render() {
     const {
+      pointComponent,
       path,
       coordinates,
       color,

--- a/packages/dx-react-chart/src/templates/series/bar-collection.test.jsx
+++ b/packages/dx-react-chart/src/templates/series/bar-collection.test.jsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { BarCollection } from './bar-collection';
+
+jest.mock('@devexpress/dx-chart-core', () => ({
+  getAreaAnimationStyle: 'test-animation-style',
+  dBar: point => ({ bar: `point-${point.index}` }),
+}));
+
+describe('BarCollection', () => {
+  const TestComponent = () => null;
+
+  it('should render bars', () => {
+    const points = [
+      { index: 10, custom: 'p1' },
+      { index: 20, custom: 'p2' },
+      { index: 30, custom: 'p3' },
+    ];
+    const getAnimatedStyle = jest.fn().mockReturnValue('animated-style');
+    const tree = mount((
+      <BarCollection
+        pointComponent={TestComponent}
+        index={1}
+        coordinates={points}
+        color="color"
+        style={{ tag: 'style' }}
+        getAnimatedStyle={getAnimatedStyle}
+        scales="test-scales"
+      />
+    ));
+
+    const items = tree.find(TestComponent);
+    expect(items.length).toEqual(3);
+    expect(items.get(0).props).toEqual({
+      seriesIndex: 1,
+      index: 10,
+      color: 'color',
+      bar: 'point-10',
+      custom: 'p1',
+      style: 'animated-style',
+    });
+    expect(items.get(1).props).toEqual({
+      seriesIndex: 1,
+      index: 20,
+      color: 'color',
+      bar: 'point-20',
+      custom: 'p2',
+      style: 'animated-style',
+    });
+    expect(items.get(2).props).toEqual({
+      seriesIndex: 1,
+      index: 30,
+      color: 'color',
+      bar: 'point-30',
+      custom: 'p3',
+      style: 'animated-style',
+    });
+    expect(getAnimatedStyle.mock.calls).toEqual([
+      [{ tag: 'style' }, 'test-animation-style', 'test-scales'],
+      [{ tag: 'style' }, 'test-animation-style', 'test-scales'],
+      [{ tag: 'style' }, 'test-animation-style', 'test-scales'],
+    ]);
+  });
+});

--- a/packages/dx-react-chart/src/templates/series/path.jsx
+++ b/packages/dx-react-chart/src/templates/series/path.jsx
@@ -6,6 +6,7 @@ import { withStates } from '../../utils/with-states';
 class RawPath extends React.PureComponent {
   render() {
     const {
+      pointComponent,
       path,
       coordinates,
       color,

--- a/packages/dx-react-chart/src/templates/series/point-collection.jsx
+++ b/packages/dx-react-chart/src/templates/series/point-collection.jsx
@@ -9,6 +9,7 @@ export class PointCollection extends React.PureComponent {
       pointComponent: Point,
       path, // Not used - see note above.
       coordinates,
+      index,
       point = {},
       style,
       getAnimatedStyle,
@@ -20,6 +21,7 @@ export class PointCollection extends React.PureComponent {
     return (coordinates.map(item => (
       <Point
         key={item.index.toString()}
+        seriesIndex={index}
         style={getAnimatedStyle(style, getScatterAnimationStyle, scales)}
         {...restProps}
         {...getAttributes(item)}

--- a/packages/dx-react-chart/src/templates/series/point-collection.test.jsx
+++ b/packages/dx-react-chart/src/templates/series/point-collection.test.jsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { PointCollection } from './point-collection';
+
+jest.mock('@devexpress/dx-chart-core', () => ({
+  getScatterAnimationStyle: 'test-animation-style',
+  pointAttributes: options => point => ({ point: `${options}-${point.index}` }),
+}));
+
+describe('PointCollection', () => {
+  const TestComponent = () => null;
+
+  it('should render bars', () => {
+    const points = [
+      { index: 10, custom: 'p1' },
+      { index: 20, custom: 'p2' },
+      { index: 30, custom: 'p3' },
+    ];
+    const getAnimatedStyle = jest.fn().mockReturnValue('animated-style');
+    const tree = mount((
+      <PointCollection
+        pointComponent={TestComponent}
+        index={1}
+        coordinates={points}
+        point="test-point"
+        color="color"
+        style={{ tag: 'style' }}
+        getAnimatedStyle={getAnimatedStyle}
+        scales="test-scales"
+      />
+    ));
+
+    const items = tree.find(TestComponent);
+    expect(items.length).toEqual(3);
+    expect(items.get(0).props).toEqual({
+      seriesIndex: 1,
+      index: 10,
+      color: 'color',
+      point: 'test-point-10',
+      custom: 'p1',
+      style: 'animated-style',
+    });
+    expect(items.get(1).props).toEqual({
+      seriesIndex: 1,
+      index: 20,
+      color: 'color',
+      point: 'test-point-20',
+      custom: 'p2',
+      style: 'animated-style',
+    });
+    expect(items.get(2).props).toEqual({
+      seriesIndex: 1,
+      index: 30,
+      color: 'color',
+      point: 'test-point-30',
+      custom: 'p3',
+      style: 'animated-style',
+    });
+    expect(getAnimatedStyle.mock.calls).toEqual([
+      [{ tag: 'style' }, 'test-animation-style', 'test-scales'],
+      [{ tag: 'style' }, 'test-animation-style', 'test-scales'],
+      [{ tag: 'style' }, 'test-animation-style', 'test-scales'],
+    ]);
+  });
+});

--- a/packages/dx-react-chart/src/templates/series/point.jsx
+++ b/packages/dx-react-chart/src/templates/series/point.jsx
@@ -6,7 +6,7 @@ import { withStates } from '../../utils/with-states';
 class RawPoint extends React.PureComponent {
   render() {
     const {
-      argument, value, index, x, y, color, ...restProps
+      argument, value, seriesIndex, index, x, y, color, ...restProps
     } = this.props;
     // *d* attribute is calculated during points scaling.
     // TODO: Do it here - d={path().size(size).type(type)()}

--- a/packages/dx-react-chart/src/templates/series/slice-collection.jsx
+++ b/packages/dx-react-chart/src/templates/series/slice-collection.jsx
@@ -10,7 +10,6 @@ export class SliceCollection extends React.PureComponent {
       path, // Not used - see note above.
       coordinates,
       index,
-      uniqueName,
       style,
       getAnimatedStyle,
       scales,

--- a/packages/dx-react-chart/src/templates/series/slice-collection.test.jsx
+++ b/packages/dx-react-chart/src/templates/series/slice-collection.test.jsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { setupConsole } from '@devexpress/dx-testing';
+import { SliceCollection } from './slice-collection';
+
+jest.mock('@devexpress/dx-chart-core', () => ({
+  getPieAnimationStyle: 'test-animation-style',
+}));
+
+describe('SliceCollection', () => {
+  let resetConsole;
+  beforeAll(() => {
+    resetConsole = setupConsole({ ignore: ['<%s>'] });
+  });
+  afterAll(() => {
+    resetConsole();
+  });
+
+  const TestComponent = () => null;
+
+  it('should render bars', () => {
+    const points = [
+      {
+        index: 10, custom: 'p1', x: 110, y: 120,
+      },
+      { index: 20, custom: 'p2' },
+      { index: 30, custom: 'p3' },
+    ];
+    const getAnimatedStyle = jest.fn().mockReturnValue('animated-style');
+    const tree = mount((
+      <SliceCollection
+        pointComponent={TestComponent}
+        index={1}
+        coordinates={points}
+        color="color"
+        style={{ tag: 'style' }}
+        getAnimatedStyle={getAnimatedStyle}
+        scales="test-scales"
+      />
+    ));
+
+    const items = tree.find(TestComponent);
+    expect(items.length).toEqual(3);
+    expect(items.get(0).props).toEqual({
+      seriesIndex: 1,
+      index: 10,
+      color: 'color',
+      custom: 'p1',
+      style: 'animated-style',
+      x: 110,
+      y: 120,
+    });
+    expect(items.get(1).props).toEqual({
+      seriesIndex: 1,
+      index: 20,
+      color: 'color',
+      custom: 'p2',
+      style: 'animated-style',
+    });
+    expect(items.get(2).props).toEqual({
+      seriesIndex: 1,
+      index: 30,
+      color: 'color',
+      custom: 'p3',
+      style: 'animated-style',
+    });
+    expect(getAnimatedStyle.mock.calls).toEqual([
+      [{ tag: 'style' }, 'test-animation-style', 'test-scales', points[0]],
+      [{ tag: 'style' }, 'test-animation-style', 'test-scales', points[1]],
+      [{ tag: 'style' }, 'test-animation-style', 'test-scales', points[2]],
+    ]);
+    expect(tree.find('g').props().transform).toEqual('translate(110 120)');
+  });
+});

--- a/packages/dx-react-chart/src/utils/series-helper.jsx
+++ b/packages/dx-react-chart/src/utils/series-helper.jsx
@@ -12,26 +12,6 @@ import {
   findSeriesByName, addSeries, getValueDomainName, ARGUMENT_DOMAIN,
 } from '@devexpress/dx-chart-core';
 
-// May be it is better to say what props are passed along rather then what are NOT passed?
-const getRenderProps = (series) => {
-  const {
-    name,
-    uniqueName,
-    axisName,
-    argumentField,
-    valueField,
-    palette,
-    symbolName,
-    isStartedFromZero,
-    getTargetElement,
-    getValueDomain, // TODO: Temporary - see corresponding note in *computeDomains*.
-    createHitTester,
-    ...restProps
-  } = series;
-
-  return restProps;
-};
-
 export const declareSeries = (pluginName, { components, ...parameters }) => {
   class Component extends React.PureComponent {
     render() {
@@ -55,13 +35,15 @@ export const declareSeries = (pluginName, { components, ...parameters }) => {
                   xScale: scales[ARGUMENT_DOMAIN],
                   yScale: scales[getValueDomainName(currentSeries.axisName)],
                 };
-                const { seriesComponent: Series, points, ...props } = getRenderProps(currentSeries);
                 return (
-                  <Series
-                    coordinates={points}
+                  <currentSeries.seriesComponent
+                    index={currentSeries.index}
+                    pointComponent={currentSeries.pointComponent}
+                    coordinates={currentSeries.points}
+                    path={currentSeries.path}
+                    color={currentSeries.color}
                     scales={currentScales}
                     getAnimatedStyle={getAnimatedStyle}
-                    {...props}
                   />
                 );
               }}

--- a/packages/dx-react-chart/src/utils/series-helper.test.jsx
+++ b/packages/dx-react-chart/src/utils/series-helper.test.jsx
@@ -34,6 +34,7 @@ describe('#declareSeries', () => {
 
   findSeriesByName.mockReturnValue({
     ...defaultProps,
+    index: 1,
     seriesComponent: TestComponentPath,
     points: coords,
     color: 'color',
@@ -77,9 +78,11 @@ describe('#declareSeries', () => {
     ));
 
     expect(tree.find(TestComponentPath).props()).toEqual({
+      index: 1,
+      path: undefined,
       coordinates: coords,
+      pointComponent: undefined,
       color: 'color',
-      styles: 'styles',
       scales: { xScale: 'argument-scale', yScale: 'value-scale' },
       getAnimatedStyle: 'test-animated-style-getter',
     });


### PR DESCRIPTION
Prevents passing all properties from series plugin component down to series component.