### PR TITLE
refactor(react-chart): property to customize scale domain

### DIFF
--- a/packages/dx-chart-core/src/plugins/scale/computeds.js
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.js
@@ -85,8 +85,8 @@ const collectDomainsFromSeries = (domains, seriesList) => {
 const customizeDomains = (domains) => {
   Object.keys(domains).forEach((name) => {
     const obj = domains[name];
-    if (obj.customizeDomain) {
-      obj.domain = obj.customizeDomain(obj.domain);
+    if (obj.modifyDomain) {
+      obj.domain = obj.modifyDomain(obj.domain);
     }
   });
 };

--- a/packages/dx-chart-core/src/plugins/scale/computeds.js
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.js
@@ -82,16 +82,11 @@ const collectDomainsFromSeries = (domains, seriesList) => {
   return domains;
 };
 
-const applyMinMax = (domains) => {
+const customizeDomains = (domains) => {
   Object.keys(domains).forEach((name) => {
     const obj = domains[name];
-    if (!obj.isDiscrete) {
-      if (obj.min !== undefined) {
-        obj.domain[0] = obj.min;
-      }
-      if (obj.max !== undefined) {
-        obj.domain[1] = obj.max;
-      }
+    if (obj.customizeDomain) {
+      obj.domain = obj.customizeDomain(obj.domain);
     }
   });
 };
@@ -100,7 +95,7 @@ export const computeDomains = (domains, seriesList) => {
   const result = copy(domains);
   collectDomainsFromSeries(result, seriesList);
   calculateDomains(result, seriesList);
-  applyMinMax(result);
+  customizeDomains(result);
   return result;
 };
 

--- a/packages/dx-chart-core/src/plugins/scale/computeds.test.js
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.test.js
@@ -250,10 +250,11 @@ describe('Scale', () => {
       });
     });
 
-    it('should take min/max from axis', () => {
+    it('should allow to customize domain', () => {
+      const mock = jest.fn().mockReturnValue([10, 11]);
       const domains = computeDomains({
         ...testDomains,
-        domain1: { min: 0, max: 10 },
+        domain1: { customizeDomain: mock },
       }, [{
         scaleName: 'domain1',
         getPointTransformer,
@@ -268,51 +269,10 @@ describe('Scale', () => {
           domain: [], factory: scaleLinear, isDiscrete: false,
         },
         domain1: {
-          domain: [0, 10], min: 0, max: 10, factory: scaleLinear, isDiscrete: false,
+          domain: [10, 11], customizeDomain: mock, factory: scaleLinear, isDiscrete: false,
         },
       });
-    });
-
-    it('should take one of min/max from axis', () => {
-      const domains = computeDomains({
-        ...testDomains,
-        domain1: { max: 7 },
-      }, [{
-        scaleName: 'domain1',
-        getPointTransformer,
-        points: [{ argument: 1, value: 3 }, { argument: 2, value: 14 }],
-      }]);
-
-      expect(domains).toEqual({
-        [ARGUMENT_DOMAIN]: {
-          domain: [1, 2], factory: scaleLinear, isDiscrete: false,
-        },
-        [VALUE_DOMAIN]: {
-          domain: [], factory: scaleLinear, isDiscrete: false,
-        },
-        domain1: {
-          domain: [3, 7], max: 7, factory: scaleLinear, isDiscrete: false,
-        },
-      });
-    });
-
-    it('should ignore min/max for band domain', () => {
-      const domains = computeDomains({
-        ...testDomains,
-        [ARGUMENT_DOMAIN]: { factory: scaleBand, min: 1, max: 7 },
-      }, [{
-        getPointTransformer,
-        points: [{ argument: 'one', value: 9 }, { argument: 'two', value: 1 }, { argument: 'three', value: 1 }],
-      }]);
-
-      expect(domains).toEqual({
-        [ARGUMENT_DOMAIN]: {
-          domain: ['one', 'two', 'three'], factory: scaleBand, isDiscrete: true, min: 1, max: 7,
-        },
-        [VALUE_DOMAIN]: {
-          domain: [1, 9], factory: scaleLinear, isDiscrete: false,
-        },
-      });
+      expect(mock).toBeCalledWith([3, 14]);
     });
   });
 

--- a/packages/dx-chart-core/src/plugins/scale/computeds.test.js
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.test.js
@@ -254,7 +254,7 @@ describe('Scale', () => {
       const mock = jest.fn().mockReturnValue([10, 11]);
       const domains = computeDomains({
         ...testDomains,
-        domain1: { customizeDomain: mock },
+        domain1: { modifyDomain: mock },
       }, [{
         scaleName: 'domain1',
         getPointTransformer,
@@ -269,7 +269,7 @@ describe('Scale', () => {
           domain: [], factory: scaleLinear, isDiscrete: false,
         },
         domain1: {
-          domain: [10, 11], customizeDomain: mock, factory: scaleLinear, isDiscrete: false,
+          domain: [10, 11], modifyDomain: mock, factory: scaleLinear, isDiscrete: false,
         },
       });
       expect(mock).toBeCalledWith([3, 14]);

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/bar-line.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/bar-line.jsxt
@@ -25,8 +25,8 @@ const Label = symbol => (props) => {
 const PriceLabel = Label(' $');
 const LabelWithThousand = Label(' k');
 
-const customizeOilDomain = domain => [domain[0], 2200];
-const customizePriceDomain = () => [0, 110];
+const modifyOilDomain = domain => [domain[0], 2200];
+const modifyPriceDomain = () => [0, 110];
 
 export default class Demo extends React.PureComponent {
   constructor(props) {
@@ -45,8 +45,8 @@ export default class Demo extends React.PureComponent {
         <Chart
           data={chartData}
         >
-          <ValueScale name="oil" customizeDomain={customizeOilDomain} />
-          <ValueScale name="price" customizeDomain={customizePriceDomain} />
+          <ValueScale name="oil" modifyDomain={modifyOilDomain} />
+          <ValueScale name="price" modifyDomain={modifyPriceDomain} />
 
           <ArgumentAxis />
           <ValueAxis

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/bar-line.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/bar-line.jsxt
@@ -25,6 +25,9 @@ const Label = symbol => (props) => {
 const PriceLabel = Label(' $');
 const LabelWithThousand = Label(' k');
 
+const customizeOilDomain = domain => [domain[0], 2200];
+const customizePriceDomain = () => [0, 110];
+
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -42,8 +45,8 @@ export default class Demo extends React.PureComponent {
         <Chart
           data={chartData}
         >
-          <ValueScale name="oil" max={2200} />
-          <ValueScale name="price" min={0} max={110} />
+          <ValueScale name="oil" customizeDomain={customizeOilDomain} />
+          <ValueScale name="price" customizeDomain={customizePriceDomain} />
 
           <ArgumentAxis />
           <ValueAxis

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/logarithm.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/logarithm.jsxt
@@ -37,7 +37,7 @@ const Point = (props) => {
 };
 
 const scale = () => scaleLog().base(2);
-const customizeDomain = domain => [domain[0], 5000e24];
+const modifyDomain = domain => [domain[0], 5000e24];
 
 const format = obj => obj.tickFormat(null, formatPrefix('.1', 1e24));
 
@@ -58,7 +58,7 @@ export default class Demo extends React.PureComponent {
         <Chart
           data={chartData}
         >
-          <ValueScale factory={scale} customizeDomain={customizeDomain} />
+          <ValueScale factory={scale} modifyDomain={modifyDomain} />
           <ArgumentAxis />
           <ValueAxis
             tickFormat={format}

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/logarithm.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/logarithm.jsxt
@@ -37,6 +37,7 @@ const Point = (props) => {
 };
 
 const scale = () => scaleLog().base(2);
+const customizeDomain = domain => [domain[0], 5000e24];
 
 const format = obj => obj.tickFormat(null, formatPrefix('.1', 1e24));
 
@@ -57,7 +58,7 @@ export default class Demo extends React.PureComponent {
         <Chart
           data={chartData}
         >
-          <ValueScale factory={scale} max={5000e24} />
+          <ValueScale factory={scale} customizeDomain={customizeDomain} />
           <ArgumentAxis />
           <ValueAxis
             tickFormat={format}

--- a/packages/dx-react-chart-demos/src/demo-sources/combination/multiple-axes.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/combination/multiple-axes.jsxt
@@ -79,9 +79,13 @@ const TooltipContent = ({ text, ...restProps }) => (
   />
 );
 
+const titleStyle = { marginRight: '120px' };
 const stacks = [
   { series: ['USA', 'Saudi Arabia', 'Iran', 'Mexico', 'Russia'] },
 ];
+
+const modifyOilDomain = domain => [domain[0], 2200];
+const modifyPriceDomain = () => [0, 110];
 
 export default class Demo extends React.PureComponent {
   constructor(props) {
@@ -112,12 +116,11 @@ export default class Demo extends React.PureComponent {
         >
           <ValueScale
             name="oil"
-            max={2200}
+            modifyDomain={modifyOilDomain}
           />
           <ValueScale
             name="price"
-            min={0}
-            max={110}
+            modifyDomain={modifyPriceDomain}
           />
 
           <ArgumentAxis />
@@ -133,7 +136,7 @@ export default class Demo extends React.PureComponent {
 
           <Title
             text="Oil production vs Oil price"
-            style={{ marginRight: '120px' }}
+            style={titleStyle}
           />
 
           <BarSeries

--- a/packages/dx-react-chart-demos/src/demo-sources/line-chart/axes-types.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/line-chart/axes-types.jsxt
@@ -11,7 +11,7 @@ import { scaleLog, scaleTime } from 'd3-scale';
 
 import { bitcoin as data } from '../../../demo-data/data-vizualization';
 
-const customizeDomain = () => [100, 100000];
+const modifyDomain = () => [100, 100000];
 
 const superscript = '⁰¹²³⁴⁵⁶⁷⁸⁹';
 const formatPower = d => (`${d}`).split('').map(c => superscript[c]).join('');
@@ -36,7 +36,7 @@ export default class Demo extends React.PureComponent {
           data={chartData}
         >
           <ArgumentScale factory={scaleTime} />
-          <ValueScale factory={scaleLog} customizeDomain={customizeDomain} />
+          <ValueScale factory={scaleLog} modifyDomain={modifyDomain} />
           <ArgumentAxis />
           <ValueAxis tickFormat={format} />
 

--- a/packages/dx-react-chart-demos/src/demo-sources/line-chart/axes-types.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/line-chart/axes-types.jsxt
@@ -11,6 +11,8 @@ import { scaleLog, scaleTime } from 'd3-scale';
 
 import { bitcoin as data } from '../../../demo-data/data-vizualization';
 
+const customizeDomain = () => [100, 100000];
+
 const superscript = '⁰¹²³⁴⁵⁶⁷⁸⁹';
 const formatPower = d => (`${d}`).split('').map(c => superscript[c]).join('');
 const format = scale => scale.tickFormat(4, d => 10
@@ -34,7 +36,7 @@ export default class Demo extends React.PureComponent {
           data={chartData}
         >
           <ArgumentScale factory={scaleTime} />
-          <ValueScale factory={scaleLog} min={100} max={100000} />
+          <ValueScale factory={scaleLog} customizeDomain={customizeDomain} />
           <ArgumentAxis />
           <ValueAxis tickFormat={format} />
 

--- a/packages/dx-react-chart/docs/reference/argument-scale.md
+++ b/packages/dx-react-chart/docs/reference/argument-scale.md
@@ -17,7 +17,7 @@ import { ArgumentScale } from '@devexpress/dx-react-chart';
 Name | Type | Default | Description
 -----|------|---------|------------
 factory? | () => [ScaleObject](#scaleobject) | | A function that constructs a custom scale.
-modifyDomain? | (domain: Array&lt;any&gt;) => Array&lt;any&gt; | | A function that modifies scale domain.
+modifyDomain? | (domain: Array&lt;any&gt;) => Array&lt;any&gt; | | A function that modifies the scale domain.
 
 ## Interfaces
 

--- a/packages/dx-react-chart/docs/reference/argument-scale.md
+++ b/packages/dx-react-chart/docs/reference/argument-scale.md
@@ -17,8 +17,7 @@ import { ArgumentScale } from '@devexpress/dx-react-chart';
 Name | Type | Default | Description
 -----|------|---------|------------
 factory? | () => [ScaleObject](#scaleobject) | | A function that constructs a custom scale.
-min? | number | | The scale' minimum value.
-max? | number | | The scale' maximum value.
+modifyDomain? | (domain: Array&lt;any&gt;) => Array&lt;any&gt; | | A function that modifies scale domain.
 
 ## Interfaces
 

--- a/packages/dx-react-chart/docs/reference/value-scale.md
+++ b/packages/dx-react-chart/docs/reference/value-scale.md
@@ -18,5 +18,4 @@ Name | Type | Default | Description
 -----|------|---------|------------
 name? | string | | The scale's name.
 factory? | () => [ScaleObject](./argument-scale.md#scaleobject) | | A function that constructs a custom scale.
-min? | number | | The scale's minimum value.
-max? | number | | The scale's maximum value.
+modifyDomain? | (domain: Array&lt;any&gt;) => Array&lt;any&gt; | | A function that modifies scale domain.

--- a/packages/dx-react-chart/docs/reference/value-scale.md
+++ b/packages/dx-react-chart/docs/reference/value-scale.md
@@ -18,4 +18,4 @@ Name | Type | Default | Description
 -----|------|---------|------------
 name? | string | | The scale's name.
 factory? | () => [ScaleObject](./argument-scale.md#scaleobject) | | A function that constructs a custom scale.
-modifyDomain? | (domain: Array&lt;any&gt;) => Array&lt;any&gt; | | A function that modifies scale domain.
+modifyDomain? | (domain: Array&lt;any&gt;) => Array&lt;any&gt; | | A function that modifies the scale domain.

--- a/packages/dx-react-chart/src/plugins/scale.jsx
+++ b/packages/dx-react-chart/src/plugins/scale.jsx
@@ -6,8 +6,8 @@ import { withPatchedProps } from '../utils';
 
 export class Scale extends React.PureComponent {
   render() {
-    const { name, factory, customizeDomain } = this.props;
-    const args = { factory, customizeDomain };
+    const { name, factory, modifyDomain } = this.props;
+    const args = { factory, modifyDomain };
     const getDomains = ({ domains }) => addDomain(domains, name, args);
     return (
       <Plugin name="Scale">
@@ -20,12 +20,12 @@ export class Scale extends React.PureComponent {
 Scale.propTypes = {
   name: PropTypes.string.isRequired,
   factory: PropTypes.func,
-  customizeDomain: PropTypes.func,
+  modifyDomain: PropTypes.func,
 };
 
 Scale.defaultProps = {
   factory: undefined,
-  customizeDomain: undefined,
+  modifyDomain: undefined,
 };
 
 export const ArgumentScale = withPatchedProps(props => ({

--- a/packages/dx-react-chart/src/plugins/scale.jsx
+++ b/packages/dx-react-chart/src/plugins/scale.jsx
@@ -6,10 +6,8 @@ import { withPatchedProps } from '../utils';
 
 export class Scale extends React.PureComponent {
   render() {
-    const {
-      name, min, max, factory,
-    } = this.props;
-    const args = { min, max, factory };
+    const { name, factory, customizeDomain } = this.props;
+    const args = { factory, customizeDomain };
     const getDomains = ({ domains }) => addDomain(domains, name, args);
     return (
       <Plugin name="Scale">
@@ -21,15 +19,13 @@ export class Scale extends React.PureComponent {
 
 Scale.propTypes = {
   name: PropTypes.string.isRequired,
-  min: PropTypes.number,
-  max: PropTypes.number,
   factory: PropTypes.func,
+  customizeDomain: PropTypes.func,
 };
 
 Scale.defaultProps = {
-  min: undefined,
-  max: undefined,
   factory: undefined,
+  customizeDomain: undefined,
 };
 
 export const ArgumentScale = withPatchedProps(props => ({

--- a/packages/dx-react-chart/src/plugins/scale.test.jsx
+++ b/packages/dx-react-chart/src/plugins/scale.test.jsx
@@ -21,54 +21,41 @@ describe('Scale', () => {
   };
 
   it('should update domains', () => {
-    const mock = () => 0;
+    const mockFactory = () => 0;
+    const mockCustomize = () => 0;
     const tree = mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <Scale name="scale-1" min={1} max={2} factory={mock} />
+        <Scale name="scale-1" factory={mockFactory} customizeDomain={mockCustomize} />
       </PluginHost>
     ));
 
-    expect(getComputedState(tree)).toEqual({
-      domains: 'added-domains',
-    });
-    expect(addDomain).toBeCalledWith('test-domains', 'scale-1', { min: 1, max: 2, factory: mock });
-  });
-
-  it('should handle *constructor* keyword case', () => {
-    const tree = mount((
-      <PluginHost>
-        {pluginDepsToComponents(defaultDeps)}
-        <Scale name="scale-1" min={1} />
-      </PluginHost>
-    ));
-
-    expect(getComputedState(tree)).toEqual({
-      domains: 'added-domains',
-    });
-    expect(addDomain).toBeCalledWith('test-domains', 'scale-1', { min: 1 });
+    expect(getComputedState(tree)).toEqual({ domains: 'added-domains' });
+    expect(addDomain).toBeCalledWith(
+      'test-domains', 'scale-1', { factory: mockFactory, customizeDomain: mockCustomize },
+    );
   });
 
   it('should add argument scale', () => {
     mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <ArgumentScale name="scale-1" min={1} />
+        <ArgumentScale name="scale-1" />
       </PluginHost>
     ));
 
-    expect(addDomain).toBeCalledWith('test-domains', 'test_argument', { min: 1 });
+    expect(addDomain).toBeCalledWith('test-domains', 'test_argument', { });
   });
 
   it('should add value scale', () => {
     mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <ValueScale name="scale-1" max={2} />
+        <ValueScale name="scale-1" />
       </PluginHost>
     ));
 
-    expect(addDomain).toBeCalledWith('test-domains', 'test_value', { max: 2 });
+    expect(addDomain).toBeCalledWith('test-domains', 'test_value', { });
     expect(getValueDomainName).toBeCalledWith('scale-1');
   });
 });

--- a/packages/dx-react-chart/src/plugins/scale.test.jsx
+++ b/packages/dx-react-chart/src/plugins/scale.test.jsx
@@ -22,17 +22,17 @@ describe('Scale', () => {
 
   it('should update domains', () => {
     const mockFactory = () => 0;
-    const mockCustomize = () => 0;
+    const mockModify = () => 0;
     const tree = mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <Scale name="scale-1" factory={mockFactory} customizeDomain={mockCustomize} />
+        <Scale name="scale-1" factory={mockFactory} modifyDomain={mockModify} />
       </PluginHost>
     ));
 
     expect(getComputedState(tree)).toEqual({ domains: 'added-domains' });
     expect(addDomain).toBeCalledWith(
-      'test-domains', 'scale-1', { factory: mockFactory, customizeDomain: mockCustomize },
+      'test-domains', 'scale-1', { factory: mockFactory, modifyDomain: mockModify },
     );
   });
 


### PR DESCRIPTION
Add `modifyDomain` scale property. Removes `min` and `max` scale properties.

BREAKING CHANGES:

The `min` and `max` scale properties are replaced with the `modifyDomain` property because the *band* scale domain cannot be customized in *min* and *max* terms.

Replace this

```javascript
<ArgumentScale min={0} max={10} ... />
```

with this

```javascript
const modifyDomain = () => [0, 10];

<ArgumentScale modifyDomain={modifyDomain} ... />
```