### PR TITLE
chore(react-chart-material-ui): replace Popoper with Popper

### DIFF
--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.jsx
@@ -3,6 +3,7 @@ import * as PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Popper from '@material-ui/core/Popper';
 import Paper from '@material-ui/core/Paper';
+import classNames from 'classnames';
 import { getBorderColor } from '../utils';
 
 const styles = theme => ({
@@ -57,7 +58,7 @@ class RawOverlay extends React.PureComponent {
 
   render() {
     const {
-      classes, children, target, ...restProps
+      classes, className, children, target, ...restProps
     } = this.props;
     const { modifiers } = this.state;
     return (
@@ -65,7 +66,7 @@ class RawOverlay extends React.PureComponent {
         open
         anchorEl={target}
         placement="top"
-        className={classes.popper}
+        className={classNames(classes.popper, className)}
         modifiers={modifiers}
         {...restProps}
       >

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.jsx
@@ -1,22 +1,86 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import Popover from '@material-ui/core/Popover';
+import { withStyles } from '@material-ui/core/styles';
+import Popper from '@material-ui/core/Popper';
+import Paper from '@material-ui/core/Paper';
+import { getBorderColor } from '../utils';
 
-export const Overlay = ({
-  children, target, ...restProps
-}) => (
-  <Popover
-    open
-    anchorEl={target}
-    anchorOrigin={{ vertical: 'center', horizontal: 'center' }}
-    transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-    {...restProps}
-  >
-    {children}
-  </Popover>
-);
+const styles = theme => ({
+  popper: {
+    zIndex: 1,
+    marginBottom: '.5rem',
+  },
+  paper: {
+    padding: `${theme.spacing.unit * 0.5}px ${theme.spacing.unit}px`,
+  },
+  arrow: {
+    position: 'absolute',
+    display: 'block',
+    width: '1rem',
+    height: '.5rem',
+    margin: '0 .3rem',
+    bottom: '-.5rem', // placement:"top" specific
 
-Overlay.propTypes = {
+    '&::before, &::after': {
+      position: 'absolute',
+      display: 'block',
+      content: '""',
+      borderColor: 'transparent',
+      borderStyle: 'solid',
+      borderWidth: '.5rem .5rem 0', // placement:"top" specific
+    },
+    '&::before': {
+      bottom: 0,
+      borderTopColor: getBorderColor(theme),
+    },
+    '&::after': {
+      bottom: '1px',
+      borderTopColor: theme.palette.background.paper,
+    },
+  },
+});
+
+class RawOverlay extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {};
+    // *React.createRef* is not used because it cannot be accessed (*current* is null)
+    // in *componentDidMount* (looks like Popper does not render its children immediately).
+    // Accesing it in *componentDidUpdate* requires additional checks.
+    // The callback version is just simpler.
+    this.arrowRef = element => this.setState({
+      modifiers: {
+        arrow: { element },
+      },
+    });
+  }
+
+  render() {
+    const {
+      classes, children, target, ...restProps
+    } = this.props;
+    const { modifiers } = this.state;
+    return (
+      <Popper
+        open
+        anchorEl={target}
+        placement="top"
+        className={classes.popper}
+        modifiers={modifiers}
+        {...restProps}
+      >
+        <Paper className={classes.paper}>
+          {children}
+        </Paper>
+        <div ref={this.arrowRef} className={classes.arrow} />
+      </Popper>
+    );
+  }
+}
+
+RawOverlay.propTypes = {
   children: PropTypes.node.isRequired,
   target: PropTypes.func.isRequired,
 };
+
+export const Overlay = withStyles(styles)(RawOverlay);

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.jsx
@@ -1,87 +1,57 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Popper from '@material-ui/core/Popper';
 import Paper from '@material-ui/core/Paper';
 import classNames from 'classnames';
-import { getBorderColor } from '../utils';
 
-const styles = theme => ({
-  popper: {
-    zIndex: 1,
-    marginBottom: '.5rem',
-  },
-  paper: {
-    padding: `${theme.spacing.unit * 0.5}px ${theme.spacing.unit}px`,
-  },
-  arrow: {
-    position: 'absolute',
-    display: 'block',
-    width: '1rem',
-    height: '.5rem',
-    margin: '0 .3rem',
-    bottom: '-.5rem', // placement:"top" specific
-
-    '&::before, &::after': {
+const styles = (theme) => {
+  const { unit } = theme.spacing;
+  const arrowSize = unit * 1.2;
+  return {
+    popper: {
+      zIndex: 1,
+      marginBottom: `${arrowSize}px`,
+    },
+    paper: {
+      padding: `${unit * 0.5}px ${unit}px`,
+    },
+    arrow: {
+      width: `${arrowSize * 5}px`,
+      height: `${arrowSize * 2.5}px`,
       position: 'absolute',
-      display: 'block',
-      content: '""',
-      borderColor: 'transparent',
-      borderStyle: 'solid',
-      borderWidth: '.5rem .5rem 0', // placement:"top" specific
-    },
-    '&::before': {
-      bottom: 0,
-      borderTopColor: getBorderColor(theme),
-    },
-    '&::after': {
-      bottom: '1px',
-      borderTopColor: theme.palette.background.paper,
-    },
-  },
-});
+      top: '100%',
+      left: '50%',
+      transform: 'translateX(-50%)',
+      overflow: 'hidden',
 
-class RawOverlay extends React.PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {};
-    // *React.createRef* is not used because it cannot be accessed (*current* is null)
-    // in *componentDidMount* (looks like Popper does not render its children immediately).
-    // Accesing it in *componentDidUpdate* requires additional checks.
-    // The callback version is just simpler.
-    this.arrowRef = element => this.setState({
-      modifiers: {
-        arrow: { element },
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        width: `${arrowSize}px`,
+        height: `${arrowSize}px`,
+        background: theme.palette.background.paper,
+        transform: 'translateX(-50%) translateY(-50%) rotate(45deg)',
+        top: 0,
+        left: '50%',
+        boxShadow: theme.shadows[2],
       },
-    });
-  }
-
-  render() {
-    const {
-      classes, className, children, target, ...restProps
-    } = this.props;
-    const { modifiers } = this.state;
-    return (
-      <Popper
-        open
-        anchorEl={target}
-        placement="top"
-        className={classNames(classes.popper, className)}
-        modifiers={modifiers}
-        {...restProps}
-      >
-        <Paper className={classes.paper}>
-          {children}
-        </Paper>
-        <div ref={this.arrowRef} className={classes.arrow} />
-      </Popper>
-    );
-  }
-}
-
-RawOverlay.propTypes = {
-  children: PropTypes.node.isRequired,
-  target: PropTypes.func.isRequired,
+    },
+  };
 };
 
-export const Overlay = withStyles(styles)(RawOverlay);
+export const Overlay = withStyles(styles)(({
+  classes, className, children, target, ...restProps
+}) => (
+  <Popper
+    open
+    anchorEl={target}
+    placement="top"
+    className={classNames(classes.popper, className)}
+    {...restProps}
+  >
+    <Paper className={classes.paper}>
+      {children}
+    </Paper>
+    <div className={classes.arrow} />
+  </Popper>
+));

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.test.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.test.jsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createMount } from '@material-ui/core/test-utils';
+import { createMount, getClasses } from '@material-ui/core/test-utils';
 import { Overlay } from './overlay';
 
 describe('Overlay', () => {
@@ -7,6 +7,7 @@ describe('Overlay', () => {
     target: () => ({ }),
   };
 
+  const classes = getClasses(<Overlay {...defaultProps}>Test</Overlay>);
   const mount = createMount();
 
   it('should render Popover', () => {
@@ -22,8 +23,41 @@ describe('Overlay', () => {
       open: true,
       anchorEl: defaultProps.target,
       placement: 'top',
+      className: classes.popper,
     });
-    expect(tree.find('Paper').exists()).toBeTruthy();
+    expect(tree.find('Paper').props()).toMatchObject({
+      className: classes.paper,
+    });
+    expect(tree.find('div').get(3).props).toMatchObject({
+      className: classes.arrow,
+    });
     expect(tree.find('.content').exists()).toBeTruthy();
+  });
+
+  it('should pass custom class to the root element', () => {
+    const tree = mount((
+      <Overlay
+        {...defaultProps}
+        className="custom-class"
+      >
+        <div className="content" />
+      </Overlay>
+    ));
+
+    expect(tree.find('Popper').is('.custom-class')).toBeTruthy();
+    expect(tree.find('Popper').is(`.${classes.popper}`)).toBeTruthy();
+  });
+
+  it('should pass rest props to the root element', () => {
+    const tree = mount((
+      <Overlay
+        {...defaultProps}
+        custom={10}
+      >
+        <div className="content" />
+      </Overlay>
+    ));
+
+    expect(tree.find('Popper').props().custom).toEqual(10);
   });
 });

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.test.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.test.jsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { createMount } from '@material-ui/core/test-utils';
 import { Overlay } from './overlay';
 
 describe('Overlay', () => {
   const defaultProps = {
-    target: () => {},
+    target: () => ({ }),
   };
 
+  const mount = createMount();
+
   it('should render Popover', () => {
-    const tree = shallow((
+    const tree = mount((
       <Overlay
         {...defaultProps}
       >
@@ -16,6 +18,12 @@ describe('Overlay', () => {
       </Overlay>
     ));
 
-    expect(tree.find('.content')).toBeTruthy();
+    expect(tree.find('Popper').props()).toMatchObject({
+      open: true,
+      anchorEl: defaultProps.target,
+      placement: 'top',
+    });
+    expect(tree.find('Paper').exists()).toBeTruthy();
+    expect(tree.find('.content').exists()).toBeTruthy();
   });
 });


### PR DESCRIPTION
Now *material-ui* tooltip's appearance and positioning are more similar to those in *bootstrap4*.