### PR TITLE
fix(react-grid): stretch table container to a container size

### DIFF
--- a/packages/dx-react-grid-bootstrap3/src/templates/table-container.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-container.jsx
@@ -11,6 +11,7 @@ export const TableContainer = ({
   <div
     className={classNames('table-responsive', className)}
     style={{
+      flex: 1,
       overflow: 'auto',
       WebkitOverflowScrolling: 'touch',
       border: 0,

--- a/packages/dx-react-grid-material-ui/src/templates/table-container.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-container.jsx
@@ -5,6 +5,7 @@ import { withStyles } from '@material-ui/core/styles';
 
 const styles = {
   root: {
+    flex: 1,
     overflow: 'auto',
     WebkitOverflowScrolling: 'touch',
     // NOTE: fix sticky positioning in Safari

--- a/packages/dx-styles/dx-grid-bs4.css
+++ b/packages/dx-styles/dx-grid-bs4.css
@@ -70,6 +70,7 @@ span.dx-g-bs4-group-panel-item-icon {
   bottom: 0;
 }
 .dx-g-bs4-table-container {
+  flex: 1;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
fixes #1795 