### PR TITLE
fix(react-chart): fix-event-handlers-in-safari

### DIFF
--- a/packages/dx-chart-core/src/utils/event-tracker.js
+++ b/packages/dx-chart-core/src/utils/event-tracker.js
@@ -57,14 +57,26 @@ const buildLeaveEventHandler = handlers => (e) => {
   handlers.forEach(handler => handler(arg));
 };
 
+// The result is of Map<string, Function> type.
+// Keys are DOM event names (https://developer.mozilla.org/en-US/docs/Web/Events).
 export const buildEventHandlers = (seriesList, { clickHandlers, pointerMoveHandlers }) => {
   const handlers = {};
   if (clickHandlers.length) {
     handlers.click = buildEventHandler(seriesList, clickHandlers);
   }
   if (pointerMoveHandlers.length) {
-    handlers.pointermove = buildEventHandler(seriesList, pointerMoveHandlers);
-    handlers.pointerleave = buildLeaveEventHandler(pointerMoveHandlers);
+    const moveHandler = buildEventHandler(seriesList, pointerMoveHandlers);
+    const leaveHandler = buildLeaveEventHandler(pointerMoveHandlers);
+    if ('onpointermove' in window) { // eslint-disable-line no-undef
+      handlers.pointermove = moveHandler;
+      handlers.pointerleave = leaveHandler;
+    } else if ('ontouchmove' in window) { // eslint-disable-line no-undef
+      handlers.touchmove = moveHandler;
+      handlers.touchleave = leaveHandler;
+    } else {
+      handlers.mousemove = moveHandler;
+      handlers.mouseleave = leaveHandler;
+    }
   }
   return handlers;
 };

--- a/packages/dx-chart-core/src/utils/event-tracker.test.js
+++ b/packages/dx-chart-core/src/utils/event-tracker.test.js
@@ -165,7 +165,7 @@ describe('EventTracker', () => {
       });
     });
 
-    it('should create only pointer move handlers', () => {
+    it('should create only move handlers', () => {
       const handlers = buildEventHandlers([series1, series2, series3], {
         clickHandlers: [], pointerMoveHandlers: [1],
       });
@@ -176,7 +176,7 @@ describe('EventTracker', () => {
       });
     });
 
-    it('should raise event on pointer leave', () => {
+    it('should invoke handlers on leave event', () => {
       const { mouseleave } = buildEventHandlers([series1, series2, series3], {
         clickHandlers: [], pointerMoveHandlers: [handler1, handler2],
       });

--- a/packages/dx-chart-core/src/utils/event-tracker.test.js
+++ b/packages/dx-chart-core/src/utils/event-tracker.test.js
@@ -171,16 +171,16 @@ describe('EventTracker', () => {
       });
 
       expect(handlers).toEqual({
-        pointermove: expect.any(Function),
-        pointerleave: expect.any(Function),
+        mousemove: expect.any(Function),
+        mouseleave: expect.any(Function),
       });
     });
 
     it('should raise event on pointer leave', () => {
-      const { pointerleave } = buildEventHandlers([series1, series2, series3], {
+      const { mouseleave } = buildEventHandlers([series1, series2, series3], {
         clickHandlers: [], pointerMoveHandlers: [handler1, handler2],
       });
-      pointerleave({
+      mouseleave({
         clientX: 572,
         clientY: 421,
         currentTarget,
@@ -188,6 +188,38 @@ describe('EventTracker', () => {
 
       expect(handler1).toBeCalledWith({ location: [412, 281], targets: [] });
       expect(handler2).toBeCalledWith({ location: [412, 281], targets: [] });
+    });
+
+    it('should use touch events if available', () => {
+      window.ontouchmove = true; // eslint-disable-line no-undef
+      try {
+        const handlers = buildEventHandlers([series1, series2, series3], {
+          clickHandlers: [], pointerMoveHandlers: [1],
+        });
+
+        expect(handlers).toEqual({
+          touchmove: expect.any(Function),
+          touchleave: expect.any(Function),
+        });
+      } finally {
+        delete window.ontouchmove; // eslint-disable-line no-undef
+      }
+    });
+
+    it('should use pointer events if available', () => {
+      window.onpointermove = true; // eslint-disable-line no-undef
+      try {
+        const handlers = buildEventHandlers([series1, series2, series3], {
+          clickHandlers: [], pointerMoveHandlers: [1],
+        });
+
+        expect(handlers).toEqual({
+          pointermove: expect.any(Function),
+          pointerleave: expect.any(Function),
+        });
+      } finally {
+        delete window.onpointermove; // eslint-disable-line no-undef
+      }
     });
   });
 });

--- a/packages/dx-react-chart/src/plugins/event-tracker.jsx
+++ b/packages/dx-react-chart/src/plugins/event-tracker.jsx
@@ -11,16 +11,22 @@ import { buildEventHandlers } from '@devexpress/dx-chart-core';
 
 const wrapToList = arg => (arg ? [arg] : []);
 
-const EVENT_NAME_MAP = {
+const EVENT_NAME_TO_REACT_MAP = {
   click: 'onClick',
+  mousemove: 'onMouseMove',
+  mouseleave: 'onMouseLeave',
+  touchmove: 'onTouchMove',
+  touchleave: 'onTouchLeave',
   pointermove: 'onPointerMove',
   pointerleave: 'onPointerLeave',
 };
 
+// Translates event names from common space to React.
+// https://developer.mozilla.org/en-US/docs/Web/Events
 const translateEventNames = (handlers) => {
   const result = {};
   Object.entries(handlers).forEach(([name, handler]) => {
-    result[EVENT_NAME_MAP[name]] = handler;
+    result[EVENT_NAME_TO_REACT_MAP[name]] = handler;
   });
   return result;
 };


### PR DESCRIPTION
Handles *mousemove* and *mouseleave* events if either *pointer* or *touch* events are not available.