### PR TITLE
chore(react-chart): fix HoverState and Tooltip plugins dependencies

### DIFF
--- a/packages/dx-react-chart/src/plugins/hover-state.jsx
+++ b/packages/dx-react-chart/src/plugins/hover-state.jsx
@@ -8,6 +8,8 @@ import {
   changeSeriesState, processPointerMove, getHoverTargets, HOVERED,
 } from '@devexpress/dx-chart-core';
 
+const dependencies = [{ name: 'EventTracker', optional: true }];
+
 export class HoverState extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -15,7 +17,7 @@ export class HoverState extends React.PureComponent {
       hover: props.hover || props.defaultHover,
     };
     const handlePointerMove = this.handlePointerMove.bind(this);
-    this.getPointerMoveHandlers = ({ pointerMoveHandlers }) => [
+    this.getPointerMoveHandlers = ({ pointerMoveHandlers = [] }) => [
       ...pointerMoveHandlers, handlePointerMove,
     ];
   }
@@ -37,7 +39,7 @@ export class HoverState extends React.PureComponent {
     // to notify that "series" is updated.
     const getSeries = ({ series }) => changeSeriesState(series, getHoverTargets(hover), HOVERED);
     return (
-      <Plugin name="HoverState">
+      <Plugin name="HoverState" dependencies={dependencies}>
         <Getter name="pointerMoveHandlers" computed={this.getPointerMoveHandlers} />
         <Getter name="series" computed={getSeries} />
       </Plugin>

--- a/packages/dx-react-chart/src/plugins/hover-state.jsx
+++ b/packages/dx-react-chart/src/plugins/hover-state.jsx
@@ -25,12 +25,10 @@ export class HoverState extends React.PureComponent {
   }
 
   handlePointerMove({ targets }) {
-    const { onHoverChange } = this.props;
-    const { hover: currentTarget } = this.state;
-    const hover = processPointerMove(targets, currentTarget, onHoverChange);
-    if (hover !== undefined) {
-      this.setState({ hover });
-    }
+    this.setState(({ hover: currentTarget }, { onHoverChange }) => {
+      const hover = processPointerMove(targets, currentTarget, onHoverChange);
+      return hover !== undefined ? { hover } : null;
+    });
   }
 
   render() {

--- a/packages/dx-react-chart/src/plugins/tooltip.jsx
+++ b/packages/dx-react-chart/src/plugins/tooltip.jsx
@@ -11,6 +11,8 @@ import {
 import { getParameters, processHandleTooltip } from '@devexpress/dx-chart-core';
 import { Target } from '../templates/tooltip/target';
 
+const dependencies = [{ name: 'EventTracker', optional: true }];
+
 class RawTooltip extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -20,7 +22,7 @@ class RawTooltip extends React.PureComponent {
     this.createTargetElement = this.createTargetElement.bind(this);
     this.getTargetElement = this.getTargetElement.bind(this);
     const handlePointerMove = this.handlePointerMove.bind(this);
-    this.getPointerMoveHandlers = ({ pointerMoveHandlers }) => [
+    this.getPointerMoveHandlers = ({ pointerMoveHandlers = [] }) => [
       ...pointerMoveHandlers, handlePointerMove,
     ];
   }
@@ -60,7 +62,7 @@ class RawTooltip extends React.PureComponent {
       target,
     } = this.state;
     return (
-      <Plugin name="Tooltip">
+      <Plugin name="Tooltip" dependencies={dependencies}>
         <Getter name="pointerMoveHandlers" computed={this.getPointerMoveHandlers} />
         <Template name="series">
           <TemplatePlaceholder />

--- a/packages/dx-react-chart/src/utils/series-helper.jsx
+++ b/packages/dx-react-chart/src/utils/series-helper.jsx
@@ -40,6 +40,7 @@ export const declareSeries = (pluginName, { components, ...parameters }) => {
                     index={currentSeries.index}
                     pointComponent={currentSeries.pointComponent}
                     coordinates={currentSeries.points}
+                    state={currentSeries.state}
                     color={currentSeries.color}
                     scales={currentScales}
                     getAnimatedStyle={getAnimatedStyle}

--- a/packages/dx-react-chart/src/utils/series-helper.test.jsx
+++ b/packages/dx-react-chart/src/utils/series-helper.test.jsx
@@ -37,6 +37,7 @@ describe('#declareSeries', () => {
     index: 1,
     seriesComponent: TestComponentPath,
     points: coords,
+    state: 'test-state',
     color: 'color',
     styles: 'styles',
   });
@@ -82,6 +83,7 @@ describe('#declareSeries', () => {
       path: undefined,
       coordinates: coords,
       pointComponent: undefined,
+      state: 'test-state',
       color: 'color',
       scales: { xScale: 'argument-scale', yScale: 'value-scale' },
       getAnimatedStyle: 'test-animated-style-getter',


### PR DESCRIPTION
Makes plugins optionally dependent on *EventTracker* plugin.