### PR TITLE
refactor(react-chart): make refs in Axis persistent

### DIFF
--- a/packages/dx-react-chart/src/plugins/axis.test.jsx
+++ b/packages/dx-react-chart/src/plugins/axis.test.jsx
@@ -9,7 +9,6 @@ jest.mock('@devexpress/dx-chart-core', () => ({
   axisCoordinates: jest.fn(),
   axesData: jest.fn(),
   LEFT: 'left',
-  TOP: 'top',
   BOTTOM: 'bottom',
 }));
 
@@ -27,18 +26,18 @@ describe('Axis', () => {
   const TickComponent = () => null;
   const LabelComponent = () => null;
   const LineComponent = () => null;
+
   const getterForAxis = position => ({
     getter: {
       layouts: {
-        [`${position}-axis`]: {
-          x: 3, y: 4, width: 250, height: 150,
-        },
+        [`${position}-axis`]: { width: 250, height: 150 },
       },
     },
     template: {
       [`${position}-axis`]: {},
     },
   });
+
   const defaultDeps = {
     getter: {
       scales: {
@@ -46,7 +45,7 @@ describe('Axis', () => {
       },
       layouts: {
         'bottom-axis': {
-          x: 1, y: 2, width: 200, height: 100,
+          width: 200, height: 100,
         },
       },
       axes: [{}],
@@ -58,8 +57,8 @@ describe('Axis', () => {
       'bottom-axis': {},
     },
   };
+
   const defaultProps = {
-    min: 0,
     position: 'bottom',
     name: 'test-domain',
     rootComponent: RootComponent,
@@ -68,30 +67,32 @@ describe('Axis', () => {
     lineComponent: LineComponent,
   };
 
-  const mockTicks = [{
-    text: 'text1',
-    x1: 1,
-    x2: 2,
-    y1: 3,
-    y2: 4,
-    xText: 'xText1',
-    yText: 'yText1',
-    dominantBaseline: 'dominantBaseline1',
-    textAnchor: 'textAnchor1',
-    key: '1',
-  },
-  {
-    text: 'text2',
-    x1: 11,
-    x2: 22,
-    y1: 33,
-    y2: 44,
-    xText: 'xText2',
-    yText: 'yText2',
-    dominantBaseline: 'dominantBaseline2',
-    textAnchor: 'textAnchor2',
-    key: '2',
-  }];
+  const mockTicks = [
+    {
+      text: 'text1',
+      x1: 1,
+      x2: 2,
+      y1: 3,
+      y2: 4,
+      xText: 'xText1',
+      yText: 'yText1',
+      dominantBaseline: 'dominantBaseline1',
+      textAnchor: 'textAnchor1',
+      key: '1',
+    },
+    {
+      text: 'text2',
+      x1: 11,
+      x2: 22,
+      y1: 33,
+      y2: 44,
+      xText: 'xText2',
+      yText: 'yText2',
+      dominantBaseline: 'dominantBaseline2',
+      textAnchor: 'textAnchor2',
+      key: '2',
+    },
+  ];
 
   const setupAxisCoordinates = (sides) => {
     axisCoordinates.mockReturnValue({ sides, ticks: mockTicks });
@@ -107,67 +108,51 @@ describe('Axis', () => {
     const tree = mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <Axis
-          {...defaultProps}
-        />
+        <Axis {...defaultProps} />
       </PluginHost>
     ));
 
-    const {
-      x, y, refsHandler, children,
-    } = tree.find(RootComponent).props();
-    expect(x).toBe(-0);
-    expect(y).toBe(-0);
-    expect(refsHandler).toEqual(expect.any(Function));
-    expect(children).toEqual(expect.any(Object));
+    expect(tree.find(RootComponent).props()).toEqual({
+      dx: 1,
+      dy: 0,
+      onSizeChange: expect.any(Function),
+      children: expect.anything(),
+    });
   });
 
-  it('should pass correct bbox for group, vertical-left position', () => {
-    const element = {
-      getBBox: jest.fn(() => ({
-        x: -30, y: 0, width: 20, height: 30,
-      })),
-    };
-    setupAxisCoordinates([0, 1]);
+  it('should pass correct bbox, vertical-left position', () => {
+    setupAxisCoordinates([1, 0]);
     const tree = mount((
       <PluginHost>
         <Axis {...defaultProps} position="left" />
         {pluginDepsToComponents(defaultDeps, getterForAxis('left'))}
       </PluginHost>
     ));
-    const { refsHandler } = tree.find(RootComponent).props();
 
-    refsHandler(element);
-    expect(defaultDeps.action.changeBBox.mock.calls[0][0])
-      .toMatchObject({ placeholder: 'left-axis', bBox: { width: 30, height: 30 } });
+    tree.find(RootComponent).props().onSizeChange({ tag: 'size' });
+
+    expect(defaultDeps.action.changeBBox.mock.calls[0][0]).toEqual({
+      placeholder: 'left-axis', bBox: { tag: 'size' },
+    });
   });
 
-  it('should pass correct bbox for group, vertical-right position', () => {
-    const element = {
-      getBBox: jest.fn(() => ({
-        x: 10, y: 0, width: 30, height: 30,
-      })),
-    };
-    setupAxisCoordinates([0, 1]);
+  it('should pass correct bbox, vertical-right position', () => {
+    setupAxisCoordinates([1, 0]);
     const tree = mount((
       <PluginHost>
         <Axis {...defaultProps} position="right" />
         {pluginDepsToComponents(defaultDeps, getterForAxis('right'))}
       </PluginHost>
     ));
-    const { refsHandler } = tree.find(RootComponent).props();
 
-    refsHandler(element);
-    expect(defaultDeps.action.changeBBox.mock.calls[0][0])
-      .toMatchObject({ placeholder: 'right-axis', bBox: { width: 40, height: 30 } });
+    tree.find(RootComponent).props().onSizeChange({ tag: 'size' });
+
+    expect(defaultDeps.action.changeBBox.mock.calls[0][0]).toEqual({
+      placeholder: 'right-axis', bBox: { tag: 'size' },
+    });
   });
 
-  it('should pass correct bbox for group, horizontal-top position', () => {
-    const element = {
-      getBBox: jest.fn(() => ({
-        x: 0, y: -40, width: 30, height: 30,
-      })),
-    };
+  it('should pass correct bbox, horizontal-top position', () => {
     setupAxisCoordinates([1, 0]);
     const tree = mount((
       <PluginHost>
@@ -175,19 +160,15 @@ describe('Axis', () => {
         {pluginDepsToComponents(defaultDeps, getterForAxis('top'))}
       </PluginHost>
     ));
-    const { refsHandler } = tree.find(RootComponent).props();
 
-    refsHandler(element);
-    expect(defaultDeps.action.changeBBox.mock.calls[0][0])
-      .toMatchObject({ placeholder: 'top-axis', bBox: { width: 30, height: 40 } });
+    tree.find(RootComponent).props().onSizeChange({ tag: 'size' });
+
+    expect(defaultDeps.action.changeBBox.mock.calls[0][0]).toEqual({
+      placeholder: 'top-axis', bBox: { tag: 'size' },
+    });
   });
 
   it('should pass correct bbox for group, horizontal-bottom position', () => {
-    const element = {
-      getBBox: jest.fn(() => ({
-        x: 0, y: 10, width: 30, height: 20,
-      })),
-    };
     setupAxisCoordinates([1, 0]);
     const tree = mount((
       <PluginHost>
@@ -195,31 +176,12 @@ describe('Axis', () => {
         {pluginDepsToComponents(defaultDeps)}
       </PluginHost>
     ));
-    const { refsHandler } = tree.find(RootComponent).props();
 
-    refsHandler(element);
-    expect(defaultDeps.action.changeBBox.mock.calls[0][0])
-      .toMatchObject({ placeholder: 'bottom-axis', bBox: { width: 30, height: 30 } });
-  });
+    tree.find(RootComponent).props().onSizeChange({ tag: 'size' });
 
-  it('should render argument axis', () => {
-    setupAxisCoordinates([1, 0]);
-    const tree = mount((
-      <PluginHost>
-        {pluginDepsToComponents(defaultDeps)}
-        <Axis
-          {...defaultProps}
-        />
-      </PluginHost>
-    ));
-
-    const {
-      x, y, refsHandler, children,
-    } = tree.find(RootComponent).props();
-    expect(x).toBe(-0);
-    expect(y).toBe(-0);
-    expect(refsHandler).toEqual(expect.any(Function));
-    expect(children).toEqual(expect.any(Object));
+    expect(defaultDeps.action.changeBBox.mock.calls[0][0]).toEqual({
+      placeholder: 'bottom-axis', bBox: { tag: 'size' },
+    });
   });
 
   it('should pass axisCoordinates method correct parameters, horizontal orientation', () => {
@@ -256,7 +218,7 @@ describe('Axis', () => {
             },
             layouts: {
               'bottom-axis': {
-                x: 3, y: 4, width: 250, height: 150,
+                width: 250, height: 150,
               },
             },
           },
@@ -289,6 +251,7 @@ describe('Axis', () => {
         />
       </PluginHost>
     ));
+
     expect(tree.find(TickComponent).get(0).props).toEqual({
       x1: 1,
       x2: 2,

--- a/packages/dx-react-chart/src/templates/axis/root.jsx
+++ b/packages/dx-react-chart/src/templates/axis/root.jsx
@@ -1,14 +1,52 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 
+const getOffset = position => (position >= 0 ? 0 : -position);
+const getSize = (position, delta) => (position >= 0 ? position + delta : -position);
+
 export class Root extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.ref = (node) => {
+      this.node = node;
+    };
+    this.state = {
+      // *width* and *height* are actually used in *adjust* (eslint false alarm)
+      x: 0, y: 0, width: 0, height: 0, // eslint-disable-line react/no-unused-state
+    };
+    this.adjust = this.adjust.bind(this);
+  }
+
+  componentDidMount() {
+    this.setState(this.adjust);
+  }
+
+  componentDidUpdate() {
+    // *setState* can be called unconditionally because it contains proper check inside.
+    this.setState(this.adjust); // eslint-disable-line react/no-did-update-set-state
+  }
+
+  adjust({ width: prevWidth, height: prevHeight }, { dx, dy, onSizeChange }) {
+    const bbox = this.node.getBBox();
+    const width = dx ? bbox.width : getSize(bbox.x, bbox.width);
+    const height = dy ? bbox.height : getSize(bbox.y, bbox.height);
+    const x = dx ? 0 : getOffset(bbox.x);
+    const y = dy ? 0 : getOffset(bbox.y);
+    if (width === prevWidth && height === prevHeight) {
+      return null;
+    }
+    onSizeChange({ width, height });
+    return {
+      x, y, width, height,
+    };
+  }
+
   render() {
-    const {
-      x, y, refsHandler, children, ...restProps
-    } = this.props;
+    const { children, onSizeChange, ...restProps } = this.props;
+    const { x, y } = this.state;
     return (
       <g
-        ref={refsHandler}
+        ref={this.ref}
         transform={`translate(${x} ${y})`}
         {...restProps}
       >
@@ -19,8 +57,8 @@ export class Root extends React.PureComponent {
 }
 
 Root.propTypes = {
-  x: PropTypes.number.isRequired,
-  y: PropTypes.number.isRequired,
-  refsHandler: PropTypes.func.isRequired,
+  dx: PropTypes.number.isRequired,
+  dy: PropTypes.number.isRequired,
+  onSizeChange: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
 };

--- a/packages/dx-react-chart/src/templates/axis/root.test.jsx
+++ b/packages/dx-react-chart/src/templates/axis/root.test.jsx
@@ -1,40 +1,101 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
+import { setupConsole } from '@devexpress/dx-testing';
 import { Root } from './root';
 
-const defaultProps = {
-  x: 1,
-  y: 2,
-  refsHandler: jest.fn(),
-  children: null,
-};
-
 describe('Root', () => {
-  it('should render root element', () => {
-    const tree = shallow((
-      <Root {...defaultProps}>
+  let resetConsole;
+  const getBBox = jest.fn();
+
+  beforeAll(() => {
+    resetConsole = setupConsole({ ignore: ['The tag <%s> is unrecognized in this browser.'] });
+    global.HTMLUnknownElement.prototype.getBBox = getBBox;
+  });
+
+  afterAll(() => {
+    delete global.HTMLUnknownElement.prototype.getBBox;
+    resetConsole();
+  });
+
+  afterEach(getBBox.mockReset);
+
+  it('should render root element, horizontal top', () => {
+    getBBox.mockReturnValue({
+      x: 8, y: -37, width: 40, height: 30,
+    });
+    const mock = jest.fn();
+    const tree = mount((
+      <Root dx={1} dy={0} onSizeChange={mock}>
         <div />
       </Root>
     ));
 
     const g = tree.find('g');
-    const { transform } = g.props();
-
-    expect(transform)
-      .toBe('translate(1 2)');
-    expect(g.find('div').exists())
-      .toBeTruthy();
+    expect(g.props().transform).toEqual('translate(0 37)');
+    expect(g.find('div').exists()).toBeTruthy();
+    expect(mock).toBeCalledWith({ width: 40, height: 37 });
   });
 
-  it('should pass the rest property to the root element', () => {
-    const tree = shallow((
-      <Root {...defaultProps} customProperty>
+  it('should render root element, horizontal top', () => {
+    getBBox.mockReturnValue({
+      x: 8, y: 7, width: 40, height: 30,
+    });
+    const mock = jest.fn();
+    const tree = mount((
+      <Root dx={1} dy={0} onSizeChange={mock}>
         <div />
-      </Root>));
+      </Root>
+    ));
 
-    const { customProperty } = tree.find('g').props();
+    const g = tree.find('g');
+    expect(g.props().transform).toEqual('translate(0 0)');
+    expect(g.find('div').exists()).toBeTruthy();
+    expect(mock).toBeCalledWith({ width: 40, height: 37 });
+  });
 
-    expect(customProperty)
-      .toBeTruthy();
+  it('should render root element, vertical left', () => {
+    getBBox.mockReturnValue({
+      x: -48, y: 7, width: 40, height: 30,
+    });
+    const mock = jest.fn();
+    const tree = mount((
+      <Root dx={0} dy={1} onSizeChange={mock}>
+        <div />
+      </Root>
+    ));
+
+    const g = tree.find('g');
+    expect(g.props().transform).toEqual('translate(48 0)');
+    expect(g.find('div').exists()).toBeTruthy();
+    expect(mock).toBeCalledWith({ width: 48, height: 30 });
+  });
+
+  it('should render root element, vertical right', () => {
+    getBBox.mockReturnValue({
+      x: 8, y: 7, width: 40, height: 30,
+    });
+    const mock = jest.fn();
+    const tree = mount((
+      <Root dx={0} dy={1} onSizeChange={mock}>
+        <div />
+      </Root>
+    ));
+
+    const g = tree.find('g');
+    expect(g.props().transform).toEqual('translate(0 0)');
+    expect(g.find('div').exists()).toBeTruthy();
+    expect(mock).toBeCalledWith({ width: 48, height: 30 });
+  });
+
+  it('should pass rest properties to the root element', () => {
+    getBBox.mockReturnValue({});
+    const tree = mount((
+      <Root dx={1} dy={0} onSizeChange={() => null} custom={10}>
+        <div />
+      </Root>
+    ));
+
+    const { custom } = tree.find('g').props();
+    expect(custom).toEqual(10);
   });
 });


### PR DESCRIPTION
Keeps *div* ref in constructor.
Moves axis group alignment logic to Root component.