### PR TITLE
chore(react-chart): update continuous series hit testing

### DIFF
--- a/packages/dx-chart-core/src/utils/hover-state.js
+++ b/packages/dx-chart-core/src/utils/hover-state.js
@@ -46,12 +46,3 @@ export const processPointerMove = (targets, currentTarget, notify) => {
   }
   return nextTarget;
 };
-
-// It handles the case when point is hovered and series does not contain visual points.
-// Series then knows that it is also hovered and can represent the changed state.
-export const getHoverTargets = (hover) => {
-  if (!hover) {
-    return [];
-  }
-  return hover.point >= 0 ? [{ series: hover.series }, hover] : [hover];
-};

--- a/packages/dx-chart-core/src/utils/hover-state.test.js
+++ b/packages/dx-chart-core/src/utils/hover-state.test.js
@@ -1,4 +1,4 @@
-import { getHoverTargets, processPointerMove } from './hover-state';
+import { processPointerMove } from './hover-state';
 
 describe('HoverState', () => {
   describe('#processPointerMove', () => {
@@ -76,21 +76,6 @@ describe('HoverState', () => {
 
       expect(result).toEqual({ series: '1', distance: 0.1 });
       expect(mock).toBeCalledWith({ series: '1', distance: 0.1 });
-    });
-  });
-
-  describe('#getHoveredTargets', () => {
-    it('should return empty array', () => {
-      expect(getHoverTargets(null)).toEqual([]);
-    });
-
-    it('should return item as is', () => {
-      expect(getHoverTargets({ series: '1' })).toEqual([{ series: '1' }]);
-    });
-
-    it('should return additional item for point', () => {
-      expect(getHoverTargets({ series: '1', point: 2 }))
-        .toEqual([{ series: '1' }, { series: '1', point: 2 }]);
     });
   });
 });

