### PR TITLE
refactor(react-scheduler): simplify the onNavigate function arguments

### DIFF
--- a/packages/dx-react-scheduler-material-ui/src/templates/date-navigator/calendar/root.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/date-navigator/calendar/root.jsx
@@ -21,10 +21,10 @@ export class Root extends React.PureComponent {
     this.setState({ currentDate: nextDate.toDate() });
   }
 
-  onCellClick({ nextDate }) {
+  onCellClick(nextDate) {
     const { onSelectedDateChange } = this.props;
     this.setState({ selectedDate: nextDate, currentDate: nextDate });
-    onSelectedDateChange({ nextDate });
+    onSelectedDateChange(nextDate);
   }
 
   render() {

--- a/packages/dx-react-scheduler-material-ui/src/templates/date-navigator/calendar/root.test.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/date-navigator/calendar/root.test.jsx
@@ -111,10 +111,10 @@ describe('Calendar', () => {
         />
       ));
       const { onCellClick } = Table.mock.calls[0][0];
-      onCellClick({ nextDate: '2018-07-17' });
+      onCellClick('2018-07-17');
 
       expect(onSelectedDateChangeMock)
-        .toBeCalledWith({ nextDate: '2018-07-17' });
+        .toBeCalledWith('2018-07-17');
       expect(tree.state().currentDate)
         .toBe('2018-07-17');
       expect(tree.state().selectedDate)

--- a/packages/dx-react-scheduler-material-ui/src/templates/date-navigator/calendar/table.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/date-navigator/calendar/table.jsx
@@ -65,7 +65,7 @@ const TableBase = ({
                   selected={selected}
                   today={today}
                   onClick={() => {
-                    onCellClick({ nextDate: startDate });
+                    onCellClick(startDate);
                   }}
                 >
                   {moment(startDate).format('D')}

--- a/packages/dx-react-scheduler-material-ui/src/templates/date-navigator/calendar/table.test.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/date-navigator/calendar/table.test.jsx
@@ -99,7 +99,7 @@ describe('Calendar', () => {
       tree.find(defaultProps.cellComponent).props().onClick();
 
       expect(cellClickMock)
-        .toBeCalledWith({ nextDate: '2018-07-16' });
+        .toBeCalledWith('2018-07-16');
     });
   });
 });

--- a/packages/dx-react-scheduler-material-ui/src/templates/date-navigator/root.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/date-navigator/root.jsx
@@ -16,7 +16,7 @@ export const Root = ({
   >
     <NavigationButton
       type="back"
-      onClick={() => { onNavigate({ back: true }); }}
+      onClick={() => { onNavigate('back'); }}
     />
     <OpenButton
       onVisibilityToggle={onVisibilityToggle}
@@ -24,7 +24,7 @@ export const Root = ({
     />
     <NavigationButton
       type="forward"
-      onClick={() => { onNavigate({ back: false }); }}
+      onClick={() => { onNavigate('forward'); }}
     />
   </div>
 );

--- a/packages/dx-react-scheduler-material-ui/src/templates/date-navigator/root.test.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/date-navigator/root.test.jsx
@@ -64,10 +64,10 @@ describe('DateNavigator', () => {
         .toBe('back');
       expect(next.props().type)
         .toBe('forward');
-      expect(onNavigate.mock.calls[0][0].back)
-        .toBeTruthy();
-      expect(onNavigate.mock.calls[1][0].back)
-        .toBeFalsy();
+      expect(onNavigate.mock.calls[0][0])
+        .toBe('back');
+      expect(onNavigate.mock.calls[1][0])
+        .toBe('forward');
     });
   });
 });

