### PR TITLE
chore(react-chart): add Line and Spline series components

### DIFF
--- a/packages/dx-react-chart/docs/reference/area-series.md
+++ b/packages/dx-react-chart/docs/reference/area-series.md
@@ -39,11 +39,20 @@ Describes properties passed to a component that renders the series.
 Field | Type | Description
 ------|------|------------
 coordinates | Array&lt;{ x: number, y: number, y1: number }&gt; | Coordinates of the series' points.
-path | (coordinates: Array&lt;{ x: number, y: number, y1: number }&gt;) => string | A function used to calculate the series' path.
 color | string | A series color.
+
+### AreaSeries.PathSeriesProps
+
+Describes properties of a component that renders series.
+
+Extends [AreaSeries.SeriesProps](#areaseriesseriesprops)
+
+Field | Type | Description
+------|------|------------
+path? | (coordinates: Array&lt;{ x: number, y: number, y1: number }&gt;) => string | A function used to calculate the series' path.
 
 ## Plugin Components
 
 Name | Properties | Description
 -----|------------|------------
-AreaSeries.Path | [AreaSeries.SeriesProps](#areaseriesseriesprops) | A component that renders series.
+AreaSeries.Path | [AreaSeries.PathSeriesProps](#areaseriespathseriesprops) | A component that renders series.

--- a/packages/dx-react-chart/docs/reference/line-series.md
+++ b/packages/dx-react-chart/docs/reference/line-series.md
@@ -39,11 +39,20 @@ Describes properties passed to a component that renders series.
 Field | Type | Description
 ------|------|------------
 coordinates | Array&lt;{ x: number, y: number }&gt; | Coordinates of the series' points.
-path | (coordinates: Array&lt;{ x: number, y: number }&gt;) => string | A function used to calculate the series' path.
 color | string | A series color.
+
+### LineSeries.PathSeriesProps
+
+Describes properties of a component that renders series.
+
+Extends [LineSeries.SeriesProps](#lineseriesseriesprops)
+
+Field | Type | Description
+------|------|------------
+path? | (coordinates: Array&lt;{ x: number, y: number }&gt;) => string | A function used to calculate the series' path.
 
 ## Plugin Components
 
 Name | Properties | Description
 -----|------------|------------
-LineSeries.Path | [LineSeries.SeriesProps](#lineseriesseriesprops) | A component that renders series.
+LineSeries.Path | [LineSeries.PathSeriesProps](#lineseriespathseriesprops) | A component that renders series.

--- a/packages/dx-react-chart/docs/reference/spline-series.md
+++ b/packages/dx-react-chart/docs/reference/spline-series.md
@@ -39,11 +39,20 @@ Describes properties passed to a component that renders series.
 Field | Type | Description
 ------|------|------------
 coordinates | Array&lt;{ x: number, y: number }&gt; | Coordinates of the series' points.
-path | (coordinates: Array&lt;{ x: number, y: number }&gt;) => string | A function used to calculate the series' path.
 color | string | A series color.
+
+### SplineSeries.PathSeriesProps
+
+Describes properties of a component that renders series.
+
+Extends [SplineSeries.SeriesProps](#splineseriesseriesprops)
+
+Field | Type | Description
+------|------|------------
+path? | (coordinates: Array&lt;{ x: number, y: number }&gt;) => string | A function used to calculate the series' path.
 
 ## Plugin Components
 
 Name | Properties | Description
 -----|------------|------------
-SplineSeries.Path | [SplineSeries.SeriesProps](#splineseriesseriesprops) | A component that renders series.
+SplineSeries.Path | [SplineSeries.PathSeriesProps](#splineseriespathseriesprops) | A component that renders series.

--- a/packages/dx-react-chart/src/plugins/area-series.jsx
+++ b/packages/dx-react-chart/src/plugins/area-series.jsx
@@ -1,14 +1,11 @@
 import {
-  dArea as path,
-  getAreaPointTransformer as getPointTransformer,
-  createAreaHitTester as createHitTester,
+  getAreaPointTransformer as getPointTransformer, createAreaHitTester as createHitTester,
 } from '@devexpress/dx-chart-core';
 import { declareSeries } from '../utils';
 import { Area as Path } from '../templates/series/area';
 
 export const AreaSeries = declareSeries('AreaSeries', {
   components: { Path },
-  path,
   getPointTransformer,
   createHitTester,
 });

--- a/packages/dx-react-chart/src/plugins/area-series.test.jsx
+++ b/packages/dx-react-chart/src/plugins/area-series.test.jsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { PluginHost } from '@devexpress/dx-react-core';
-import { dArea, findSeriesByName } from '@devexpress/dx-chart-core';
+import { findSeriesByName } from '@devexpress/dx-chart-core';
 import { pluginDepsToComponents } from '@devexpress/dx-react-core/test-utils';
 import { AreaSeries } from './area-series';
 
 jest.mock('@devexpress/dx-chart-core', () => ({
-  dArea: jest.fn(),
   findSeriesByName: jest.fn(),
   addSeries: jest.fn(),
   ARGUMENT_DOMAIN: 'test_argument_domain',
@@ -35,7 +34,6 @@ describe('Area series', () => {
     index: 1,
     points: coords,
     seriesComponent: SeriesComponent,
-    path: dArea,
     color: 'color',
   });
 
@@ -67,7 +65,6 @@ describe('Area series', () => {
       pointComponent: undefined,
       index: 1,
       coordinates: coords,
-      path: dArea,
       color: 'color',
       getAnimatedStyle: undefined,
       scales: { xScale: 'arg-scale', yScale: 'val-scale' },

--- a/packages/dx-react-chart/src/plugins/line-series.jsx
+++ b/packages/dx-react-chart/src/plugins/line-series.jsx
@@ -1,14 +1,12 @@
 import {
-  dLine as path,
   getLinePointTransformer as getPointTransformer,
   createLineHitTester as createHitTester,
 } from '@devexpress/dx-chart-core';
 import { declareSeries } from '../utils';
-import { Path } from '../templates/series/path';
+import { Line as Path } from '../templates/series/line';
 
 export const LineSeries = declareSeries('LineSeries', {
   components: { Path },
-  path,
   getPointTransformer,
   createHitTester,
 });

--- a/packages/dx-react-chart/src/plugins/line-series.test.jsx
+++ b/packages/dx-react-chart/src/plugins/line-series.test.jsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { PluginHost } from '@devexpress/dx-react-core';
-import { dLine, findSeriesByName } from '@devexpress/dx-chart-core';
+import { findSeriesByName } from '@devexpress/dx-chart-core';
 import { pluginDepsToComponents } from '@devexpress/dx-react-core/test-utils';
 import { LineSeries } from './line-series';
 
 jest.mock('@devexpress/dx-chart-core', () => ({
-  dLine: jest.fn(),
   findSeriesByName: jest.fn(),
   addSeries: jest.fn(),
   ARGUMENT_DOMAIN: 'test_argument_domain',
@@ -35,7 +34,6 @@ describe('Line series', () => {
     index: 1,
     points: coords,
     seriesComponent: SeriesComponent,
-    path: dLine,
     color: 'color',
   });
 
@@ -64,7 +62,6 @@ describe('Line series', () => {
       pointComponent: undefined,
       index: 1,
       coordinates: coords,
-      path: dLine,
       color: 'color',
       getAnimatedStyle: undefined,
       scales: { xScale: 'arg-scale', yScale: 'val-scale' },

--- a/packages/dx-react-chart/src/plugins/spline-series.jsx
+++ b/packages/dx-react-chart/src/plugins/spline-series.jsx
@@ -1,14 +1,12 @@
 import {
-  dSpline as path,
   getLinePointTransformer as getPointTransformer,
   createSplineHitTester as createHitTester,
 } from '@devexpress/dx-chart-core';
 import { declareSeries } from '../utils';
-import { Path } from '../templates/series/path';
+import { Spline as Path } from '../templates/series/spline';
 
 export const SplineSeries = declareSeries('SplineSeries', {
   components: { Path },
-  path,
   getPointTransformer,
   createHitTester,
 });

--- a/packages/dx-react-chart/src/plugins/spline-series.test.jsx
+++ b/packages/dx-react-chart/src/plugins/spline-series.test.jsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { PluginHost } from '@devexpress/dx-react-core';
-import { findSeriesByName, dSpline } from '@devexpress/dx-chart-core';
+import { findSeriesByName } from '@devexpress/dx-chart-core';
 import { pluginDepsToComponents } from '@devexpress/dx-react-core/test-utils';
 import { SplineSeries } from './spline-series';
 
 jest.mock('@devexpress/dx-chart-core', () => ({
-  dSpline: jest.fn(),
   findSeriesByName: jest.fn(),
   addSeries: jest.fn(),
   ARGUMENT_DOMAIN: 'test_argument_domain',
@@ -36,7 +35,6 @@ describe('Spline series', () => {
     index: 1,
     points: coords,
     seriesComponent: SeriesComponent,
-    path: dSpline,
     color: 'color',
   });
 
@@ -65,7 +63,6 @@ describe('Spline series', () => {
       pointComponent: undefined,
       index: 1,
       coordinates: coords,
-      path: dSpline,
       color: 'color',
       getAnimatedStyle: undefined,
       scales: { xScale: 'arg-scale', yScale: 'val-scale' },

--- a/packages/dx-react-chart/src/templates/series/area.jsx
+++ b/packages/dx-react-chart/src/templates/series/area.jsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { getAreaAnimationStyle, HOVERED, SELECTED } from '@devexpress/dx-chart-core';
+import {
+  dArea, getAreaAnimationStyle, HOVERED, SELECTED,
+} from '@devexpress/dx-chart-core';
 import { withStates } from '../../utils/with-states';
 import { withPattern } from '../../utils/with-pattern';
 
@@ -27,7 +29,7 @@ class RawArea extends React.PureComponent {
 }
 
 RawArea.propTypes = {
-  path: PropTypes.func.isRequired,
+  path: PropTypes.func,
   coordinates: PropTypes.array.isRequired,
   index: PropTypes.number.isRequired,
   state: PropTypes.string,
@@ -38,6 +40,7 @@ RawArea.propTypes = {
 };
 
 RawArea.defaultProps = {
+  path: dArea,
   state: undefined,
   color: undefined,
   style: undefined,

--- a/packages/dx-react-chart/src/templates/series/line.jsx
+++ b/packages/dx-react-chart/src/templates/series/line.jsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { dLine } from '@devexpress/dx-chart-core';
+import { Path } from './path';
+
+export class Line extends React.PureComponent {
+  render() {
+    return <Path {...this.props} />;
+  }
+}
+
+Line.defaultProps = { path: dLine };

--- a/packages/dx-react-chart/src/templates/series/point-collection.jsx
+++ b/packages/dx-react-chart/src/templates/series/point-collection.jsx
@@ -8,7 +8,6 @@ export class PointCollection extends React.PureComponent {
       coordinates,
       index,
       state,
-      path,
       ...restProps
     } = this.props;
     return (coordinates.map(point => (

--- a/packages/dx-react-chart/src/templates/series/spline.jsx
+++ b/packages/dx-react-chart/src/templates/series/spline.jsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { dSpline } from '@devexpress/dx-chart-core';
+import { Path } from './path';
+
+export class Spline extends React.PureComponent {
+  render() {
+    return <Path {...this.props} />;
+  }
+}
+
+Spline.defaultProps = { path: dSpline };

--- a/packages/dx-react-chart/src/utils/series-helper.jsx
+++ b/packages/dx-react-chart/src/utils/series-helper.jsx
@@ -40,7 +40,6 @@ export const declareSeries = (pluginName, { components, ...parameters }) => {
                     index={currentSeries.index}
                     pointComponent={currentSeries.pointComponent}
                     coordinates={currentSeries.points}
-                    path={currentSeries.path}
                     color={currentSeries.color}
                     scales={currentScales}
                     getAnimatedStyle={getAnimatedStyle}


### PR DESCRIPTION
Updates *LineSeries* and *SplineSeries* so that their *Path* components reflect corresponding difference.
Now `SplineSeries.Path` will render curved line.

BREAKING CHANGES:
Starting with this release, the *Area*, *Line*, and *Spline* series do not pass the `path` property to their `seriesComponent` component because it is an inner part of the component's implementation.
You can create *path* function using [d3.line](https://github.com/d3/d3-shape#line) and [d3.area](https://github.com/d3/d3-shape#area).