### PR TITLE
chore(react-chart): rename `axisName` property to `scaleName` in series

### DIFF
--- a/packages/dx-chart-core/src/plugins/scale/computeds.js
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.js
@@ -8,7 +8,7 @@ import {
 const isDefined = item => item !== undefined;
 
 // TODO: Property name should not contain "axis" part as it actually means domain.
-const getSeriesValueDomainName = series => getValueDomainName(series.axisName);
+const getSeriesValueDomainName = series => getValueDomainName(series.scaleName);
 
 const calculateDomainField = (items, domain, type) => (
   type === BAND ? [...domain, ...items] : extent([...domain, ...extent(items)])

--- a/packages/dx-chart-core/src/plugins/scale/computeds.test.js
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.test.js
@@ -146,9 +146,9 @@ describe('computeDomains', () => {
       [{
         name: 'series1', getPointTransformer, points: makePoints([2, 3, 5, 6]),
       }, {
-        name: 'series2', getPointTransformer, points: makePoints([-1, -3, 0, 1]), axisName: 'domain1',
+        name: 'series2', getPointTransformer, points: makePoints([-1, -3, 0, 1]), scaleName: 'domain1',
       }, {
-        name: 'series3', getPointTransformer, points: makePoints([1, 2, 3, 1]), axisName: 'domain1',
+        name: 'series3', getPointTransformer, points: makePoints([1, 2, 3, 1]), scaleName: 'domain1',
       }, {
         name: 'series4', getPointTransformer, points: makePoints([2, 5, 7, 3]),
       }],
@@ -214,7 +214,7 @@ describe('computeDomains', () => {
       [{ name: 'domain1', min: 0, max: 10 }],
       [{
         name: 'series1',
-        axisName: 'domain1',
+        scaleName: 'domain1',
         getPointTransformer,
         points: [{ argument: 1, value: 3 }, { argument: 2, value: 14 }],
       }],
@@ -235,7 +235,7 @@ describe('computeDomains', () => {
       [{ name: 'domain1', max: 7 }],
       [{
         name: 'series1',
-        axisName: 'domain1',
+        scaleName: 'domain1',
         getPointTransformer,
         points: [{ argument: 1, value: 3 }, { argument: 2, value: 14 }],
       }],
@@ -280,7 +280,7 @@ describe('computeDomains', () => {
         { name: 'domain2' },
       ],
       [{
-        name: 'series1', getPointTransformer, axisName: 'domain1', points: [{ argument: 1, value: 9 }],
+        name: 'series1', getPointTransformer, scaleName: 'domain1', points: [{ argument: 1, value: 9 }],
       }],
     );
 

--- a/packages/dx-chart-core/src/plugins/series/computeds.js
+++ b/packages/dx-chart-core/src/plugins/series/computeds.js
@@ -201,7 +201,7 @@ const scalePoints = (series, scales) => {
   const transform = series.getPointTransformer({
     ...series,
     argumentScale: scales[ARGUMENT_DOMAIN],
-    valueScale: scales[getValueDomainName(series.axisName)],
+    valueScale: scales[getValueDomainName(series.scaleName)],
   });
   return {
     ...series,

--- a/packages/dx-chart-core/src/plugins/series/computeds.test.js
+++ b/packages/dx-chart-core/src/plugins/series/computeds.test.js
@@ -466,7 +466,7 @@ describe('scaleSeriesPoints', () => {
     const getPointTransformer2 = jest.fn()
       .mockReturnValue(point => ({ ...point, tag: '#2' }));
     const series1 = {
-      axisName: 'domain-1',
+      scaleName: 'domain-1',
       getPointTransformer: getPointTransformer1,
       points: [{ name: 'a1' }, { name: 'a2' }],
     };

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/animation.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/animation.jsxt
@@ -54,7 +54,7 @@ export default class Demo extends React.PureComponent {
             name="Units Sold"
             valueField="sale"
             argumentField="month"
-            axisName="sale"
+            scaleName="sale"
             pointComponent={Point}
           />
 
@@ -62,7 +62,7 @@ export default class Demo extends React.PureComponent {
             name="Total Transactions"
             valueField="total"
             argumentField="month"
-            axisName="total"
+            scaleName="total"
           />
           <Animation />
           <Legend />

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/bar-line.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/bar-line.jsxt
@@ -72,37 +72,37 @@ export default class Demo extends React.PureComponent {
             name="USA"
             valueField="usa"
             argumentField="year"
-            axisName="oil"
+            scaleName="oil"
           />
           <BarSeries
             name="Saudi Arabia"
             valueField="saudiArabia"
             argumentField="year"
-            axisName="oil"
+            scaleName="oil"
           />
           <BarSeries
             name="Iran"
             valueField="iran"
             argumentField="year"
-            axisName="oil"
+            scaleName="oil"
           />
           <BarSeries
             name="Mexico"
             valueField="mexico"
             argumentField="year"
-            axisName="oil"
+            scaleName="oil"
           />
           <BarSeries
             name="Russia"
             valueField="russia"
             argumentField="year"
-            axisName="oil"
+            scaleName="oil"
           />
           <LineSeries
             name="Oil Price"
             valueField="price"
             argumentField="year"
-            axisName="price"
+            scaleName="price"
           />
           <Stack
             stacks={[

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/combination-series.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/combination-series.jsxt
@@ -41,14 +41,14 @@ export default class Demo extends React.PureComponent {
             name="Units Sold"
             valueField="sale"
             argumentField="month"
-            axisName="sale"
+            scaleName="sale"
           />
 
           <LineSeries
             name="Total Transactions"
             valueField="total"
             argumentField="month"
-            axisName="total"
+            scaleName="total"
           />
 
           <Legend />

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/group-bar.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/group-bar.jsxt
@@ -28,17 +28,17 @@ export default class Demo extends React.PureComponent {
           <BarSeries
             valueField="young"
             argumentField="state"
-            axisName="age"
+            scaleName="age"
           />
           <BarSeries
             valueField="middle"
             argumentField="state"
-            axisName="age"
+            scaleName="age"
           />
           <BarSeries
             valueField="older"
             argumentField="state"
-            axisName="age"
+            scaleName="age"
           />
           <Stack />
           <Scale />

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/typescript.tsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/typescript.tsxt
@@ -39,14 +39,14 @@ export default class Demo extends React.Component<object, object> {
             name="Units Sold"
             valueField="sale"
             argumentField="month"
-            axisName="sale"
+            scaleName="sale"
           />
 
           <LineSeries
             name="Total Transactions"
             valueField="total"
             argumentField="month"
-            axisName="total"
+            scaleName="total"
           />
           <Scale />
         </Chart>

--- a/packages/dx-react-chart-demos/src/demo-sources/combination/bar-line.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/combination/bar-line.jsxt
@@ -72,37 +72,37 @@ export default class Demo extends React.PureComponent {
             name="USA"
             valueField="usa"
             argumentField="year"
-            axisName="oil"
+            scaleName="oil"
           />
           <BarSeries
             name="Saudi Arabia"
             valueField="saudiArabia"
             argumentField="year"
-            axisName="oil"
+            scaleName="oil"
           />
           <BarSeries
             name="Iran"
             valueField="iran"
             argumentField="year"
-            axisName="oil"
+            scaleName="oil"
           />
           <BarSeries
             name="Mexico"
             valueField="mexico"
             argumentField="year"
-            axisName="oil"
+            scaleName="oil"
           />
           <BarSeries
             name="Russia"
             valueField="russia"
             argumentField="year"
-            axisName="oil"
+            scaleName="oil"
           />
           <LineSeries
             name="Oil Price"
             valueField="price"
             argumentField="year"
-            axisName="price"
+            scaleName="price"
           />
           <Animation />
           <Legend />

--- a/packages/dx-react-chart/docs/reference/area-series.md
+++ b/packages/dx-react-chart/docs/reference/area-series.md
@@ -26,7 +26,7 @@ Name | Type | Default | Description
 name | string | | A series name.
 valueField | string | | The name of a data field that provides series point values.
 argumentField | string | | The name of a data field that provides series point argument values.
-axisName? | string | | An associated axis.
+scaleName? | string | | An associated scale.
 color? | string | | The series color.
 seriesComponent | ComponentType&lt;[AreaSeries.SeriesProps](#areaseriesseriesprops)&gt; | | A component that renders series.
 

--- a/packages/dx-react-chart/docs/reference/bar-series.md
+++ b/packages/dx-react-chart/docs/reference/bar-series.md
@@ -26,7 +26,7 @@ Name | Type | Default | Description
 name | string | | The series name.
 valueField | string | | The name of a data field that provides series point values.
 argumentField | string | | The name of a data field that provides series point argument values.
-axisName? | string | | An associated axis.
+scaleName? | string | | An associated scale.
 barWidth? | number | | The bar width in relative units.
 color? | string | | The series color.
 pointComponent | ComponentType&lt;[BarSeries.PointProps](#barseriespointprops)&gt; | | A component that renders a bar.

--- a/packages/dx-react-chart/docs/reference/line-series.md
+++ b/packages/dx-react-chart/docs/reference/line-series.md
@@ -26,7 +26,7 @@ Name | Type | Default | Description
 name | string | | The series name.
 valueField | string | | The name of a data field that provides series point values.
 argumentField | string | | The name of a data field that provides series point argument values.
-axisName? | string | | An associated axis.
+scaleName? | string | | An associated scale.
 color? | string | | The series color.
 seriesComponent | ComponentType&lt;[LineSeries.SeriesProps](#lineseriesseriesprops)&gt; | | A component that renders series.
 

--- a/packages/dx-react-chart/docs/reference/scatter-series.md
+++ b/packages/dx-react-chart/docs/reference/scatter-series.md
@@ -26,7 +26,7 @@ Name | Type | Default | Description
 name | string | | A series name.
 valueField | string | | The name of a data field that provides series point values.
 argumentField | string | | The name of a data field that provides series point argument values.
-axisName? | string | | The associated axis.
+scaleName? | string | | The associated scale.
 point? | { size : number } | point: { size: 7 } | Point options.
 color? | string | | A series color.
 pointComponent | ComponentType&lt;[ScatterSeries.PointProps](#scatterseriespointprops)&gt; | | A component that renders a series point.

--- a/packages/dx-react-chart/docs/reference/spline-series.md
+++ b/packages/dx-react-chart/docs/reference/spline-series.md
@@ -26,7 +26,7 @@ Name | Type | Default | Description
 name | string | | The series name.
 valueField | string | | The name of a data field that provides series point values.
 argumentField | string | | The name of a data field that provides series point argument values.
-axisName? | string | | An associated axis.
+scaleName? | string | | An associated scale.
 color? | string | | The series color.
 seriesComponent | ComponentType&lt;[SplineSeries.SeriesProps](#splineseriesseriesprops)&gt; | | A component that renders series.
 

--- a/packages/dx-react-chart/src/utils/series-helper.jsx
+++ b/packages/dx-react-chart/src/utils/series-helper.jsx
@@ -33,7 +33,7 @@ export const declareSeries = (pluginName, { components, ...parameters }) => {
                 const currentSeries = findSeriesByName(symbolName, series);
                 const currentScales = {
                   xScale: scales[ARGUMENT_DOMAIN],
-                  yScale: scales[getValueDomainName(currentSeries.axisName)],
+                  yScale: scales[getValueDomainName(currentSeries.scaleName)],
                 };
                 return (
                   <currentSeries.seriesComponent

--- a/packages/dx-react-chart/src/utils/series-helper.test.jsx
+++ b/packages/dx-react-chart/src/utils/series-helper.test.jsx
@@ -27,7 +27,7 @@ describe('#declareSeries', () => {
 
   const defaultProps = {
     name: 'name',
-    axisName: 'axisName',
+    scaleName: 'scaleName',
     valueField: 'valueField',
     argumentField: 'argumentField',
   };


### PR DESCRIPTION
BREAKING CHANGES:

Previously, series bonded to the `ValueAxis` plugin using the `axisName` property. Now that property has been renamed `scaleName` because the series bonds to the `ValueScale` plugin.