--- a/packages/dx-react-scheduler/docs/reference/date-navigator.md
+++ b/packages/dx-react-scheduler/docs/reference/date-navigator.md
@@ -45,7 +45,7 @@ openButtonComponent | ComponentType&lt;[DateNavigator.OpenButtonProps](#datenavi
 navigatorText? | string | Text displayed in the date navigator.
 rootRef | (ref: ReactInstance) => void | A function that accepts the date navigator's root element.
 onVisibilityToggle | () => void | An event raised when the date navigator should be shown or hidden.
-onNavigate | ({ back: boolean }) => void | An event raised when a navigation button is clicked. The event handler should switch the date navigator to the next (`back` is false) or previous (`back` is true) date.
+onNavigate | (direction: 'forward' &#124; 'back') => void | An event raised when a navigation button is clicked. The event handler should switch the date navigator to the next or previous date.
 
 ### DateNavigator.OverlayProps
 

--- a/packages/dx-react-scheduler/src/plugins/date-navigator.jsx
+++ b/packages/dx-react-scheduler/src/plugins/date-navigator.jsx
@@ -16,8 +16,11 @@ const pluginDependencies = [
   { name: 'ViewState' },
 ];
 
-const navigate = (action, currentView, intervalCount) => payload => action({
-  ...payload, amount: intervalCount, step: currentView.type,
+const navigate = (action, currentView, intervalCount) => (direction, nextDate) => action({
+  direction,
+  nextDate,
+  amount: intervalCount,
+  step: currentView.type,
 });
 
 export class DateNavigator extends React.PureComponent {
@@ -81,8 +84,8 @@ export class DateNavigator extends React.PureComponent {
               changeCurrentDate,
             }) => {
               const navigateAction = navigate(changeCurrentDate, currentView, intervalCount);
-              const calendarDateChanged = (args) => {
-                navigateAction(args);
+              const calendarDateChanged = (nextDate) => {
+                navigateAction(undefined, nextDate);
                 this.handleHide();
               };
               const navigatorText = viewBoundText(

--- a/packages/dx-react-scheduler/src/plugins/date-navigator.test.jsx
+++ b/packages/dx-react-scheduler/src/plugins/date-navigator.test.jsx
@@ -111,7 +111,12 @@ describe('DateNavigator', () => {
     expect(navigatorText)
       .toBe('July 2018');
     expect(defaultDeps.action.changeCurrentDate)
-      .toBeCalledWith({ amount: 3, step: 'month' }, expect.any(Object), expect.any(Object));
+      .toBeCalledWith({
+        amount: 3,
+        step: 'month',
+        direction: undefined,
+        nextDate: undefined,
+      }, expect.any(Object), expect.any(Object));
   });
 
   it('should render calendar', () => {

--- a/packages/dx-scheduler-core/src/plugins/view-state/reducers.js
+++ b/packages/dx-scheduler-core/src/plugins/view-state/reducers.js
@@ -4,9 +4,9 @@ export const changeCurrentDate = (currentDate, {
   nextDate,
   step,
   amount,
-  back = false,
+  direction = 'forward',
 }) => (
-  nextDate || moment(currentDate)[back ? 'subtract' : 'add'](amount, step).toDate()
+  nextDate || moment(currentDate)[direction === 'back' ? 'subtract' : 'add'](amount, step).toDate()
 );
 
 export const setCurrentViewName = (currentViewName, { nextViewName }) => nextViewName;

--- a/packages/dx-scheduler-core/src/plugins/view-state/reducers.test.js
+++ b/packages/dx-scheduler-core/src/plugins/view-state/reducers.test.js
@@ -19,7 +19,7 @@ describe('DateNavigator reducers', () => {
     it('should calculate prev date', () => {
       const state = '2018-07-13';
 
-      const nextState = changeCurrentDate(state, { back: true, amount: 1, step: 'week' });
+      const nextState = changeCurrentDate(state, { direction: 'back', amount: 1, step: 'week' });
       expect(nextState.toString())
         .toBe(new Date(2018, 6, 6).toString());
     });


### PR DESCRIPTION
BREAKING CHANGE:

To make the `DateNavigator.Root`  component API more simple and consistent we changed its `onNavigate` property argument type.

Previously: 
```
onNavigate({ back: boolean }) => void
```

Now:
```
onNavigate(direction: 'forward' | 'back') => void
```