### PR TITLE
refactor(react-chart): move domains Getter to series component

### DIFF
--- a/packages/dx-chart-core/src/plugins/axis/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/axis/computeds.ts
@@ -7,7 +7,7 @@ import {
   GetGridCoordinatesFn,
 } from '../../types';
 
-const getTicks = (scale: ScaleObject): any[] => (scale.ticks ? scale.ticks() : scale.domain());
+const getTicks = (scale: ScaleObject) => (scale.ticks ? scale.ticks() : scale.domain());
 
 const createTicks = <T>(scale: ScaleObject, callback: ProcessTickFn<T>): ReadonlyArray<T> => {
   const fixedScale = fixOffset(scale);

--- a/packages/dx-chart-core/src/plugins/scale/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.ts
@@ -11,6 +11,7 @@ import {
 const makeDomain = ({ factory, modifyDomain }: DomainOptions): DomainInfo => ({
   domain: [],
   factory,
+  isDiscrete: !!(factory && isDiscrete(factory)),
   modifyDomain,
 });
 
@@ -44,7 +45,7 @@ const getArgument: GetItemFn = point => point.argument;
 const getValue: GetItemFn = point => point.value;
 
 /** @internal */
-export const scaleLinear: FactoryFn = d3ScaleLinear;
+export const scaleLinear: FactoryFn = d3ScaleLinear as any;
 /** @internal */
 export const scaleBand: FactoryFn = () => (
   d3ScaleBand().paddingInner(0.3).paddingOuter(0.15) as any
@@ -54,6 +55,8 @@ const guessFactory = (points: PointList, getItem: GetItemFn) => (
   points.length && typeof getItem(points[0]) === 'string' ? scaleBand : scaleLinear
 );
 
+const isDiscrete = (factory: FactoryFn) => 'bandwidth' in factory();
+
 const updateDomainFactory = (domain: DomainInfo, series: Series, getItem: GetItemFn) => {
   if (domain.factory) {
     return domain;
@@ -62,7 +65,7 @@ const updateDomainFactory = (domain: DomainInfo, series: Series, getItem: GetIte
   return {
     ...domain,
     factory,
-    isDiscrete: 'bandwidth' in factory(),
+    isDiscrete: isDiscrete(factory),
   };
 };
 

--- a/packages/dx-chart-core/src/plugins/scale/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.ts
@@ -26,8 +26,6 @@ export const addDomain: AddDomainFn = (domains, name, options) => ({
   [name]: makeDomain(options),
 });
 
-const getSeriesValueDomainName = (series: Series) => getValueDomainName(series.scaleName);
-
 const floatsEqual = (a: number, b: number) => Math.abs(a - b) < Number.EPSILON;
 
 const mergeContinuousDomains: MergeDomainsFn = (domain, items) => {
@@ -98,7 +96,7 @@ const updateDomain = (
 export const extendDomains: ExtendDomainsFn = (domains, series) => {
   const argumentDomain = updateDomain(
     domains[ARGUMENT_DOMAIN], series, getArgument, getArgumentDomainItems);
-  const valueDomainName = getSeriesValueDomainName(series);
+  const valueDomainName = getValueDomainName(series.scaleName);
   const valueDomain = updateDomain(
     domains[valueDomainName], series, getValue, getValueDomainItems);
   const changes = {};

--- a/packages/dx-chart-core/src/plugins/scale/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.ts
@@ -113,10 +113,9 @@ export const buildScales: BuildScalesFn = (domains, { width, height }) => {
   const scales = {};
   Object.keys(domains).forEach((name) => {
     const { factory, domain } = domains[name];
-    const scale = (factory || scaleLinear)();
-    scale.domain(domain);
-    scale.range(isHorizontal(name) ? [0, width] : [height, 0]);
-    scales[name] = scale;
+    scales[name] = (factory || scaleLinear)()
+      .domain(domain)
+      .range(isHorizontal(name) ? [0, width] : [height, 0]);
   });
   return scales;
 };

--- a/packages/dx-chart-core/src/plugins/scale/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.ts
@@ -3,28 +3,27 @@ import { scaleLinear as d3ScaleLinear, scaleBand as d3ScaleBand } from 'd3-scale
 import { isHorizontal, getValueDomainName } from '../../utils/scale';
 import { ARGUMENT_DOMAIN, VALUE_DOMAIN } from '../../constants';
 import {
-  Series, ScaleObject, SeriesList, PointList, DomainItems, DomainInfoCache, BuildScalesFn,
-  AddDomainFn, MergeDomainsFn, GetItemFn, DomainInfo, FactoryFn, ComputeDomainsFn,
+  Series, PointList, DomainItems, DomainInfoCache, BuildScalesFn, DomainInfo, DomainOptions,
+  AddDomainFn, MergeDomainsFn, GetItemFn, GetDomainItemsFn,
+  FactoryFn, ExtendDomainsFn,
 } from '../../types';
+
+const makeDomain = ({ factory, modifyDomain }: DomainOptions): DomainInfo => ({
+  domain: [],
+  factory,
+  modifyDomain,
+});
 
 /** @internal */
 export const defaultDomains: DomainInfoCache = {
-  [ARGUMENT_DOMAIN]: { domain: [] },
-  [VALUE_DOMAIN]: { domain: [] },
+  [ARGUMENT_DOMAIN]: makeDomain({}),
+  [VALUE_DOMAIN]: makeDomain({}),
 };
 /** @internal */
-export const addDomain: AddDomainFn = (domains, name, props) => ({
+export const addDomain: AddDomainFn = (domains, name, options) => ({
   ...domains,
-  [name]: props,
+  [name]: makeDomain(options),
 });
-
-const copy = (domains: DomainInfoCache): DomainInfoCache => {
-  const result = {};
-  Object.keys(domains).forEach((name) => {
-    result[name] = { ...domains[name], domain: [] };
-  });
-  return result;
-};
 
 const getSeriesValueDomainName = (series: Series) => getValueDomainName(series.scaleName);
 
@@ -36,90 +35,78 @@ const mergeDiscreteDomains: MergeDomainsFn = (domain, items) =>
 const getArgument: GetItemFn = point => point.argument;
 const getValue: GetItemFn = point => point.value;
 
-const extendDomain = (target: DomainInfo, items: DomainItems) => {
-  const merge = target.isDiscrete ? mergeDiscreteDomains : mergeContinuousDomains;
-  Object.assign(target, { domain: merge(target.domain, items) });
-};
-
-const calculateDomains = (domains: DomainInfoCache, seriesList: SeriesList) => {
-  seriesList.forEach((seriesItem) => {
-    const valueDomainName = getSeriesValueDomainName(seriesItem);
-    const { points } = seriesItem;
-    // TODO: This is a temporary workaround for Stack plugin.
-    // Once scales (or domains) are exposed for modification Stack will modify scale and
-    // this code will be removed.
-    const valueDomainItems = seriesItem.getValueDomain
-      ? seriesItem.getValueDomain(points) : points.map(getValue);
-    extendDomain(domains[valueDomainName], valueDomainItems);
-    extendDomain(domains[ARGUMENT_DOMAIN], points.map(getArgument));
-  });
-};
 /** @internal */
 export const scaleLinear: FactoryFn = d3ScaleLinear;
 /** @internal */
 export const scaleBand: FactoryFn = () => (
-  d3ScaleBand().paddingInner(0.3).paddingOuter(0.15) as any as ScaleObject
+  d3ScaleBand().paddingInner(0.3).paddingOuter(0.15) as any
 );
 
-const guessFactory = (points: PointList, getItem: GetItemFn) => {
-  if (points.length && typeof getItem(points[0]) === 'string') {
-    return scaleBand as any as FactoryFn;
+const guessFactory = (points: PointList, getItem: GetItemFn) => (
+  points.length && typeof getItem(points[0]) === 'string' ? scaleBand : scaleLinear
+);
+
+const updateDomainFactory = (domain: DomainInfo, series: Series, getItem: GetItemFn) => {
+  if (domain.factory) {
+    return domain;
   }
-  return scaleLinear;
+  const factory = guessFactory(series.points, getItem);
+  return {
+    ...domain,
+    factory,
+    isDiscrete: 'bandwidth' in factory(),
+  };
 };
 
-const collectDomainsFromSeries = (domains: DomainInfoCache, seriesList: SeriesList) => {
-  seriesList.forEach((seriesItem) => {
-    if (!domains[ARGUMENT_DOMAIN].factory) {
-      Object.assign(domains[ARGUMENT_DOMAIN], {
-        factory: guessFactory(seriesItem.points, getArgument),
-      });
-    }
-    const valueDomainName = getSeriesValueDomainName(seriesItem);
-    const obj = domains[valueDomainName];
-    if (!obj.factory) {
-      obj.factory = guessFactory(seriesItem.points, getValue);
-    }
-    // TODO: It is to be removed together with *TODO* from above.
-    if (seriesItem.getPointTransformer.isStartedFromZero && obj.domain.length === 0) {
-      obj.domain = [0];
-    }
-  });
-  Object.keys(domains).forEach((name) => {
-    const obj = domains[name];
-    if (!obj.factory) {
-      obj.factory = scaleLinear;
-    }
-    obj.isDiscrete = !!obj.factory().bandwidth;
-  });
-  return domains;
+const updateDomainItems = (domain: DomainInfo, items: DomainItems): DomainInfo => {
+  const merge = domain.isDiscrete ? mergeDiscreteDomains : mergeContinuousDomains;
+  const merged = merge(domain.domain, items);
+  return {
+    ...domain,
+    domain: domain.modifyDomain ? domain.modifyDomain(merged) : merged,
+  };
 };
 
-const customizeDomains = (domains: DomainInfoCache) => {
-  Object.keys(domains).forEach((name) => {
-    const obj = domains[name];
-    if (obj.modifyDomain) {
-      obj.domain = obj.modifyDomain(obj.domain);
-    }
-  });
+const getArgumentDomainItems: GetDomainItemsFn = series => series.points.map(getArgument);
+
+const getValueDomainItems: GetDomainItemsFn = (series) => {
+  // TODO: This is a temporary workaround for Stack plugin.
+  // Once scales (or domains) are exposed for modification Stack will modify scale and
+  // this code will be removed.
+  const items = series.getValueDomain
+    ? series.getValueDomain(series.points) : series.points.map(getValue);
+  // TODO: It is also a part of that workaround.
+  return series.getPointTransformer.isStartedFromZero ? [0, ...items] : items;
 };
+
+const updateDomain = (
+  domain: DomainInfo, series: Series, getItem: GetItemFn, getDomainItems: GetDomainItemsFn,
+) => updateDomainItems(updateDomainFactory(domain, series, getItem), getDomainItems(series));
 
 /** @internal */
-export const computeDomains: ComputeDomainsFn = (domains, seriesList) => {
-  const result = copy(domains);
-  collectDomainsFromSeries(result, seriesList);
-  calculateDomains(result, seriesList);
-  customizeDomains(result);
-  return result;
+export const extendDomains: ExtendDomainsFn = (domains, series) => {
+  const argumentDomain = updateDomain(
+    domains[ARGUMENT_DOMAIN], series, getArgument, getArgumentDomainItems);
+  const valueDomainName = getSeriesValueDomainName(series);
+  const valueDomain = updateDomain(
+    domains[valueDomainName], series, getValue, getValueDomainItems);
+  const changes = {};
+  if (argumentDomain !== domains[ARGUMENT_DOMAIN]) {
+    changes[ARGUMENT_DOMAIN] = argumentDomain;
+  }
+  if (valueDomain !== domains[valueDomainName]) {
+    changes[valueDomainName] = valueDomain;
+  }
+  return Object.keys(changes).length ? { ...domains, ...changes } : domains;
 };
 
 /** @internal */
 export const buildScales: BuildScalesFn = (domains, { width, height }) => {
   const scales = {};
   Object.keys(domains).forEach((name) => {
-    const obj = domains[name];
-    const scale = obj.factory!();
-    scale.domain(obj.domain);
+    const { factory, domain } = domains[name];
+    const scale = (factory || scaleLinear)();
+    scale.domain(domain);
     scale.range(isHorizontal(name) ? [0, width] : [height, 0]);
     scales[name] = scale;
   });

--- a/packages/dx-chart-core/src/types/chart-core.types.ts
+++ b/packages/dx-chart-core/src/types/chart-core.types.ts
@@ -3,29 +3,33 @@ export type DataItems = ReadonlyArray<DataItem>;
 
 export type DomainItems = ReadonlyArray<any>;
 
+export type NumberArray = [number, number];
+
 // TODO: Find a way to use types from "d3-scale".
 export interface ScaleObject {
   (value: any): number;
   /** A function that returns an array of ticks  */
-  ticks?: (ticks?: number) => DomainItems;
-  /** A function that sets (if the domain parameter is an array) or */
-  /** gets (if the domain parameter is undefined) the current domain. */
-  domain: (domain?: DomainItems) => any;
-  /** A function that returns a tick formatter function. */
-  tickFormat?: (count?: number, format?: string) => GetFormatFn;
-  /** A function that returns each band’s width. */
-  bandwidth?: () => number;
-  /** A function that sets (if the range parameter is an array) or */
-  /** gets (if the range parameter is undefined) the scale’s current range. */
-  range: (range?: DomainItems) => any;
+  ticks?(ticks?: number): DomainItems;
+  /** A function that sets the current domain */
+  domain(domain: DomainItems): this;
+  /** A function that gets the current domain */
+  domain(): DomainItems;
+  /** A function that returns a tick formatter function */
+  tickFormat?(count?: number, format?: string): GetFormatFn;
+  /** A function that returns each band’s width */
+  bandwidth?(): number;
+  /** A function that sets the current range */
+  range(range: NumberArray): this;
+  /** A function that gets the current range */
+  range(): NumberArray;
   /** Returns an exact copy of this scale */
-  copy: () => ScaleObject;
+  copy(): this;
   /** Enables or disables clamping */
-  clamp?: (clamp: boolean) => ScaleObject;
+  clamp?(clamp: boolean): this;
   /** A function that sets a scale’s inner padding and returns the current scale */
-  paddingInner?: (arg: number) => ScaleObject;
+  paddingInner?(arg: number): this;
   /** A function that sets a scale’s outer padding and returns the current scale */
-  paddingOuter?: (arg: number) => ScaleObject;
+  paddingOuter?(arg: number): this;
 }
 
 /** @internal */
@@ -134,7 +138,6 @@ export type PointDistance = {
   readonly index: number,
   readonly distance: number,
 };
-export type NumberArray = [number, number];
 export type Location = Readonly<NumberArray>;
 type HitTestResult = {
   readonly points: ReadonlyArray<PointDistance>;

--- a/packages/dx-chart-core/src/types/plugins.scale.types.ts
+++ b/packages/dx-chart-core/src/types/plugins.scale.types.ts
@@ -1,6 +1,6 @@
 import { PureComputed } from '@devexpress/dx-core';
 import {
-  ScaleObject, DomainItems, ScalesCache, SeriesList, Point,
+  ScaleObject, DomainItems, ScalesCache, Point, Series,
 } from './chart-core.types';
 
 export type FactoryFn = () => ScaleObject;
@@ -8,22 +8,29 @@ export type ModifyDomainFn = (domain: DomainItems) => DomainItems;
 /** @internal */
 export type DomainInfo = {
   readonly modifyDomain?: ModifyDomainFn;
-  domain: DomainItems;
-  factory?: FactoryFn;
-  isDiscrete?: boolean;
+  readonly domain: DomainItems;
+  readonly factory?: FactoryFn;
+  readonly isDiscrete?: boolean;
 };
 /** @internal */
 export type DomainInfoCache = {
   readonly [name: string]: DomainInfo;
 };
 /** @internal */
-export type AddDomainFn = PureComputed<[DomainInfoCache, string, any]>;
+export type DomainOptions = {
+  readonly modifyDomain?: ModifyDomainFn;
+  readonly factory?: FactoryFn;
+};
+/** @internal */
+export type AddDomainFn = PureComputed<[DomainInfoCache, string, DomainOptions]>;
+/** @internal */
+export type ExtendDomainsFn = PureComputed<[DomainInfoCache, Series]>;
 /** @internal */
 export type MergeDomainsFn = (domain: DomainItems, items: DomainItems) => DomainItems;
 /** @internal */
 export type GetItemFn = (point: Point) => any;
 /** @internal */
-export type ComputeDomainsFn = PureComputed<[DomainInfoCache, SeriesList]>;
+export type GetDomainItemsFn = (series: Series) => DomainItems;
 /** @internal */
 export type Layout = {
   width: number;

--- a/packages/dx-chart-core/src/types/plugins.scale.types.ts
+++ b/packages/dx-chart-core/src/types/plugins.scale.types.ts
@@ -10,7 +10,7 @@ export type DomainInfo = {
   readonly modifyDomain?: ModifyDomainFn;
   readonly domain: DomainItems;
   readonly factory?: FactoryFn;
-  readonly isDiscrete?: boolean;
+  readonly isDiscrete: boolean;
 };
 /** @internal */
 export type DomainInfoCache = {

--- a/packages/dx-react-chart/api/dx-react-chart.api.ts
+++ b/packages/dx-react-chart/api/dx-react-chart.api.ts
@@ -270,15 +270,15 @@ interface RawAxisProps {
 interface ScaleObject {
   // (undocumented)
   (value: any): number;
-  bandwidth?: () => number;
-  clamp?: (clamp: boolean) => ScaleObject;
-  copy: () => ScaleObject;
-  domain: (domain?: DomainItems) => any;
-  paddingInner?: (arg: number) => ScaleObject;
-  paddingOuter?: (arg: number) => ScaleObject;
-  range: (range?: DomainItems) => any;
-  tickFormat?: (count?: number, format?: string) => GetFormatFn;
-  ticks?: (ticks?: number) => DomainItems;
+  bandwidth?(): number;
+  clamp?(clamp: boolean): this;
+  copy(): this;
+  domain(domain: DomainItems): this;
+  paddingInner?(arg: number): this;
+  paddingOuter?(arg: number): this;
+  range(range: NumberArray): this;
+  tickFormat?(count?: number, format?: string): GetFormatFn;
+  ticks?(ticks?: number): DomainItems;
 }
 
 // @public (undocumented)
@@ -452,11 +452,11 @@ interface ValueScaleProps extends ScaleProps {
 // WARNING: Unsupported export: DataItem
 // WARNING: Unsupported export: DataItems
 // WARNING: Unsupported export: DomainItems
+// WARNING: Unsupported export: NumberArray
 // WARNING: Unsupported export: TargetList
 // WARNING: Unsupported export: GetFormatFn
 // WARNING: Unsupported export: Colors
 // WARNING: Unsupported export: PointDistance
-// WARNING: Unsupported export: NumberArray
 // WARNING: Unsupported export: Location
 // WARNING: Unsupported export: HitTestResult
 // WARNING: Unsupported export: HitTestFn

--- a/packages/dx-react-chart/src/plugins/area-series.test.tsx
+++ b/packages/dx-react-chart/src/plugins/area-series.test.tsx
@@ -8,6 +8,7 @@ import { AreaSeries } from './area-series';
 jest.mock('@devexpress/dx-chart-core', () => ({
   findSeriesByName: jest.fn(),
   addSeries: jest.fn(),
+  extendDomains: jest.fn(),
   ARGUMENT_DOMAIN: 'test_argument_domain',
   getValueDomainName: () => 'test_value_domain',
   checkZeroStart: jest.fn(),

--- a/packages/dx-react-chart/src/plugins/axis.tsx
+++ b/packages/dx-react-chart/src/plugins/axis.tsx
@@ -24,7 +24,7 @@ const SVG_STYLE: React.CSSProperties = {
 };
 
 const adjustScaleRange = (scale: ScaleObject, [width, height]: NumberArray) => {
-  const range = scale.range().slice();
+  const range = scale.range().slice() as NumberArray;
   if (Math.abs(range[0] - range[1]) < 0.01) {
     return scale;
   }

--- a/packages/dx-react-chart/src/plugins/bar-series.test.tsx
+++ b/packages/dx-react-chart/src/plugins/bar-series.test.tsx
@@ -9,6 +9,7 @@ jest.mock('@devexpress/dx-chart-core', () => ({
   dBar: jest.fn(),
   findSeriesByName: jest.fn(),
   addSeries: jest.fn(),
+  extendDomains: jest.fn(),
   ARGUMENT_DOMAIN: 'test_argument_domain',
   getValueDomainName: () => 'test_value_domain',
 }));

--- a/packages/dx-react-chart/src/plugins/chart-core.test.tsx
+++ b/packages/dx-react-chart/src/plugins/chart-core.test.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { PluginHost } from '@devexpress/dx-react-core';
 import { pluginDepsToComponents, getComputedState } from '@devexpress/dx-testing';
-import { computeDomains, buildScales, scaleSeriesPoints } from '@devexpress/dx-chart-core';
+import { buildScales, scaleSeriesPoints } from '@devexpress/dx-chart-core';
 import { ChartCore } from './chart-core';
 
 jest.mock('@devexpress/dx-chart-core', () => ({
-  computeDomains: jest.fn().mockReturnValue('computed-domains'),
   buildScales: jest.fn().mockReturnValue('built-scales'),
   scaleSeriesPoints: jest.fn().mockReturnValue('scaled-series'),
 }));
@@ -32,12 +31,10 @@ describe('Chart Core', () => {
 
     expect(getComputedState(tree)).toEqual({
       ...defaultDeps.getter,
-      domains: 'computed-domains',
       scales: 'built-scales',
       series: 'scaled-series',
     });
-    expect(computeDomains).toBeCalledWith('test-domains', 'test-series');
-    expect(buildScales).toBeCalledWith('computed-domains', 'test-pane');
+    expect(buildScales).toBeCalledWith('test-domains', 'test-pane');
     expect(scaleSeriesPoints).toBeCalledWith('test-series', 'built-scales');
   });
 });

--- a/packages/dx-react-chart/src/plugins/chart-core.tsx
+++ b/packages/dx-react-chart/src/plugins/chart-core.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
 import { Plugin, Getter, Getters } from '@devexpress/dx-react-core';
-import { computeDomains, buildScales, scaleSeriesPoints } from '@devexpress/dx-chart-core';
-
-const getDomains = ({ domains, series }: Getters) => computeDomains(domains, series);
+import { buildScales, scaleSeriesPoints } from '@devexpress/dx-chart-core';
 
 const getScales = ({ domains, layouts }: Getters) => buildScales(domains, layouts.pane);
 
 const getSeries = ({ series, scales }: Getters) => scaleSeriesPoints(series, scales);
 
-export const ChartCore: React.SFC = () => (
-  <Plugin>
-    <Getter name="domains" computed={getDomains} />
-    <Getter name="scales" computed={getScales} />
-    <Getter name="series" computed={getSeries} />
-  </Plugin>
-);
+export class ChartCore extends React.PureComponent {
+  render() {
+    return (
+      <Plugin>
+        <Getter name="scales" computed={getScales} />
+        <Getter name="series" computed={getSeries} />
+      </Plugin>
+    );
+  }
+}

--- a/packages/dx-react-chart/src/plugins/line-series.test.tsx
+++ b/packages/dx-react-chart/src/plugins/line-series.test.tsx
@@ -8,6 +8,7 @@ import { LineSeries } from './line-series';
 jest.mock('@devexpress/dx-chart-core', () => ({
   findSeriesByName: jest.fn(),
   addSeries: jest.fn(),
+  extendDomains: jest.fn(),
   ARGUMENT_DOMAIN: 'test_argument_domain',
   getValueDomainName: () => 'test_value_domain',
   checkZeroStart: jest.fn(),

--- a/packages/dx-react-chart/src/plugins/pie-series.test.tsx
+++ b/packages/dx-react-chart/src/plugins/pie-series.test.tsx
@@ -8,6 +8,7 @@ import { PieSeries } from './pie-series';
 jest.mock('@devexpress/dx-chart-core', () => ({
   findSeriesByName: jest.fn(),
   addSeries: jest.fn(),
+  extendDomains: jest.fn(),
   ARGUMENT_DOMAIN: 'test_argument_domain',
   getValueDomainName: () => 'test_value_domain',
 }));

--- a/packages/dx-react-chart/src/plugins/scale.test.tsx
+++ b/packages/dx-react-chart/src/plugins/scale.test.tsx
@@ -26,7 +26,7 @@ describe('Scale', () => {
     const tree = mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
-        <Scale name="scale-1" factory={mockFactory} modifyDomain={mockModify as any} />
+        <Scale name="scale-1" factory={mockFactory as any} modifyDomain={mockModify as any} />
       </PluginHost>
     ));
 

--- a/packages/dx-react-chart/src/plugins/scatter-series.test.tsx
+++ b/packages/dx-react-chart/src/plugins/scatter-series.test.tsx
@@ -8,6 +8,7 @@ import { ScatterSeries } from './scatter-series';
 jest.mock('@devexpress/dx-chart-core', () => ({
   findSeriesByName: jest.fn(),
   addSeries: jest.fn(),
+  extendDomains: jest.fn(),
   ARGUMENT_DOMAIN: 'test_argument_domain',
   getValueDomainName: () => 'test_value_domain',
   checkZeroStart: jest.fn(),

--- a/packages/dx-react-chart/src/plugins/spline-series.test.tsx
+++ b/packages/dx-react-chart/src/plugins/spline-series.test.tsx
@@ -8,6 +8,7 @@ import { SplineSeries } from './spline-series';
 jest.mock('@devexpress/dx-chart-core', () => ({
   findSeriesByName: jest.fn(),
   addSeries: jest.fn(),
+  extendDomains: jest.fn(),
   ARGUMENT_DOMAIN: 'test_argument_domain',
   getValueDomainName: () => 'test_value_domain',
   checkZeroStart: jest.fn(),

--- a/packages/dx-react-chart/src/utils/series-helper.test.tsx
+++ b/packages/dx-react-chart/src/utils/series-helper.test.tsx
@@ -1,13 +1,16 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { PluginHost } from '@devexpress/dx-react-core';
-import { findSeriesByName, addSeries, getValueDomainName } from '@devexpress/dx-chart-core';
+import {
+  findSeriesByName, addSeries, extendDomains, getValueDomainName,
+} from '@devexpress/dx-chart-core';
 import { pluginDepsToComponents, getComputedState } from '@devexpress/dx-testing';
 import { declareSeries } from './series-helper';
 
 jest.mock('@devexpress/dx-chart-core', () => ({
   findSeriesByName: jest.fn(),
   addSeries: jest.fn(),
+  extendDomains: jest.fn(),
   ARGUMENT_DOMAIN: 'test_argument_domain',
   getValueDomainName: jest.fn(),
 }));
@@ -43,12 +46,14 @@ describe('#declareSeries', () => {
     styles: 'styles',
   });
   (addSeries as jest.Mock).mockReturnValue('extended-series');
+  (extendDomains as jest.Mock).mockReturnValue('extended-domains');
   (getValueDomainName as jest.Mock).mockReturnValue('value_domain');
 
   afterEach(jest.clearAllMocks);
 
   const defaultDeps = {
     getter: {
+      domains: 'test-domains',
       series: 'test-series',
       data: 'test-data',
       palette: 'test-palette',
@@ -92,7 +97,7 @@ describe('#declareSeries', () => {
     });
   });
 
-  it('should add series to list', () => {
+  it('should add series to list and extend domains', () => {
     const tree = mount((
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
@@ -111,9 +116,12 @@ describe('#declareSeries', () => {
       seriesComponent: TestComponentPath,
       pointComponent: TestComponentPoint,
     }, {});
+    expect(extendDomains)
+      .toBeCalledWith('test-domains', (findSeriesByName as jest.Mock).mock.results[0].value);
     expect(getComputedState(tree)).toEqual({
       ...defaultDeps.getter,
       series: 'extended-series',
+      domains: 'extended-domains',
     });
   });
 

--- a/packages/dx-react-chart/src/utils/series-helper.tsx
+++ b/packages/dx-react-chart/src/utils/series-helper.tsx
@@ -16,10 +16,6 @@ import {
   ExtraSeriesParameters, SeriesProps, PathComponentProps, Scales,
 } from '../types';
 
-const getDomains = ({
-  series, domains,
-}: Getters) => extendDomains(domains, series[series.length - 1]);
-
 /** @internal */
 export const declareSeries = <T extends SeriesProps>(
   pluginName: string,
@@ -54,6 +50,10 @@ export const declareSeries = <T extends SeriesProps>(
         data,
         palette,
       }: Getters) => addSeries(series, data, palette, seriesItem, restProps);
+      const getDomains = ({
+        series,
+        domains
+      }: Getters) => extendDomains(domains, findSeriesByName(symbolName, series));
       return (
         <Plugin name={pluginName}>
           <Getter name="series" computed={getSeries} />

--- a/packages/dx-react-chart/src/utils/series-helper.tsx
+++ b/packages/dx-react-chart/src/utils/series-helper.tsx
@@ -52,7 +52,7 @@ export const declareSeries = <T extends SeriesProps>(
       }: Getters) => addSeries(series, data, palette, seriesItem, restProps);
       const getDomains = ({
         series,
-        domains
+        domains,
       }: Getters) => extendDomains(domains, findSeriesByName(symbolName, series));
       return (
         <Plugin name={pluginName}>

--- a/packages/dx-react-chart/src/utils/series-helper.tsx
+++ b/packages/dx-react-chart/src/utils/series-helper.tsx
@@ -10,11 +10,15 @@ import {
   PluginComponents,
 } from '@devexpress/dx-react-core';
 import {
-  findSeriesByName, addSeries, getValueDomainName, ARGUMENT_DOMAIN,
+  findSeriesByName, addSeries, extendDomains, getValueDomainName, ARGUMENT_DOMAIN,
 } from '@devexpress/dx-chart-core';
 import {
   ExtraSeriesParameters, SeriesProps, PathComponentProps, Scales,
 } from '../types';
+
+const getDomains = ({
+  series, domains,
+}: Getters) => extendDomains(domains, series[series.length - 1]);
 
 /** @internal */
 export const declareSeries = <T extends SeriesProps>(
@@ -53,6 +57,7 @@ export const declareSeries = <T extends SeriesProps>(
       return (
         <Plugin name={pluginName}>
           <Getter name="series" computed={getSeries} />
+          <Getter name="domains" computed={getDomains} />
           <Template name="series">
             <TemplatePlaceholder />
             <TemplateConnector>


### PR DESCRIPTION
The **domains** *Getter* is moved from `ChartCore` to series component.
The behavior is changed as well. Previously all domains were built at once. Now domains are updated every time a series is added.