### PR TITLE
refactor(react-chart): rename "showGrids" Axis property

### DIFF
--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/animation.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/animation.jsxt
@@ -44,8 +44,8 @@ export default class Demo extends React.PureComponent {
           data={chartData}
         >
           <ArgumentAxis />
-          <ValueAxis scaleName="sale" showGrids={false} showLine showTicks />
-          <ValueAxis scaleName="total" position="right" showGrids={false} showLine showTicks />
+          <ValueAxis scaleName="sale" showGrid={false} showLine showTicks />
+          <ValueAxis scaleName="total" position="right" showGrid={false} showLine showTicks />
 
           <BarSeries
             name="Units Sold"

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/combination-series.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/combination-series.jsxt
@@ -34,8 +34,8 @@ export default class Demo extends React.PureComponent {
           data={chartData}
         >
           <ArgumentAxis />
-          <ValueAxis scaleName="sale" showGrids={false} showLine showTicks />
-          <ValueAxis scaleName="total" position="right" showGrids={false} showLine showTicks />
+          <ValueAxis scaleName="sale" showGrid={false} showLine showTicks />
+          <ValueAxis scaleName="total" position="right" showGrid={false} showLine showTicks />
 
           <BarSeries
             name="Units Sold"

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/typescript.tsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/typescript.tsxt
@@ -32,8 +32,8 @@ export default class Demo extends React.Component<object, object> {
           data={chartData}
         >
           <ArgumentAxis />
-          <ValueAxis scaleName="sale" showGrids={false} showLine={true} showTicks={true} />
-          <ValueAxis scaleName="total" position="right" showGrids={false} showLine={true} showTicks={true} />
+          <ValueAxis scaleName="sale" showGrid={false} showLine={true} showTicks={true} />
+          <ValueAxis scaleName="total" position="right" showGrid={false} showLine={true} showTicks={true} />
 
           <BarSeries
             name="Units Sold"

--- a/packages/dx-react-chart-demos/src/demo-sources/point-chart/scatter.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/point-chart/scatter.jsxt
@@ -27,7 +27,7 @@ export default class Demo extends React.PureComponent {
         <Chart
           data={chartData}
         >
-          <ArgumentAxis showGrids />
+          <ArgumentAxis showGrid />
           <ValueAxis />
           <ScatterSeries
             valueField="val1"

--- a/packages/dx-react-chart/docs/reference/argument-axis.md
+++ b/packages/dx-react-chart/docs/reference/argument-axis.md
@@ -28,7 +28,7 @@ position? | 'bottom' &#124; 'top' | 'bottom' | The axis position.
 indentFromAxis? | number | 10 | The indent from the axis.
 type? | 'band' &#124; 'linear' | 'linear' | Axis type.
 showTicks? | boolean | true | Specifies whether to render ticks.
-showGrid? | boolean | false | Specifies whether to render grids.
+showGrid? | boolean | false | Specifies whether to render the grid.
 showLine? | boolean | true | Specifies whether to render the axis's line.
 showLabels? | boolean | true | Specifies whether to render the axis's labels.
 tickFormat? | (scale: [ScaleObject](scale.md#scaleobject)) => (tick: string) => string  | | A function that returns a tick formatter function.

--- a/packages/dx-react-chart/docs/reference/argument-axis.md
+++ b/packages/dx-react-chart/docs/reference/argument-axis.md
@@ -28,7 +28,7 @@ position? | 'bottom' &#124; 'top' | 'bottom' | The axis position.
 indentFromAxis? | number | 10 | The indent from the axis.
 type? | 'band' &#124; 'linear' | 'linear' | Axis type.
 showTicks? | boolean | true | Specifies whether to render ticks.
-showGrids? | boolean | false | Specifies whether to render grids.
+showGrid? | boolean | false | Specifies whether to render grids.
 showLine? | boolean | true | Specifies whether to render the axis's line.
 showLabels? | boolean | true | Specifies whether to render the axis's labels.
 tickFormat? | (scale: [ScaleObject](scale.md#scaleobject)) => (tick: string) => string  | | A function that returns a tick formatter function.

--- a/packages/dx-react-chart/docs/reference/value-axis.md
+++ b/packages/dx-react-chart/docs/reference/value-axis.md
@@ -29,7 +29,7 @@ scaleName? | string | | The scale name.
 indentFromAxis? | number | 10 | The indent from the axis.
 type? | 'band' &#124; 'linear' | 'linear' | Axis type.
 showTicks? | boolean | false | Specifies whether to render ticks.
-showGrids? | boolean | true | Specifies whether to render grids.
+showGrid? | boolean | true | Specifies whether to render grids.
 showLine? | boolean | false | Specifies whether to render the axis's line.
 showLabels? | boolean | true | Specifies whether to render the axis's labels.
 tickFormat? | (scale: [ScaleObject](scale.md#scaleobject)) => (tick: string) => string  | | A function that returns a tick formatter function.

--- a/packages/dx-react-chart/docs/reference/value-axis.md
+++ b/packages/dx-react-chart/docs/reference/value-axis.md
@@ -29,7 +29,7 @@ scaleName? | string | | The scale name.
 indentFromAxis? | number | 10 | The indent from the axis.
 type? | 'band' &#124; 'linear' | 'linear' | Axis type.
 showTicks? | boolean | false | Specifies whether to render ticks.
-showGrid? | boolean | true | Specifies whether to render grids.
+showGrid? | boolean | true | Specifies whether to render the grid.
 showLine? | boolean | false | Specifies whether to render the axis's line.
 showLabels? | boolean | true | Specifies whether to render the axis's labels.
 tickFormat? | (scale: [ScaleObject](scale.md#scaleobject)) => (tick: string) => string  | | A function that returns a tick formatter function.

--- a/packages/dx-react-chart/src/plugins/axis.jsx
+++ b/packages/dx-react-chart/src/plugins/axis.jsx
@@ -49,7 +49,7 @@ class RawAxis extends React.PureComponent {
       tickSize,
       tickFormat,
       indentFromAxis,
-      showGrids,
+      showGrid,
       showTicks,
       showLine,
       showLabels,
@@ -167,7 +167,7 @@ class RawAxis extends React.PureComponent {
           <TemplateConnector>
             {({ scales, layouts }) => {
               const scale = scales[scaleName];
-              if (!scale || !showGrids) {
+              if (!scale || !showGrid) {
                 return null;
               }
 
@@ -204,7 +204,7 @@ RawAxis.propTypes = {
   lineComponent: PropTypes.func.isRequired,
   gridComponent: PropTypes.func.isRequired,
   position: PropTypes.string.isRequired,
-  showGrids: PropTypes.bool.isRequired,
+  showGrid: PropTypes.bool.isRequired,
   showTicks: PropTypes.bool.isRequired,
   showLine: PropTypes.bool.isRequired,
   showLabels: PropTypes.bool.isRequired,
@@ -244,7 +244,7 @@ export const Axis = withComponents({
 // TODO: Check that only BOTTOM and TOP are accepted.
 export const ArgumentAxis = withPatchedProps(props => ({
   position: BOTTOM,
-  showGrids: false,
+  showGrid: false,
   showTicks: true,
   showLine: true,
   showLabels: true,
@@ -255,7 +255,7 @@ export const ArgumentAxis = withPatchedProps(props => ({
 // TODO: Check that only LEFT and RIGHT are accepted.
 export const ValueAxis = withPatchedProps(props => ({
   position: LEFT,
-  showGrids: true,
+  showGrid: true,
   showTicks: false,
   showLine: false,
   showLabels: true,

--- a/packages/dx-react-chart/src/plugins/axis.test.jsx
+++ b/packages/dx-react-chart/src/plugins/axis.test.jsx
@@ -60,7 +60,7 @@ describe('Axis', () => {
     position: 'bottom',
     scaleName: 'test-domain',
     showTicks: true,
-    showGrids: true,
+    showGrid: true,
     showLine: true,
     showLabels: true,
     rootComponent: RootComponent,
@@ -315,9 +315,9 @@ describe('Axis', () => {
     });
   });
 
-  it('should not render grid component, showGrids is false', () => {
+  it('should not render grid component, showGrid is false', () => {
     setupAxisCoordinates([1, 0]);
-    const tree = mount(<AxisTester showGrids={false} />);
+    const tree = mount(<AxisTester showGrid={false} />);
 
     expect(tree.find(GridComponent).get(0)).toBeFalsy();
   });


### PR DESCRIPTION
BREAKING CHANGES:

The `showGrids` *Axis* property is renamed to `showGrid`.