--- a/packages/dx-chart-core/src/utils/series.js
+++ b/packages/dx-chart-core/src/utils/series.js
@@ -130,12 +130,7 @@ export const createPieHitTester = createPointsEnumeratingHitTesterCreator(
 const buildFilter = (targets) => {
   const result = {};
   targets.forEach(({ series, point }) => {
-    result[series] = result[series] || { points: {} };
-    if (point >= 0) {
-      result[series].points[point] = true;
-    } else {
-      result[series].self = true;
-    }
+    (result[series] = result[series] || new Set()).add(point);
   });
   return result;
 };
@@ -147,18 +142,15 @@ export const changeSeriesState = (seriesList, targets, state) => {
   const filter = buildFilter(targets);
   let matches = 0;
   const result = seriesList.map((seriesItem) => {
-    const obj = filter[seriesItem.name];
-    if (!obj) {
+    const set = filter[seriesItem.name];
+    if (!set) {
       return seriesItem;
     }
     matches += 1;
-    const props = {};
-    if (obj.self) {
-      props.state = state;
-    }
-    if (Object.keys(obj.points).length) {
+    const props = { state };
+    if (set.size) {
       props.points = seriesItem.points.map(
-        point => (obj.points[point.index] ? { ...point, state } : point),
+        point => (set.has(point.index) ? { ...point, state } : point),
       );
     }
     return { ...seriesItem, ...props };

--- a/packages/dx-chart-core/src/utils/series.test.js
+++ b/packages/dx-chart-core/src/utils/series.test.js
@@ -293,25 +293,25 @@ describe('Series', () => {
   });
 
   describe('#changeSeriesState', () => {
-    const series1 = { name: 's1' };
-    const series2 = { name: 's2' };
+    const series1 = { name: 's1', points: [] };
+    const series2 = { name: 's2', points: [] };
     const series3 = { name: 's3', points: [{ index: 1 }, { index: 3 }] };
     const series4 = { name: 's4', points: [{ index: 2 }, { index: 5 }, { index: 6 }] };
 
     it('should change series and points', () => {
-      const result = changeSeriesState([series1, series2, series3, series4], [
-        { series: 's1' },
-        { series: 's3' },
+      const [
+        newSeries1, newSeries2, newSeries3, newSeries4,
+      ] = changeSeriesState([series1, series2, series3, series4], [
         { series: 's3', point: 3 },
         { series: 's4', point: 5 },
         { series: 's4', point: 2 },
       ], 'test-state');
 
-      expect(result[0]).toEqual({ ...series1, state: 'test-state' });
+      expect(newSeries1).toBe(series1);
 
-      expect(result[1]).toBe(series2);
+      expect(newSeries2).toBe(series2);
 
-      expect(result[2]).toEqual({
+      expect(newSeries3).toEqual({
         ...series3,
         state: 'test-state',
         points: [
@@ -319,17 +319,18 @@ describe('Series', () => {
           { ...series3.points[1], state: 'test-state' },
         ],
       });
-      expect(result[2].points[0]).toBe(series3.points[0]);
+      expect(newSeries3.points[0]).toBe(series3.points[0]);
 
-      expect(result[3]).toEqual({
+      expect(newSeries4).toEqual({
         ...series4,
+        state: 'test-state',
         points: [
           { ...series4.points[0], state: 'test-state' },
           { ...series4.points[1], state: 'test-state' },
           series4.points[2],
         ],
       });
-      expect(result[3].points[2]).toBe(series4.points[2]);
+      expect(newSeries4.points[2]).toBe(series4.points[2]);
     });
 
     it('should return original list when there are no matches', () => {

--- a/packages/dx-chart-core/src/utils/series.test.js
+++ b/packages/dx-chart-core/src/utils/series.test.js
@@ -78,10 +78,12 @@ describe('Series', () => {
       expect(hitTest([120, 40])).toEqual({
         points: [{ index: 'p1', distance: matchFloat(0.71) }],
       });
-      expect(hitTest([140, 60])).toEqual({});
+      expect(hitTest([140, 60])).toEqual({
+        points: [{ index: 'p1', distance: matchFloat(3.54) }],
+      });
       expect(hitTest([160, 30])).toEqual(null);
       expect(hitTest([180, 70])).toEqual({
-        points: [{ index: 'p2', distance: matchFloat(0.71) }, { index: 'p3', distance: matchFloat(0.85) }],
+        points: [{ index: 'p2', distance: matchFloat(0.71) }],
       });
 
       expect(isPointInPath.mock.calls).toEqual([
@@ -139,10 +141,12 @@ describe('Series', () => {
       expect(hitTest([120, 40])).toEqual({
         points: [{ index: 'p1', distance: matchFloat(0.71) }],
       });
-      expect(hitTest([140, 60])).toEqual({});
+      expect(hitTest([140, 60])).toEqual({
+        points: [{ index: 'p1', distance: matchFloat(3.54) }],
+      });
       expect(hitTest([160, 30])).toEqual(null);
       expect(hitTest([180, 70])).toEqual({
-        points: [{ index: 'p2', distance: matchFloat(0.71) }, { index: 'p3', distance: matchFloat(0.85) }],
+        points: [{ index: 'p2', distance: matchFloat(0.71) }],
       });
 
       expect(isPointInPath.mock.calls).toEqual([
@@ -203,10 +207,12 @@ describe('Series', () => {
       expect(hitTest([120, 40])).toEqual({
         points: [{ index: 'p1', distance: matchFloat(0.71) }],
       });
-      expect(hitTest([140, 60])).toEqual({});
+      expect(hitTest([140, 60])).toEqual({
+        points: [{ index: 'p1', distance: matchFloat(3.54) }],
+      });
       expect(hitTest([160, 30])).toEqual(null);
       expect(hitTest([180, 70])).toEqual({
-        points: [{ index: 'p2', distance: matchFloat(0.71) }, { index: 'p3', distance: matchFloat(0.85) }],
+        points: [{ index: 'p2', distance: matchFloat(0.71) }],
       });
 
       expect(isPointInPath.mock.calls).toEqual([

--- a/packages/dx-react-chart/src/plugins/hover-state.jsx
+++ b/packages/dx-react-chart/src/plugins/hover-state.jsx
@@ -5,7 +5,7 @@ import {
   Getter,
 } from '@devexpress/dx-react-core';
 import {
-  changeSeriesState, processPointerMove, getHoverTargets, HOVERED,
+  changeSeriesState, processPointerMove, HOVERED,
 } from '@devexpress/dx-chart-core';
 
 const dependencies = [{ name: 'EventTracker', optional: true }];
@@ -37,7 +37,8 @@ export class HoverState extends React.PureComponent {
     const { hover } = this.state;
     // Function has to be recreated every time as there is no other way
     // to notify that "series" is updated.
-    const getSeries = ({ series }) => changeSeriesState(series, getHoverTargets(hover), HOVERED);
+    const targets = hover ? [hover] : [];
+    const getSeries = ({ series }) => changeSeriesState(series, targets, HOVERED);
     return (
       <Plugin name="HoverState" dependencies={dependencies}>
         <Getter name="pointerMoveHandlers" computed={this.getPointerMoveHandlers} />
@@ -50,11 +51,11 @@ export class HoverState extends React.PureComponent {
 HoverState.propTypes = {
   defaultHover: PropTypes.shape({
     series: PropTypes.string.isRequired,
-    point: PropTypes.number,
+    point: PropTypes.number.isRequired,
   }),
   hover: PropTypes.shape({
     series: PropTypes.string.isRequired,
-    point: PropTypes.number,
+    point: PropTypes.number.isRequired,
   }),
   onHoverChange: PropTypes.func,
 };

--- a/packages/dx-react-chart/src/plugins/hover-state.test.jsx
+++ b/packages/dx-react-chart/src/plugins/hover-state.test.jsx
@@ -2,14 +2,13 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { PluginHost } from '@devexpress/dx-react-core';
 import { pluginDepsToComponents, getComputedState } from '@devexpress/dx-testing';
-import { changeSeriesState, processPointerMove, getHoverTargets } from '@devexpress/dx-chart-core';
+import { changeSeriesState, processPointerMove } from '@devexpress/dx-chart-core';
 import { HoverState } from './hover-state';
 
 jest.mock('@devexpress/dx-chart-core', () => ({
   HOVERED: 'TEST-HOVERED',
   changeSeriesState: jest.fn().mockReturnValue('hovered-series'),
   processPointerMove: jest.fn().mockReturnValue('test-target'),
-  getHoverTargets: jest.fn().mockReturnValue('test-hover-target'),
 }));
 
 describe('HoverState', () => {
@@ -35,8 +34,7 @@ describe('HoverState', () => {
       pointerMoveHandlers: ['test-handler', expect.any(Function)],
       series: 'hovered-series',
     });
-    expect(changeSeriesState).toBeCalledWith('test-series', 'test-hover-target', 'TEST-HOVERED');
-    expect(getHoverTargets).toBeCalledWith(undefined);
+    expect(changeSeriesState).toBeCalledWith('test-series', [], 'TEST-HOVERED');
   });
 
   it('should handle "hover" prop', () => {
@@ -44,11 +42,12 @@ describe('HoverState', () => {
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
 
-        <HoverState defaultHover={{ series: '2', point: 3 }} hover={{ series: '1' }} />
+        <HoverState defaultHover={{ series: '2', point: 3 }} hover={{ series: '1', point: 2 }} />
       </PluginHost>
     ));
 
-    expect(getHoverTargets).toBeCalledWith({ series: '1' });
+    expect(changeSeriesState)
+      .toBeCalledWith('test-series', [{ series: '1', point: 2 }], 'TEST-HOVERED');
   });
 
   it('should handle "defaultHover" prop', () => {
@@ -56,11 +55,12 @@ describe('HoverState', () => {
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
 
-        <HoverState defaultHover={{ series: '1' }} />
+        <HoverState defaultHover={{ series: '1', point: 2 }} />
       </PluginHost>
     ));
 
-    expect(getHoverTargets).toBeCalledWith({ series: '1' });
+    expect(changeSeriesState)
+      .toBeCalledWith('test-series', [{ series: '1', point: 2 }], 'TEST-HOVERED');
   });
 
   it('should handle hover change', () => {
@@ -69,12 +69,12 @@ describe('HoverState', () => {
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
 
-        <HoverState hover={{ series: '1' }} onHoverChange={mock} />
+        <HoverState hover={{ series: '1', point: 2 }} onHoverChange={mock} />
       </PluginHost>
     ));
 
     getComputedState(tree).pointerMoveHandlers[1]({ targets: 'test-targets' });
 
-    expect(processPointerMove).toBeCalledWith('test-targets', { series: '1' }, mock);
+    expect(processPointerMove).toBeCalledWith('test-targets', { series: '1', point: 2 }, mock);
   });
 });

--- a/packages/dx-react-chart/src/plugins/selection-state.jsx
+++ b/packages/dx-react-chart/src/plugins/selection-state.jsx
@@ -9,7 +9,8 @@ import { changeSeriesState, SELECTED } from '@devexpress/dx-chart-core';
 export class SelectionState extends React.PureComponent {
   render() {
     const { selection } = this.props;
-    const getSeries = ({ series }) => changeSeriesState(series, selection, SELECTED);
+    const targets = selection || [];
+    const getSeries = ({ series }) => changeSeriesState(series, targets, SELECTED);
     return (
       <Plugin name="SelectionState">
         <Getter name="series" computed={getSeries} />
@@ -21,10 +22,10 @@ export class SelectionState extends React.PureComponent {
 SelectionState.propTypes = {
   selection: PropTypes.arrayOf(PropTypes.shape({
     series: PropTypes.string.isRequired,
-    point: PropTypes.number,
+    point: PropTypes.number.isRequired,
   })),
 };
 
 SelectionState.defaultProps = {
-  selection: [],
+  selection: undefined,
 };

--- a/packages/dx-react-chart/src/plugins/selection-state.test.jsx
+++ b/packages/dx-react-chart/src/plugins/selection-state.test.jsx
@@ -20,7 +20,7 @@ describe('SelectionState', () => {
   };
 
   it('should provide getters', () => {
-    const mock = [{ series: '1' }, { series: '2', point: 2 }];
+    const mock = [{ series: '1', point: 1 }, { series: '2', point: 2 }];
     const tree = mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}


### PR DESCRIPTION
Selects point closest to pointer position when *area*, *line*, *spline* series is hovered. Now hover target always has `point` field.