### PR TITLE
refactor(react-chart): remove DOM access in Axis *render*

### DIFF
--- a/packages/dx-react-chart/src/plugins/axis.jsx
+++ b/packages/dx-react-chart/src/plugins/axis.jsx
@@ -37,9 +37,9 @@ const adjustScaleRange = (scale, [width, height]) => {
 class RawAxis extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.setRootRef = (node) => {
-      this.node = node;
-    };
+    this.rootRef = React.createRef();
+    this.adjustedWidth = 0;
+    this.adjustedHeight = 0;
   }
 
   render() {
@@ -71,22 +71,25 @@ class RawAxis extends React.PureComponent {
               }
 
               const { width, height } = layouts[placeholder] || { width: 0, height: 0 };
-              // DOM content should not be accessed in *render* - it should be done
-              // in *componentDidMount* and *componentDidUpdate*.
-              // TODO: Remove references to *this.node*.
-              const { width: postWidth, height: postHeight } = (
-                this.node ? this.node.getBoundingClientRect() : { width, height }
-              );
-              // Isn't it too late to adjust sizes?
-              const postCalculatedScale = adjustScaleRange(scale, [postWidth, postHeight]);
               const { sides: [dx, dy], ticks } = axisCoordinates({
                 name,
-                scale: postCalculatedScale,
+                // Isn't it too late to adjust sizes?
+                scale: adjustScaleRange(scale, [this.adjustedWidth, this.adjustedHeight]),
                 position,
                 tickSize,
                 tickFormat,
                 indentFromAxis,
               });
+              const handleSizeChange = (size) => {
+                // The callback is called when DOM is available -
+                // *rootRef.current* can be surely accessed.
+                const rect = this.rootRef.current.getBoundingClientRect();
+                // *setState* is not used because it would cause excessive Plugin rerenders.
+                // Template rerender is provided by *changeBBox* invocation.
+                this.adjustedWidth = rect.width;
+                this.adjustedHeight = rect.height;
+                changeBBox({ placeholder, bBox: size });
+              };
 
               return (
                 <div
@@ -96,17 +99,17 @@ class RawAxis extends React.PureComponent {
                     height: (dx * height) || undefined,
                     flexGrow: dx || undefined,
                   }}
-                  ref={this.setRootRef}
+                  ref={this.rootRef}
                 >
                   <svg
-                    width={postWidth}
-                    height={postHeight}
+                    width={this.adjustedWidth}
+                    height={this.adjustedHeight}
                     style={SVG_STYLE}
                   >
                     <RootComponent
                       dx={dx}
                       dy={dy}
-                      onSizeChange={bBox => changeBBox({ placeholder, bBox })}
+                      onSizeChange={handleSizeChange}
                     >
                       {ticks.map(({
                         x1, x2, y1, y2, key,
@@ -120,8 +123,8 @@ class RawAxis extends React.PureComponent {
                         />
                       ))}
                       <LineComponent
-                        width={dx * postWidth}
-                        height={dy * postHeight}
+                        width={dx * this.adjustedWidth}
+                        height={dy * this.adjustedHeight}
                       />
                       {ticks.map(({
                         text,

--- a/packages/dx-react-chart/src/plugins/axis.test.jsx
+++ b/packages/dx-react-chart/src/plugins/axis.test.jsx
@@ -27,26 +27,17 @@ describe('Axis', () => {
   const LabelComponent = () => null;
   const LineComponent = () => null;
 
-  const getterForAxis = position => ({
-    getter: {
-      layouts: {
-        [`${position}-axis`]: { width: 250, height: 150 },
-      },
-    },
-    template: {
-      [`${position}-axis`]: {},
-    },
-  });
-
   const defaultDeps = {
     getter: {
       scales: {
         'test-domain': mockScale,
+        'other-domain': mockScale,
       },
       layouts: {
-        'bottom-axis': {
-          width: 200, height: 100,
-        },
+        'top-axis': { width: 150, height: 100 },
+        'bottom-axis': { width: 200, height: 150 },
+        'left-axis': { width: 250, height: 200 },
+        'right-axis': { width: 300, height: 250 },
       },
       axes: [{}],
     },
@@ -54,7 +45,10 @@ describe('Axis', () => {
       changeBBox: jest.fn(),
     },
     template: {
+      'top-axis': {},
       'bottom-axis': {},
+      'left-axis': {},
+      'right-axis': {},
     },
   };
 
@@ -98,19 +92,44 @@ describe('Axis', () => {
     axisCoordinates.mockReturnValue({ sides, ticks: mockTicks });
   };
 
+  const enforceUpdate = tree => tree.setProps({ tag: 'enforce-update' }).update();
+
+  const getDivStyle = tree => tree.findWhere(node => (
+    node.type() === 'div' && node.prop('style') && node.prop('style').position === 'relative'
+  )).prop('style');
+
+  let originalGetBoundingClientRect;
+  const getBoundingClientRect = jest.fn();
+
+  beforeAll(() => {
+    originalGetBoundingClientRect = global.HTMLDivElement.prototype.getBoundingClientRect;
+    global.HTMLDivElement.prototype.getBoundingClientRect = getBoundingClientRect;
+  });
+
+  afterAll(() => {
+    global.HTMLDivElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  });
+
+  beforeEach(() => {
+    setupAxisCoordinates([1, 0]);
+    getBoundingClientRect.mockReturnValue({ width: 400, height: 300 });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
     axisCoordinates.mockReset();
+    getBoundingClientRect.mockReset();
   });
 
+  const AxisTester = props => (
+    <PluginHost>
+      {pluginDepsToComponents(defaultDeps)}
+      <Axis {...defaultProps} {...props} />
+    </PluginHost>
+  );
+
   it('should render root component', () => {
-    setupAxisCoordinates([1, 0]);
-    const tree = mount((
-      <PluginHost>
-        {pluginDepsToComponents(defaultDeps)}
-        <Axis {...defaultProps} />
-      </PluginHost>
-    ));
+    const tree = mount(<AxisTester />);
 
     expect(tree.find(RootComponent).props()).toEqual({
       dx: 1,
@@ -121,81 +140,73 @@ describe('Axis', () => {
   });
 
   it('should pass correct bbox, vertical-left position', () => {
-    setupAxisCoordinates([1, 0]);
-    const tree = mount((
-      <PluginHost>
-        <Axis {...defaultProps} position="left" />
-        {pluginDepsToComponents(defaultDeps, getterForAxis('left'))}
-      </PluginHost>
-    ));
+    setupAxisCoordinates([0, 1]);
+    const tree = mount(<AxisTester position="left" />);
 
     tree.find(RootComponent).props().onSizeChange({ tag: 'size' });
 
     expect(defaultDeps.action.changeBBox.mock.calls[0][0]).toEqual({
       placeholder: 'left-axis', bBox: { tag: 'size' },
     });
+
+    enforceUpdate(tree);
+
+    expect(getDivStyle(tree)).toEqual({ position: 'relative', width: 250 });
+    expect(tree.find('svg').props()).toMatchObject({ width: 400, height: 300 });
   });
 
   it('should pass correct bbox, vertical-right position', () => {
-    setupAxisCoordinates([1, 0]);
-    const tree = mount((
-      <PluginHost>
-        <Axis {...defaultProps} position="right" />
-        {pluginDepsToComponents(defaultDeps, getterForAxis('right'))}
-      </PluginHost>
-    ));
+    setupAxisCoordinates([0, 1]);
+    const tree = mount(<AxisTester position="right" />);
 
     tree.find(RootComponent).props().onSizeChange({ tag: 'size' });
 
     expect(defaultDeps.action.changeBBox.mock.calls[0][0]).toEqual({
       placeholder: 'right-axis', bBox: { tag: 'size' },
     });
+
+    enforceUpdate(tree);
+
+    expect(getDivStyle(tree)).toEqual({ position: 'relative', width: 300 });
+    expect(tree.find('svg').props()).toMatchObject({ width: 400, height: 300 });
   });
 
   it('should pass correct bbox, horizontal-top position', () => {
     setupAxisCoordinates([1, 0]);
-    const tree = mount((
-      <PluginHost>
-        <Axis {...defaultProps} position="top" />
-        {pluginDepsToComponents(defaultDeps, getterForAxis('top'))}
-      </PluginHost>
-    ));
+    const tree = mount(<AxisTester position="top" />);
 
     tree.find(RootComponent).props().onSizeChange({ tag: 'size' });
 
     expect(defaultDeps.action.changeBBox.mock.calls[0][0]).toEqual({
       placeholder: 'top-axis', bBox: { tag: 'size' },
     });
+
+    enforceUpdate(tree);
+
+    expect(getDivStyle(tree)).toEqual({ position: 'relative', height: 100, flexGrow: 1 });
+    expect(tree.find('svg').props()).toMatchObject({ width: 400, height: 300 });
   });
 
   it('should pass correct bbox for group, horizontal-bottom position', () => {
     setupAxisCoordinates([1, 0]);
-    const tree = mount((
-      <PluginHost>
-        <Axis {...defaultProps} />
-        {pluginDepsToComponents(defaultDeps)}
-      </PluginHost>
-    ));
+    const tree = mount(<AxisTester />);
 
     tree.find(RootComponent).props().onSizeChange({ tag: 'size' });
 
     expect(defaultDeps.action.changeBBox.mock.calls[0][0]).toEqual({
       placeholder: 'bottom-axis', bBox: { tag: 'size' },
     });
+
+    enforceUpdate(tree);
+
+    expect(getDivStyle(tree)).toEqual({ position: 'relative', height: 150, flexGrow: 1 });
+    expect(tree.find('svg').props()).toMatchObject({ width: 400, height: 300 });
   });
 
   it('should pass axisCoordinates method correct parameters, horizontal orientation', () => {
     const mockTickFormat = () => 0;
     setupAxisCoordinates([1, 0]);
-    mount((
-      <PluginHost>
-        {pluginDepsToComponents(defaultDeps)}
-        <Axis
-          {...defaultProps}
-          tickFormat={mockTickFormat}
-        />
-      </PluginHost>
-    ));
+    mount(<AxisTester tickFormat={mockTickFormat} />);
 
     expect(axisCoordinates).toHaveBeenCalledWith({
       name: 'test-domain',
@@ -209,28 +220,13 @@ describe('Axis', () => {
 
   it('should pass axisCoordinates method correct parameters, vertical orientation', () => {
     setupAxisCoordinates([0, 1]);
-    mount((
-      <PluginHost>
-        {pluginDepsToComponents(defaultDeps, {
-          getter: {
-            scales: {
-              'other-domain': mockScale,
-            },
-            layouts: {
-              'bottom-axis': {
-                width: 250, height: 150,
-              },
-            },
-          },
-        })}
-        <Axis
-          {...defaultProps}
-          name="other-domain"
-          tickSize={6}
-          indentFromAxis={3}
-        />
-      </PluginHost>
-    ));
+    mount(
+      <AxisTester
+        name="other-domain"
+        tickSize={6}
+        indentFromAxis={3}
+      />,
+    );
 
     expect(axisCoordinates).toHaveBeenCalledWith({
       name: 'other-domain',
@@ -243,14 +239,7 @@ describe('Axis', () => {
 
   it('should render tick component', () => {
     setupAxisCoordinates([1, 0]);
-    const tree = mount((
-      <PluginHost>
-        {pluginDepsToComponents(defaultDeps)}
-        <Axis
-          {...defaultProps}
-        />
-      </PluginHost>
-    ));
+    const tree = mount(<AxisTester />);
 
     expect(tree.find(TickComponent).get(0).props).toEqual({
       x1: 1,
@@ -268,14 +257,7 @@ describe('Axis', () => {
 
   it('should render label component', () => {
     setupAxisCoordinates([1, 0]);
-    const tree = mount((
-      <PluginHost>
-        {pluginDepsToComponents(defaultDeps)}
-        <Axis
-          {...defaultProps}
-        />
-      </PluginHost>
-    ));
+    const tree = mount(<AxisTester />);
 
     expect(tree.find(LabelComponent).get(0).props).toEqual({
       x: 'xText1',
@@ -296,48 +278,34 @@ describe('Axis', () => {
 
   it('should render line component, horizontal', () => {
     setupAxisCoordinates([1, 0]);
-    const tree = mount((
-      <PluginHost>
-        {pluginDepsToComponents(defaultDeps)}
-        <Axis
-          {...defaultProps}
-        />
-      </PluginHost>
-    ));
+    const tree = mount(<AxisTester />);
+
+    tree.find(RootComponent).props().onSizeChange({ tag: 'size' });
+    enforceUpdate(tree);
 
     expect(tree.find(LineComponent).props()).toEqual({
-      width: 200,
+      width: 400,
       height: 0,
     });
   });
 
   it('should render line component, vertical', () => {
     setupAxisCoordinates([0, 1]);
-    const tree = mount((
-      <PluginHost>
-        {pluginDepsToComponents(defaultDeps)}
-        <Axis
-          {...defaultProps}
-        />
-      </PluginHost>
-    ));
+    const tree = mount(<AxisTester />);
+
+    tree.find(RootComponent).props().onSizeChange({ tag: 'size' });
+    enforceUpdate(tree);
 
     expect(tree.find(LineComponent).props()).toEqual({
       width: 0,
-      height: 100,
+      height: 300,
     });
   });
 
   it('should pass axesData correct arguments', () => {
     setupAxisCoordinates([1, 0]);
-    mount((
-      <PluginHost>
-        {pluginDepsToComponents(defaultDeps)}
-        <Axis
-          {...defaultProps}
-        />
-      </PluginHost>
-    ));
+    mount(<AxisTester />);
+
     expect(axesData).toHaveBeenCalledWith(
       expect.arrayContaining([{}]),
       expect.objectContaining(defaultProps),


### PR DESCRIPTION
Makes `getBoundingClientRect` invocation to a time when axis is mount or updated.