### PR TITLE
refactor(react-scheduler): simplify the ViewSwitcher.Switcher component API

### DIFF
--- a/packages/dx-react-scheduler-material-ui/src/templates/view-switcher/switcher.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/view-switcher/switcher.jsx
@@ -10,7 +10,7 @@ export const Switcher = ({
   ...restProps
 }) => {
   const handleChange = (event) => {
-    onChange({ nextViewName: event.target.value });
+    onChange(event.target.value);
   };
 
   return (

--- a/packages/dx-react-scheduler-material-ui/src/templates/view-switcher/switcher.test.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/view-switcher/switcher.test.jsx
@@ -26,10 +26,10 @@ describe('ViewSwitcher', () => {
         <Switcher {...defaultProps} />
       ));
 
-      tree.simulate('change', { target: { value: '' } });
+      tree.simulate('change', { target: { value: 'next' } });
 
       expect(defaultProps.onChange)
-        .toBeCalled();
+        .toBeCalledWith('next');
     });
     it('should render items depend of available view names', () => {
       const tree = shallow((

--- a/packages/dx-react-scheduler/docs/reference/view-switcher.md
+++ b/packages/dx-react-scheduler/docs/reference/view-switcher.md
@@ -39,8 +39,7 @@ Field | Type | Description
 ------|------|------------
 currentViewName | string | A displayed view's name.
 availableViewNames | Array&lt;string&gt; | An array of available view's names.
-onChange | ({ nextViewName: string }) => void | A function that handles changes to the displayed view.
-
+onChange | (nextViewName: string) => void | A function that handles changes to the displayed view.
 
 ## Plugin Components
 

--- a/packages/dx-scheduler-core/src/plugins/view-state/reducers.js
+++ b/packages/dx-scheduler-core/src/plugins/view-state/reducers.js
@@ -9,4 +9,4 @@ export const changeCurrentDate = (currentDate, {
   nextDate || moment(currentDate)[back ? 'subtract' : 'add'](amount, step).toDate()
 );
 
-export const setCurrentViewName = (currentViewName, { nextViewName }) => nextViewName;
+export const setCurrentViewName = (currentViewName, nextViewName) => nextViewName;

--- a/packages/dx-scheduler-core/src/plugins/view-state/reducers.test.js
+++ b/packages/dx-scheduler-core/src/plugins/view-state/reducers.test.js
@@ -1,4 +1,4 @@
-import { changeCurrentDate } from './reducers';
+import { changeCurrentDate, setCurrentViewName } from './reducers';
 
 describe('DateNavigator reducers', () => {
   describe('#changeCurrentDate', () => {
@@ -22,6 +22,12 @@ describe('DateNavigator reducers', () => {
       const nextState = changeCurrentDate(state, { back: true, amount: 1, step: 'week' });
       expect(nextState.toString())
         .toBe(new Date(2018, 6, 6).toString());
+    });
+  });
+  describe('#setCurrentViewName', () => {
+    it('should return next view name', () => {
+      const nextViewName = setCurrentViewName('', 'week');
+      expect(nextViewName).toBe('week');
     });
   });
 });


### PR DESCRIPTION
BREAKING CHANGE:

To make the `ViewSwitcher.Switcher`  component API more simple, we changed its `onChange` property argument type.

Previously: 
```
onChange({ nextViewName: string }) => void
```

Now:
```
onChange(nextViewName: string) => void
```