### PR TITLE
chore(react-chart): improve small targets tracking

### DIFF
--- a/packages/dx-chart-core/src/utils/event-tracker.js
+++ b/packages/dx-chart-core/src/utils/event-tracker.js
@@ -11,7 +11,7 @@ const getEventCoords = (e) => {
 
 const DISTANCE_THRESHOLD = 20;
 
-const compare = (t1, t2) => {
+const compareHitTargets = (t1, t2) => {
   const distanceDelta = t1.distance - t2.distance;
   if (Math.abs(distanceDelta) <= DISTANCE_THRESHOLD) {
     const orderDelta = t2.order - t1.order;
@@ -45,7 +45,7 @@ const buildEventHandler = (seriesList, handlers) => {
         ));
       }
     });
-    targets.sort(compare);
+    targets.sort(compareHitTargets);
     const arg = { location, targets, event: e.nativeEvent };
     handlers.forEach(handler => handler(arg));
   };

--- a/packages/dx-chart-core/src/utils/event-tracker.js
+++ b/packages/dx-chart-core/src/utils/event-tracker.js
@@ -9,7 +9,16 @@ const getEventCoords = (e) => {
   ];
 };
 
-const compare = (t1, t2) => t1.distance - t2.distance;
+const DISTANCE_THRESHOLD = 20;
+
+const compare = (t1, t2) => {
+  const distanceDelta = t1.distance - t2.distance;
+  if (Math.abs(distanceDelta) <= DISTANCE_THRESHOLD) {
+    const orderDelta = t2.order - t1.order;
+    return orderDelta !== 0 ? orderDelta : distanceDelta;
+  }
+  return distanceDelta;
+};
 
 const buildEventHandler = (seriesList, handlers) => {
   let hitTesters = null;
@@ -26,11 +35,13 @@ const buildEventHandler = (seriesList, handlers) => {
     const location = getEventCoords(e);
     hitTesters = hitTesters || createHitTesters();
     const targets = [];
-    seriesList.forEach(({ name: series, symbolName }) => {
+    seriesList.forEach(({ name: series, index: order, symbolName }) => {
       const status = hitTesters[symbolName](location);
       if (status) {
         targets.push(...status.points.map(
-          point => ({ series, point: point.index, distance: point.distance }),
+          point => ({
+            series, point: point.index, distance: point.distance, order,
+          }),
         ));
       }
     });

--- a/packages/dx-chart-core/src/utils/event-tracker.test.js
+++ b/packages/dx-chart-core/src/utils/event-tracker.test.js
@@ -10,6 +10,7 @@ describe('EventTracker', () => {
     const hitTest1 = jest.fn();
     const series1 = {
       name: 'Series 1',
+      index: 0,
       symbolName: 'series-1',
       points: 'coordinates-1',
       createHitTester: jest.fn().mockReturnValue(hitTest1),
@@ -17,6 +18,7 @@ describe('EventTracker', () => {
     const hitTest2 = jest.fn();
     const series2 = {
       name: 'Series 2',
+      index: 1,
       symbolName: 'series-2',
       points: 'coordinates-2',
       createHitTester: jest.fn().mockReturnValue(hitTest2),
@@ -24,6 +26,7 @@ describe('EventTracker', () => {
     const hitTest3 = jest.fn();
     const series3 = {
       name: 'Series 3',
+      index: 2,
       symbolName: 'series-3',
       points: 'coordinates-3',
       createHitTester: jest.fn().mockReturnValue(hitTest3),
@@ -67,12 +70,12 @@ describe('EventTracker', () => {
     it('should provide targets on successful hit tests', () => {
       hitTest1.mockReturnValue({
         points: [
-          { index: 1, distance: 0.3 },
+          { index: 1, distance: 50 },
         ],
       });
       hitTest3.mockReturnValue({
         points: [
-          { index: 1, distance: 0.2 }, { index: 2, distance: 0.4 }, { index: 3, distance: 0.1 },
+          { index: 1, distance: 20 }, { index: 2, distance: 80 }, { index: 3, distance: 10 },
         ],
       });
       const func = call();
@@ -84,13 +87,64 @@ describe('EventTracker', () => {
       });
 
       const targets = [
-        { series: 'Series 3', point: 3, distance: 0.1 },
-        { series: 'Series 3', point: 1, distance: 0.2 },
-        { series: 'Series 1', point: 1, distance: 0.3 },
-        { series: 'Series 3', point: 2, distance: 0.4 },
+        {
+          series: 'Series 3', point: 3, distance: 10, order: 2,
+        },
+        {
+          series: 'Series 3', point: 1, distance: 20, order: 2,
+        },
+        {
+          series: 'Series 1', point: 1, distance: 50, order: 0,
+        },
+        {
+          series: 'Series 3', point: 2, distance: 80, order: 2,
+        },
       ];
       expect(handler1).toBeCalledWith({ location: [192, 281], targets, event: 'nativeEvent' });
       expect(handler2).toBeCalledWith({ location: [192, 281], targets, event: 'nativeEvent' });
+    });
+
+    it('should take series order into account', () => {
+      hitTest1.mockReturnValue({
+        points: [
+          { index: 2, distance: 30 },
+        ],
+      });
+      hitTest2.mockReturnValue({
+        points: [
+          { index: 1, distance: 40 }, { index: 3, distance: 60 },
+        ],
+      });
+      hitTest3.mockReturnValue({
+        points: [
+          { index: 0, distance: 35 },
+        ],
+      });
+      const func = call();
+      func({
+        clientX: 481,
+        clientY: 324,
+        currentTarget,
+        nativeEvent: 'nativeEvent',
+      });
+
+      const targets = [
+        {
+          series: 'Series 3', point: 0, distance: 35, order: 2,
+        },
+        {
+          series: 'Series 2', point: 1, distance: 40, order: 1,
+        },
+        {
+          series: 'Series 1', point: 2, distance: 30, order: 0,
+        },
+        {
+          series: 'Series 2', point: 3, distance: 60, order: 1,
+        },
+      ];
+
+      expect(handler1).toBeCalledWith({ location: [321, 184], targets, event: 'nativeEvent' });
+      expect(handler2).toBeCalledWith({ location: [321, 184], targets, event: 'nativeEvent' });
     });
 
     it('should create hit testers lazily', () => {

--- a/packages/dx-chart-core/src/utils/hover-state.js
+++ b/packages/dx-chart-core/src/utils/hover-state.js
@@ -1,39 +1,21 @@
 // Comparing by reference is not an option as Tracker always sends new objects.
-// On the other side Tracker cannot persist references as it actually operates with simple scalars
+// Tracker cannot persist references as it actually operates with simple scalars
 // and constructs objects to provide info in a slightly more suitable way.
 const compareTargets = (target1, target2) => (
   target1.series === target2.series && target1.point === target2.point
 );
 
-// Current value is chosen roughly and expected to be adjusted.
-const DISTANCE_PRIORITY_RATIO = 4;
-
 // If *currentTarget* is among *targets* then it has priority but only while its distance
 // is not significantly greater (DISTANCE_PRIORITY_RATIO) than that of the best candidate.
 const selectTarget = (targets, currentTarget) => {
-  if (!currentTarget) {
-    return targets.length ? targets[0] : undefined;
-  }
-  if (!targets.length) {
-    return null;
-  }
   const candidate = targets[0];
-  // Skip complex checks if *currentTarget* has minimal distance.
-  if (compareTargets(candidate, currentTarget)) {
-    return undefined;
-  }
-  // Skip complex check if there is single candidate.
-  if (targets.length === 1) {
+  if (!currentTarget) {
     return candidate;
   }
-  const current = targets.find(target => compareTargets(target, currentTarget));
-  if (current) {
-    // Here *current.distance* is exactly greater than *candidate.distance*.
-    // The question is - how much greater?
-    const ratio = current.distance / candidate.distance;
-    return ratio > DISTANCE_PRIORITY_RATIO ? candidate : undefined;
+  if (!candidate) {
+    return null;
   }
-  return candidate;
+  return compareTargets(candidate, currentTarget) ? undefined : candidate;
 };
 
 export const processPointerMove = (targets, currentTarget, notify) => {

--- a/packages/dx-chart-core/src/utils/hover-state.test.js
+++ b/packages/dx-chart-core/src/utils/hover-state.test.js
@@ -41,41 +41,5 @@ describe('HoverState', () => {
       expect(result).toEqual(undefined);
       expect(mock).not.toBeCalled();
     });
-
-    it('should keep current target if it is the closest candidate', () => {
-      const mock = jest.fn();
-      const result = processPointerMove([
-        { series: '1' },
-        { series: '2' },
-        { series: '3' },
-      ], { series: '1' }, mock);
-
-      expect(result).toEqual(undefined);
-      expect(mock).not.toBeCalled();
-    });
-
-    it('should keep current target if candidate is not much closer', () => {
-      const mock = jest.fn();
-      const result = processPointerMove([
-        { series: '1', distance: 0.1 },
-        { series: '2' },
-        { series: '3', distance: 0.3 },
-      ], { series: '3' }, mock);
-
-      expect(result).toEqual(undefined);
-      expect(mock).not.toBeCalled();
-    });
-
-    it('should change target if candidate is much closer', () => {
-      const mock = jest.fn();
-      const result = processPointerMove([
-        { series: '1', distance: 0.1 },
-        { series: '2' },
-        { series: '3', distance: 0.45 },
-      ], { series: '3' }, mock);
-
-      expect(result).toEqual({ series: '1', distance: 0.1 });
-      expect(mock).toBeCalledWith({ series: '1', distance: 0.1 });
-    });
   });
 });

--- a/packages/dx-chart-core/src/utils/series.js
+++ b/packages/dx-chart-core/src/utils/series.js
@@ -92,6 +92,12 @@ export const createSplineHitTester = createContinuousSeriesHitTesterCreator(() =
   return path;
 });
 
+const hitTestRect = (dx, dy, halfX, halfY) => (
+  Math.abs(dx) <= halfX && Math.abs(dy) <= halfY ? {
+    distance: getSegmentLength(dx, dy),
+  } : null
+);
+
 // Some kind of binary search can be used here as bars can be ordered along argument axis.
 export const createBarHitTester = createPointsEnumeratingHitTesterCreator(
   ([px, py], point) => {
@@ -99,9 +105,7 @@ export const createBarHitTester = createPointsEnumeratingHitTesterCreator(
     const yCenter = (point.y + point.y1) / 2;
     const halfWidth = point.width / 2;
     const halfHeight = Math.abs(point.y - point.y1) / 2;
-    return Math.abs(px - xCenter) <= halfWidth && Math.abs(py - yCenter) <= halfHeight ? {
-      distance: getSegmentLength(px - xCenter, py - yCenter),
-    } : null;
+    return hitTestRect(px - xCenter, py - yCenter, halfWidth, halfHeight);
   },
 );
 
@@ -131,11 +135,9 @@ export const createPieHitTester = createPointsEnumeratingHitTesterCreator(
     const dy = py - y;
     const r = getSegmentLength(dx, dy);
     const angle = mapAngleTod3(Math.atan2(dy, dx));
-    return Math.abs(r - rCenter) <= halfRadius && Math.abs(angle - angleCenter) <= halfAngle ? {
-      // This is not a correct distance calculation but for now it will suffice.
-      // For Pie series it would not be actually used.
-      distance: getSegmentLength(r - rCenter, angle - angleCenter),
-    } : null;
+    // This is not a correct distance calculation but for now it will suffice.
+    // For Pie series it would not be actually used.
+    return hitTestRect(r - rCenter, angle - angleCenter, halfRadius, halfAngle);
   },
 );
 

--- a/packages/dx-chart-core/src/utils/series.js
+++ b/packages/dx-chart-core/src/utils/series.js
@@ -1,7 +1,7 @@
 import { area } from 'd3-shape';
 import { dArea, dLine, dSpline } from '../plugins/series/computeds';
 
-const getLength = (dx, dy) => Math.sqrt(dx * dx + dy * dy);
+const getSegmentLength = (dx, dy) => Math.sqrt(dx * dx + dy * dy);
 
 // *distance* is a normalized distance to point.
 // It belongs to [0, Infinity):
@@ -27,7 +27,7 @@ const createCanvasAbusingHitTester = (makePath, points) => {
 const LINE_POINT_SIZE = 20;
 const LINE_TOLERANCE = 10;
 
-const getContinuousPointDistance = ([px, py], { x, y }) => getLength(px - x, py - y);
+const getContinuousPointDistance = ([px, py], { x, y }) => getSegmentLength(px - x, py - y);
 
 const createContinuousSeriesHitTesterCreator = makePath => (points) => {
   const fallbackHitTest = createCanvasAbusingHitTester(makePath, points);
@@ -100,7 +100,7 @@ export const createBarHitTester = createPointsEnumeratingHitTesterCreator(
     const halfWidth = point.width / 2;
     const halfHeight = Math.abs(point.y - point.y1) / 2;
     return Math.abs(px - xCenter) <= halfWidth && Math.abs(py - yCenter) <= halfHeight ? {
-      distance: getLength(px - xCenter, py - yCenter),
+      distance: getSegmentLength(px - xCenter, py - yCenter),
     } : null;
   },
 );
@@ -108,7 +108,7 @@ export const createBarHitTester = createPointsEnumeratingHitTesterCreator(
 // TODO: Use actual point size here!
 export const createScatterHitTester = createPointsEnumeratingHitTesterCreator(
   ([px, py], { x, y }) => {
-    const distance = getLength(px - x, py - y);
+    const distance = getSegmentLength(px - x, py - y);
     return distance <= 10 ? { distance } : null;
   },
 );
@@ -129,12 +129,12 @@ export const createPieHitTester = createPointsEnumeratingHitTesterCreator(
     const halfAngle = Math.abs(startAngle - endAngle) / 2;
     const dx = px - x;
     const dy = py - y;
-    const r = getLength(dx, dy);
+    const r = getSegmentLength(dx, dy);
     const angle = mapAngleTod3(Math.atan2(dy, dx));
     return Math.abs(r - rCenter) <= halfRadius && Math.abs(angle - angleCenter) <= halfAngle ? {
       // This is not a correct distance calculation but for now it will suffice.
       // For Pie series it would not be actually used.
-      distance: getLength(r - rCenter, angle - angleCenter),
+      distance: getSegmentLength(r - rCenter, angle - angleCenter),
     } : null;
   },
 );

--- a/packages/dx-chart-core/src/utils/series.test.js
+++ b/packages/dx-chart-core/src/utils/series.test.js
@@ -46,26 +46,26 @@ describe('Series', () => {
     expect(hitTest([90, 30])).toEqual(null);
 
     expect(hitTest([110, 40])).toEqual({
-      points: [{ index: 'p1', distance: matchFloat(0.35) }],
+      points: [{ index: 'p1', distance: matchFloat(7.07) }],
     });
     expect(hitTest([115, 35])).toEqual({
       points: [{ index: 'p1', distance: matchFloat(0) }],
     });
 
     expect(hitTest([185, 65])).toEqual({
-      points: [{ index: 'p2', distance: matchFloat(1) }, { index: 'p3', distance: matchFloat(0.56) }],
+      points: [{ index: 'p2', distance: matchFloat(20) }, { index: 'p3', distance: matchFloat(11.18) }],
     });
     expect(hitTest([190, 60])).toEqual({
-      points: [{ index: 'p3', distance: matchFloat(0.25) }],
+      points: [{ index: 'p3', distance: matchFloat(5) }],
     });
 
     isPointInPath.mockReturnValueOnce(true);
     expect(hitTest([140, 40])).toEqual({
-      points: [{ index: 'p1', distance: matchFloat(1.27) }],
+      points: [{ index: 'p1', distance: matchFloat(25.5) }],
     });
     isPointInPath.mockReturnValueOnce(true);
     expect(hitTest([140, 60])).toEqual({
-      points: [{ index: 'p2', distance: matchFloat(1.27) }],
+      points: [{ index: 'p2', distance: matchFloat(25.5) }],
     });
 
     expect(isPointInPath.mock.calls).toEqual([
@@ -185,9 +185,9 @@ describe('Series', () => {
 
       expect(hitTest([15, 1])).toEqual(null);
       expect(hitTest([12, 4])).toEqual({ points: [{ index: 'p1', distance: matchFloat(1) }] });
-      expect(hitTest([25, 3])).toEqual({ points: [{ index: 'p2', distance: matchFloat(1) }] });
+      expect(hitTest([25, 3])).toEqual({ points: [{ index: 'p2', distance: matchFloat(1.41) }] });
       expect(hitTest([31, 2])).toEqual({
-        points: [{ index: 'p3', distance: matchFloat(0.6) }, { index: 'p4', distance: matchFloat(1) }],
+        points: [{ index: 'p3', distance: matchFloat(1.8) }, { index: 'p4', distance: matchFloat(2.5) }],
       });
     });
   });
@@ -202,10 +202,10 @@ describe('Series', () => {
       ]);
 
       expect(hitTest([15, -7])).toEqual(null);
-      expect(hitTest([14, 10])).toEqual({ points: [{ index: 'p1', distance: matchFloat(0.72) }] });
-      expect(hitTest([32, 4])).toEqual({ points: [{ index: 'p2', distance: matchFloat(0.22) }] });
+      expect(hitTest([14, 10])).toEqual({ points: [{ index: 'p1', distance: matchFloat(7.21) }] });
+      expect(hitTest([32, 4])).toEqual({ points: [{ index: 'p2', distance: matchFloat(2.24) }] });
       expect(hitTest([49, 15])).toEqual({
-        points: [{ index: 'p3', distance: matchFloat(0.71) }, { index: 'p4', distance: matchFloat(0.78) }],
+        points: [{ index: 'p3', distance: matchFloat(7.07) }, { index: 'p4', distance: matchFloat(7.81) }],
       });
     });
   });
@@ -225,10 +225,10 @@ describe('Series', () => {
       ]);
 
       expect(hitTest([60, 61])).toEqual(null);
-      expect(hitTest([64, 45])).toEqual({ points: [{ index: 'p1', distance: matchFloat(0.72) }] });
-      expect(hitTest([68, 52])).toEqual({ points: [{ index: 'p2', distance: matchFloat(0.69) }] });
+      expect(hitTest([64, 45])).toEqual({ points: [{ index: 'p1', distance: matchFloat(0.95) }] });
+      expect(hitTest([68, 52])).toEqual({ points: [{ index: 'p2', distance: matchFloat(2.8) }] });
       expect(hitTest([60, 55])).toEqual({
-        points: [{ index: 'p2', distance: matchFloat(1) }, { index: 'p3', distance: matchFloat(1) }],
+        points: [{ index: 'p2', distance: matchFloat(0.93) }, { index: 'p3', distance: matchFloat(0.93) }],
       });
     });
   });


### PR DESCRIPTION
Removes complex hover target picking logic. Now point belonging to the last declared series has priority unless its distance is not much greater than that of other candidates.

Tracker now operates with absolute distances rather than relative (like it did beforehand).