### PR TITLE
chore(site): fix Algolia Docsearch

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -28,3 +28,5 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+# Configure sitemap
+gem 'jekyll-sitemap'

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       sass (~> 3.4)
     jekyll-seo-tag (2.5.0)
       jekyll (~> 3.3)
+    jekyll-sitemap (1.2.0)
+      jekyll (~> 3.3)
     jekyll-watch (2.0.0)
       listen (~> 3.0)
     kramdown (1.17.0)
@@ -81,11 +83,12 @@ DEPENDENCIES
   jekyll-feed (~> 0.6)
   jekyll-redirect-from (~> 0.12.1)
   jekyll-relative-links (~> 0.5.3)
+  jekyll-sitemap
   minima (~> 2.0)
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.4.4p296
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -2,18 +2,25 @@ title: DevExtreme Reactive Components
 baseurl: "/devextreme-reactive"
 version: "X.X.X"
 
+url: "https://devexpress.github.io/devextreme-reactive/" # uses for configure sitemap
 markdown: kramdown
 plugins:
   - jekyll-feed
   - jekyll-relative-links
   - jekyll-redirect-from
+  - jekyll-sitemap
 exclude:
   - Gemfile
   - Gemfile.lock
 
+
 permalink: pretty
 
 defaults:
+  - scope:
+      path: "vue/*"
+    values:
+      sitemap: false
   - scope:
       path: ""
       type: pages

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -2,7 +2,7 @@ title: DevExtreme Reactive Components
 baseurl: "/devextreme-reactive"
 version: "X.X.X"
 
-url: "https://devexpress.github.io/devextreme-reactive/" # uses for configure sitemap
+url: "https://devexpress.github.io/devextreme-reactive/" # used for configure sitemap
 markdown: kramdown
 plugins:
   - jekyll-feed

--- a/site/_layouts/docs.html
+++ b/site/_layouts/docs.html
@@ -53,6 +53,7 @@ layout: default
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 {% assign product_link_parts = page.product_link | split: "/" %}
 <script type="text/javascript">
+  debugger
   docsearch({
     apiKey: '4cd7a76d4bc286ae69fe26182a8d4b18',
     indexName: 'devextreme_reactive',

--- a/site/_layouts/docs.html
+++ b/site/_layouts/docs.html
@@ -50,15 +50,12 @@ layout: default
 </div>
 
 <script src="{{site.baseurl}}{{page.demos_script_link}}/dist/index.js?v={{ site.time | date: '%s' }}"></script>
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 {% assign product_link_parts = page.product_link | split: "/" %}
-<script type="text/javascript">
-  debugger
-  docsearch({
-    apiKey: '4cd7a76d4bc286ae69fe26182a8d4b18',
-    indexName: 'devextreme_reactive',
-    inputSelector: '#docsearch',
-    algoliaOptions: { 'facetFilters': ["techno:{{product_link_parts[1]}}", "tool:{{product_link_parts[2]}}"] },
-    debug: false
-  });
+<script
+  type="text/javascript"
+  src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
+  onload="docsearch({ apiKey: '4cd7a76d4bc286ae69fe26182a8d4b18', indexName: 'devextreme_reactive', inputSelector: '#docsearch', algoliaOptions: { 'facetFilters': ['techno:{{product_link_parts[1]}}', 'tool: {{product_link_parts[2]}}'] }, debug: false })"
+  async
+>
+</script>
 </script>

--- a/site/_layouts/docs.html
+++ b/site/_layouts/docs.html
@@ -54,7 +54,13 @@ layout: default
 <script
   type="text/javascript"
   src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
-  onload="docsearch({ apiKey: '4cd7a76d4bc286ae69fe26182a8d4b18', indexName: 'devextreme_reactive', inputSelector: '#docsearch', algoliaOptions: { 'facetFilters': ['techno:{{product_link_parts[1]}}', 'tool: {{product_link_parts[2]}}'] }, debug: false })"
+  onload="docsearch({
+    apiKey: '4cd7a76d4bc286ae69fe26182a8d4b18',
+    indexName: 'devextreme_reactive',
+    inputSelector: '#docsearch',
+    algoliaOptions: { 'facetFilters': ['techno:{{product_link_parts[1]}}', 'tool: {{product_link_parts[2]}}'] },
+    debug: false
+  })"
   async
 >
 </script>


### PR DESCRIPTION
I think we should add sitemap because
- algolia [advises](https://community.algolia.com/docsearch/recommended-configuration.html) add sitemap
- SEO advises add sitemap


About `priority` in sitemap https://github.com/jekyll/jekyll-sitemap/issues/196#issuecomment-341798669