### PR TITLE
chore: fix demo renderer default props

### DIFF
--- a/packages/dx-demo-shell/src/demo-viewer/demo-renderer.jsx
+++ b/packages/dx-demo-shell/src/demo-viewer/demo-renderer.jsx
@@ -77,7 +77,11 @@ DemoRenderer.propTypes = {
   demoName: PropTypes.string.isRequired,
   themeName: PropTypes.string.isRequired,
   variantName: PropTypes.string.isRequired,
-  perfSamplesCount: PropTypes.number.isRequired,
+  perfSamplesCount: PropTypes.number,
+};
+
+DemoRenderer.defaultProps = {
+  perfSamplesCount: undefined,
 };
 
 DemoRenderer.contextType = EmbeddedDemoContext;


### PR DESCRIPTION
Required property explicitly specified as `undefined` is considered as absent. This PR adds default value for `DemoRenderer.perfSamplesCount` property.