### PR TITLE
Add material-ui to the list of npm keywords

### DIFF
--- a/packages/dx-react-chart-material-ui/package.json
+++ b/packages/dx-react-chart-material-ui/package.json
@@ -20,6 +20,7 @@
     "chart",
     "d3js",
     "material",
+    "material-ui",
     "react-component"
   ],
   "license": "SEE LICENSE IN README.md",

--- a/packages/dx-react-grid-material-ui/package.json
+++ b/packages/dx-react-grid-material-ui/package.json
@@ -20,6 +20,7 @@
     "grid",
     "table",
     "material",
+    "material-ui",
     "react-component"
   ],
   "license": "SEE LICENSE IN README.md",

--- a/packages/dx-react-scheduler-material-ui/package.json
+++ b/packages/dx-react-scheduler-material-ui/package.json
@@ -18,6 +18,7 @@
     "react",
     "scheduler",
     "material",
+    "material-ui",
     "react-component"
   ],
   "license": "SEE LICENSE IN README.md",


### PR DESCRIPTION
I would like to enable a third-party component search for Material-UI components like Gatsby is doing it with its plugins page: https://www.gatsbyjs.org/plugins/.