### PR TITLE
refactor(react-chart): rename `name` property to `scaleName` in axes

### DIFF
--- a/packages/dx-chart-core/src/plugins/axis/computeds.js
+++ b/packages/dx-chart-core/src/plugins/axis/computeds.js
@@ -45,14 +45,14 @@ const createVerticalOptions = (position, tickSize, indentFromAxis) => {
 };
 
 export const axisCoordinates = ({
-  name,
+  scaleName,
   scale,
   position,
   tickSize,
   tickFormat,
   indentFromAxis,
 }) => {
-  const isHor = isHorizontal(name);
+  const isHor = isHorizontal(scaleName);
   const options = (isHor ? createHorizontalOptions : createVerticalOptions)(
     position, tickSize, indentFromAxis,
   );
@@ -77,8 +77,8 @@ export const axisCoordinates = ({
 const horizontalGridOptions = { y: 0, dy: 1 };
 const verticalGridOptions = { x: 0, dx: 1 };
 
-export const getGridCoordinates = ({ name, scale }) => {
-  const isHor = isHorizontal(name);
+export const getGridCoordinates = ({ scaleName, scale }) => {
+  const isHor = isHorizontal(scaleName);
   const options = isHor ? horizontalGridOptions : verticalGridOptions;
   return createTicks(scale, (coordinates, key) => ({
     key,

--- a/packages/dx-chart-core/src/plugins/axis/computeds.test.js
+++ b/packages/dx-chart-core/src/plugins/axis/computeds.test.js
@@ -16,7 +16,7 @@ describe('axisCoordinates', () => {
 
     it('should return ticks Coordinates with horizontal-top position', () => {
       const coordinates = axisCoordinates({
-        name: 'argument-domain', scale, position: 'top', tickSize, indentFromAxis,
+        scaleName: 'argument-domain', scale, position: 'top', tickSize, indentFromAxis,
       });
       expect(coordinates).toEqual({
         sides: [1, 0],
@@ -28,7 +28,7 @@ describe('axisCoordinates', () => {
 
     it('should return ticks coordinates with horizontal-bottom position', () => {
       const coordinates = axisCoordinates({
-        name: 'argument-domain', scale, position: 'bottom', tickSize, indentFromAxis,
+        scaleName: 'argument-domain', scale, position: 'bottom', tickSize, indentFromAxis,
       });
       expect(coordinates).toEqual({
         sides: [1, 0],
@@ -40,7 +40,7 @@ describe('axisCoordinates', () => {
 
     it('should pass correct domain to scale, horizontal', () => {
       axisCoordinates({
-        name: 'argument-domain', scale, position: 'top', tickSize,
+        scaleName: 'argument-domain', scale, position: 'top', tickSize,
       });
       expect(scale.mock.calls).toEqual([
         [1],
@@ -49,7 +49,7 @@ describe('axisCoordinates', () => {
 
     it('should return ticks coordinates with vertical-left position', () => {
       const coordinates = axisCoordinates({
-        name: 'value-domain', scale, position: 'left', tickSize, indentFromAxis,
+        scaleName: 'value-domain', scale, position: 'left', tickSize, indentFromAxis,
       });
       expect(coordinates).toEqual({
         sides: [0, 1],
@@ -61,7 +61,7 @@ describe('axisCoordinates', () => {
 
     it('should return ticks coordinates with vertical-right position', () => {
       const coordinates = axisCoordinates({
-        name: 'value-domain', scale, position: 'right', tickSize, indentFromAxis,
+        scaleName: 'value-domain', scale, position: 'right', tickSize, indentFromAxis,
       });
       expect(coordinates).toEqual({
         sides: [0, 1],
@@ -73,7 +73,7 @@ describe('axisCoordinates', () => {
 
     it('should pass correct domain to scale, vertical', () => {
       axisCoordinates({
-        name: 'value-domain', scale, position: 'left', tickSize,
+        scaleName: 'value-domain', scale, position: 'left', tickSize,
       });
       expect(scale.mock.calls).toEqual([
         [1],
@@ -84,7 +84,7 @@ describe('axisCoordinates', () => {
       scale.tickFormat = jest.fn(() => tick => `format ${tick}`);
       try {
         const coordinates = axisCoordinates({
-          name: 'argument-domain', scale, position: 'top', tickSize, indentFromAxis,
+          scaleName: 'argument-domain', scale, position: 'top', tickSize, indentFromAxis,
         });
         expect(coordinates.ticks).toEqual([{
           key: '0', xText: 25, yText: -10, text: 'format 1', dominantBaseline: 'baseline', textAnchor: 'middle', y1: 0, y2: -5, x1: 25, x2: 25,
@@ -99,7 +99,7 @@ describe('axisCoordinates', () => {
       const userFormat = jest.fn(() => tick => `user format ${tick}`);
       try {
         const coordinates = axisCoordinates({
-          name: 'argument-domain', scale, tickFormat: userFormat, position: 'top', tickSize, indentFromAxis,
+          scaleName: 'argument-domain', scale, tickFormat: userFormat, position: 'top', tickSize, indentFromAxis,
         });
         expect(coordinates.ticks).toEqual([{
           key: '0', xText: 25, yText: -10, text: 'user format 1', dominantBaseline: 'baseline', textAnchor: 'middle', y1: 0, y2: -5, x1: 25, x2: 25,
@@ -116,7 +116,7 @@ describe('axisCoordinates', () => {
 
     it('should pass correct domain to scale', () => {
       axisCoordinates({
-        name: 'value-domain', scale, position: 'left', tickSize,
+        scaleName: 'value-domain', scale, position: 'left', tickSize,
       });
       expect(scale.mock.calls).toEqual([
         ['a'],
@@ -125,7 +125,7 @@ describe('axisCoordinates', () => {
 
     it('should return ticks coordinates with horizontal-bottom position', () => {
       const coordinates = axisCoordinates({
-        name: 'argument-domain', scale, position: 'bottom', tickSize, indentFromAxis,
+        scaleName: 'argument-domain', scale, position: 'bottom', tickSize, indentFromAxis,
       });
       expect(coordinates).toEqual({
         sides: [1, 0],
@@ -137,7 +137,7 @@ describe('axisCoordinates', () => {
 
     it('should return ticks Coordinates with horizontal-top position', () => {
       const coordinates = axisCoordinates({
-        name: 'argument-domain', scale, position: 'top', tickSize, indentFromAxis,
+        scaleName: 'argument-domain', scale, position: 'top', tickSize, indentFromAxis,
       });
       expect(coordinates).toEqual({
         sides: [1, 0],
@@ -149,7 +149,7 @@ describe('axisCoordinates', () => {
 
     it('should return ticks coordinates with vertical-left position', () => {
       const coordinates = axisCoordinates({
-        name: 'value-domain', scale, position: 'left', tickSize, indentFromAxis,
+        scaleName: 'value-domain', scale, position: 'left', tickSize, indentFromAxis,
       });
       expect(coordinates).toEqual({
         sides: [0, 1],
@@ -161,7 +161,7 @@ describe('axisCoordinates', () => {
 
     it('should return ticks coordinates with vertical-right position', () => {
       const coordinates = axisCoordinates({
-        name: 'value-domain', scale, position: 'right', tickSize, indentFromAxis,
+        scaleName: 'value-domain', scale, position: 'right', tickSize, indentFromAxis,
       });
       expect(coordinates).toEqual({
         sides: [0, 1],
@@ -178,7 +178,7 @@ describe('getGridCoordinates', () => {
   scale.ticks = jest.fn().mockReturnValue([10, 20, 30, 40]);
 
   it('should return horizontal coordinates', () => {
-    expect(getGridCoordinates({ name: 'argument-domain', scale })).toEqual([
+    expect(getGridCoordinates({ scaleName: 'argument-domain', scale })).toEqual([
       {
         key: '0', x: 26, y: 0, dx: 0, dy: 1,
       },
@@ -195,7 +195,7 @@ describe('getGridCoordinates', () => {
   });
 
   it('should return vertical coordinates', () => {
-    expect(getGridCoordinates({ name: 'value-domain', scale })).toEqual([
+    expect(getGridCoordinates({ scaleName: 'value-domain', scale })).toEqual([
       {
         key: '0', x: 0, y: 26, dx: 1, dy: 0,
       },

--- a/packages/dx-chart-core/src/plugins/scale/computeds.js
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.js
@@ -77,8 +77,8 @@ const collectDomains = (seriesList) => {
 };
 
 const takeTypeFromAxesOptions = (domains, axes) => {
-  axes.forEach(({ name, type }) => {
-    const domain = domains[name];
+  axes.forEach(({ scaleName, type }) => {
+    const domain = domains[scaleName];
     if (domain) {
       domain.type = type;
     }
@@ -86,8 +86,8 @@ const takeTypeFromAxesOptions = (domains, axes) => {
 };
 
 const takeRestAxesOptions = (domains, axes) => {
-  axes.forEach(({ name, min, max }) => {
-    const domain = domains[name];
+  axes.forEach(({ scaleName, min, max }) => {
+    const domain = domains[scaleName];
     if (!domain) {
       return;
     }

--- a/packages/dx-chart-core/src/plugins/scale/computeds.test.js
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.test.js
@@ -169,7 +169,7 @@ describe('computeDomains', () => {
 
   it('should compute banded domain', () => {
     const domains = computeDomains(
-      [{ name: ARGUMENT_DOMAIN, type: 'band' }],
+      [{ scaleName: ARGUMENT_DOMAIN, type: 'band' }],
       [{
         name: 'series1',
         getPointTransformer,
@@ -211,7 +211,7 @@ describe('computeDomains', () => {
 
   it('should take min/max from axis', () => {
     const domains = computeDomains(
-      [{ name: 'domain1', min: 0, max: 10 }],
+      [{ scaleName: 'domain1', min: 0, max: 10 }],
       [{
         name: 'series1',
         scaleName: 'domain1',
@@ -232,7 +232,7 @@ describe('computeDomains', () => {
 
   it('should take one of min/max from axis', () => {
     const domains = computeDomains(
-      [{ name: 'domain1', max: 7 }],
+      [{ scaleName: 'domain1', max: 7 }],
       [{
         name: 'series1',
         scaleName: 'domain1',
@@ -254,7 +254,7 @@ describe('computeDomains', () => {
   it('should ignore min/max for band domain', () => {
     const domains = computeDomains(
       [{
-        name: ARGUMENT_DOMAIN, min: 1, max: 7, type: 'band',
+        scaleName: ARGUMENT_DOMAIN, min: 1, max: 7, type: 'band',
       }],
       [{
         name: 'series1',
@@ -276,8 +276,8 @@ describe('computeDomains', () => {
   it('should ignore axes for unknown domains', () => {
     const domains = computeDomains(
       [
-        { name: 'domain1' },
-        { name: 'domain2' },
+        { scaleName: 'domain1' },
+        { scaleName: 'domain2' },
       ],
       [{
         name: 'series1', getPointTransformer, scaleName: 'domain1', points: [{ argument: 1, value: 9 }],

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/animation.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/animation.jsxt
@@ -43,12 +43,9 @@ export default class Demo extends React.PureComponent {
         <Chart
           data={chartData}
         >
-          <ArgumentAxis
-            name="month"
-            type="band"
-          />
-          <ValueAxis name="sale" showGrids={false} showLine showTicks />
-          <ValueAxis name="total" position="right" showGrids={false} showLine showTicks />
+          <ArgumentAxis />
+          <ValueAxis scaleName="sale" showGrids={false} showLine showTicks />
+          <ValueAxis scaleName="total" position="right" showGrids={false} showLine showTicks />
 
           <BarSeries
             name="Units Sold"

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/combination-series.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/combination-series.jsxt
@@ -33,9 +33,9 @@ export default class Demo extends React.PureComponent {
         <Chart
           data={chartData}
         >
-          <ArgumentAxis type="band" />
-          <ValueAxis name="sale" showGrids={false} showLine showTicks />
-          <ValueAxis name="total" position="right" showGrids={false} showLine showTicks />
+          <ArgumentAxis />
+          <ValueAxis scaleName="sale" showGrids={false} showLine showTicks />
+          <ValueAxis scaleName="total" position="right" showGrids={false} showLine showTicks />
 
           <BarSeries
             name="Units Sold"

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/typescript.tsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/typescript.tsxt
@@ -32,8 +32,8 @@ export default class Demo extends React.Component<object, object> {
           data={chartData}
         >
           <ArgumentAxis />
-          <ValueAxis name="sale" showGrids={false} showLine={true} showTicks={true} />
-          <ValueAxis name="total" position="right" showGrids={false} showLine={true} showTicks={true} />
+          <ValueAxis scaleName="sale" showGrids={false} showLine={true} showTicks={true} />
+          <ValueAxis scaleName="total" position="right" showGrids={false} showLine={true} showTicks={true} />
 
           <BarSeries
             name="Units Sold"

--- a/packages/dx-react-chart-demos/src/demo-sources/combination/bar-line.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/combination/bar-line.jsxt
@@ -46,12 +46,12 @@ export default class Demo extends React.PureComponent {
 
           <ArgumentAxis />
           <ValueAxis
-            name="oil"
+            scaleName="oil"
             max={2200}
             labelComponent={LabelWithThousand}
           />
           <ValueAxis
-            name="price"
+            scaleName="price"
             position="right"
             min={0}
             max={110}

--- a/packages/dx-react-chart/docs/reference/argument-axis.md
+++ b/packages/dx-react-chart/docs/reference/argument-axis.md
@@ -25,7 +25,6 @@ Name | Type | Default | Description
 -----|------|---------|------------
 tickSize? | number | 5 | The tick size.
 position? | 'bottom' &#124; 'top' | 'bottom' | The axis position.
-name? | string | | The axis name.
 indentFromAxis? | number | 10 | The indent from the axis.
 type? | 'band' &#124; 'linear' | 'linear' | Axis type.
 showTicks? | boolean | true | Specifies whether to render ticks.

--- a/packages/dx-react-chart/docs/reference/value-axis.md
+++ b/packages/dx-react-chart/docs/reference/value-axis.md
@@ -25,7 +25,7 @@ Name | Type | Default | Description
 -----|------|---------|------------
 tickSize? | number | 5 | The tick size.
 position? | 'left' &#124; 'right' | 'left' | The axis position.
-name? | string | | The axis name.
+scaleName? | string | | The scale name.
 indentFromAxis? | number | 10 | The indent from the axis.
 type? | 'band' &#124; 'linear' | 'linear' | Axis type.
 showTicks? | boolean | false | Specifies whether to render ticks.

--- a/packages/dx-react-chart/src/plugins/axis.jsx
+++ b/packages/dx-react-chart/src/plugins/axis.jsx
@@ -44,7 +44,7 @@ class RawAxis extends React.PureComponent {
 
   render() {
     const {
-      name,
+      scaleName,
       position,
       tickSize,
       tickFormat,
@@ -70,14 +70,14 @@ class RawAxis extends React.PureComponent {
           <TemplatePlaceholder />
           <TemplateConnector>
             {({ scales, layouts }, { changeBBox }) => {
-              const scale = scales[name];
+              const scale = scales[scaleName];
               if (!scale) {
                 return null;
               }
 
               const { width, height } = layouts[placeholder] || { width: 0, height: 0 };
               const { sides: [dx, dy], ticks } = axisCoordinates({
-                name,
+                scaleName,
                 // Isn't it too late to adjust sizes?
                 scale: adjustScaleRange(scale, [this.adjustedWidth, this.adjustedHeight]),
                 position,
@@ -163,13 +163,13 @@ class RawAxis extends React.PureComponent {
           <TemplatePlaceholder />
           <TemplateConnector>
             {({ scales, layouts }) => {
-              const scale = scales[name];
+              const scale = scales[scaleName];
               if (!scale || !showGrids) {
                 return null;
               }
 
               const { width, height } = layouts.pane;
-              const ticks = getGridCoordinates({ name, scale });
+              const ticks = getGridCoordinates({ scaleName, scale });
               return ((
                 <React.Fragment>
                   {ticks.map(({
@@ -194,7 +194,7 @@ class RawAxis extends React.PureComponent {
 }
 
 RawAxis.propTypes = {
-  name: PropTypes.string.isRequired,
+  scaleName: PropTypes.string.isRequired,
   rootComponent: PropTypes.func.isRequired,
   tickComponent: PropTypes.func.isRequired,
   labelComponent: PropTypes.func.isRequired,
@@ -246,7 +246,7 @@ export const ArgumentAxis = withPatchedProps(props => ({
   showLine: true,
   showLabels: true,
   ...props,
-  name: ARGUMENT_DOMAIN,
+  scaleName: ARGUMENT_DOMAIN,
 }))(Axis);
 
 // TODO: Check that only LEFT and RIGHT are accepted.
@@ -257,7 +257,7 @@ export const ValueAxis = withPatchedProps(props => ({
   showLine: false,
   showLabels: true,
   ...props,
-  name: getValueDomainName(props.name),
+  scaleName: getValueDomainName(props.scaleName),
 }))(Axis);
 
 ArgumentAxis.components = Axis.components;

--- a/packages/dx-react-chart/src/plugins/axis.test.jsx
+++ b/packages/dx-react-chart/src/plugins/axis.test.jsx
@@ -58,7 +58,7 @@ describe('Axis', () => {
 
   const defaultProps = {
     position: 'bottom',
-    name: 'test-domain',
+    scaleName: 'test-domain',
     showTicks: true,
     showGrids: true,
     showLine: true,
@@ -232,7 +232,7 @@ describe('Axis', () => {
     mount(<AxisTester tickFormat={mockTickFormat} />);
 
     expect(axisCoordinates).toHaveBeenCalledWith({
-      name: 'test-domain',
+      scaleName: 'test-domain',
       scale: mockScale,
       position: 'bottom',
       tickSize: 5,
@@ -245,14 +245,14 @@ describe('Axis', () => {
     setupAxisCoordinates([0, 1]);
     mount(
       <AxisTester
-        name="other-domain"
+        scaleName="other-domain"
         tickSize={6}
         indentFromAxis={3}
       />,
     );
 
     expect(axisCoordinates).toHaveBeenCalledWith({
-      name: 'other-domain',
+      scaleName: 'other-domain',
       scale: mockScale,
       position: 'bottom',
       tickSize: 6,


### PR DESCRIPTION
BREAKING CHANGES:

Previously, the `ValueAxis` plugin had the `name` property for binding to series. Now the property has been renamed to `scaleName` because the axes are bound to the `ValueScale` plugin.