### PR TITLE
chore(react-chart): add draft Viewport plugin

### DIFF
--- a/packages/dx-chart-core/src/index.ts
+++ b/packages/dx-chart-core/src/index.ts
@@ -5,6 +5,7 @@ export * from './plugins/series/computeds';
 export * from './plugins/stack/computeds';
 export * from './plugins/animation/computeds';
 export * from './plugins/tooltip/computeds';
+export * from './plugins/viewport/computeds';
 export * from './utils/series';
 export * from './utils/scale';
 export * from './utils/legend';

--- a/packages/dx-chart-core/src/plugins/axis/computeds.test.ts
+++ b/packages/dx-chart-core/src/plugins/axis/computeds.test.ts
@@ -1,5 +1,5 @@
 import { isHorizontal } from '../../utils/scale';
-import { axisCoordinates, getGridCoordinates } from './computeds';
+import { axisCoordinates, getGridCoordinates, createTickFilter } from './computeds';
 
 jest.mock('../../utils/scale', () => ({
   isHorizontal: jest.fn(),
@@ -297,5 +297,21 @@ describe('getGridCoordinates', () => {
         key: '3', x: 0, y: 56, dx: 1, dy: 0,
       },
     ]);
+  });
+});
+
+describe('createTickFilter', () => {
+  it('should filter horizontal ticks', () => {
+    const filter = createTickFilter([10, 0]);
+    expect(filter({ x1: -1, y1: 5 } as any)).toEqual(false);
+    expect(filter({ x1: 4, y1: 5 } as any)).toEqual(true);
+    expect(filter({ x1: 11, y1: 5 } as any)).toEqual(false);
+  });
+
+  it('should filter vertical ticks', () => {
+    const filter = createTickFilter([0, 10]);
+    expect(filter({ x1: 5, y1: -1 } as any)).toEqual(false);
+    expect(filter({ x1: 5, y1: 4 } as any)).toEqual(true);
+    expect(filter({ x1: 5, y1: 11 } as any)).toEqual(false);
   });
 });

--- a/packages/dx-chart-core/src/plugins/axis/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/axis/computeds.ts
@@ -4,7 +4,7 @@ import {
 } from '../../constants';
 import {
   ScaleObject, GetFormatFn, ProcessTickFn, TickFormatFn, AxisCoordinatesFn,
-  GetGridCoordinatesFn,
+  GetGridCoordinatesFn, Tick, NumberArray,
 } from '../../types';
 
 const getTicks = (scale: ScaleObject) => (scale.ticks ? scale.ticks() : scale.domain());
@@ -75,6 +75,14 @@ export const axisCoordinates: AxisCoordinatesFn = ({
     sides: [Number(isHor), Number(!isHor)],
   };
 };
+
+// It is a part of a temporary walkaround. See note in Axis plugin.
+/** @internal */
+export const createTickFilter = ([width, height]: NumberArray) => (
+  width > 0
+    ? (tick: Tick) => tick.x1 >= 0 && tick.x1 <= width
+    : (tick: Tick) => tick.y1 >= 0 && tick.y1 <= height
+);
 
 const horizontalGridOptions = { y: 0, dy: 1 };
 const verticalGridOptions = { x: 0, dx: 1 };

--- a/packages/dx-chart-core/src/plugins/layout-manager/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/layout-manager/computeds.ts
@@ -1,10 +1,14 @@
+import { Size } from '@devexpress/dx-react-core';
 import {
-  BBox, BBoxes, BBoxesChange,
+  ARGUMENT_DOMAIN, VALUE_DOMAIN,
+} from '../../constants';
+import {
+  BBoxes, BBoxesChange, RangesCache,
 } from '../../types';
 
 const isEqual = (
-  { width: firstWidth, height: firstHeight }: BBox,
-  { width: secondWidth, height: secondHeight }: BBox,
+  { width: firstWidth, height: firstHeight }: Size,
+  { width: secondWidth, height: secondHeight }: Size,
 ) => firstWidth === secondWidth && firstHeight === secondHeight;
 
 /** @internal */
@@ -12,3 +16,8 @@ export const bBoxes = (prevBBoxes: BBoxes, { bBox, placeholder }: BBoxesChange) 
   if (isEqual(prevBBoxes[placeholder] || {}, bBox)) return prevBBoxes;
   return { ...prevBBoxes, [placeholder]: bBox };
 };
+
+export const getRanges = (paneSize: Size): RangesCache => ({
+  [ARGUMENT_DOMAIN]: [0, paneSize.width],
+  [VALUE_DOMAIN]: [paneSize.height, 0],
+});

--- a/packages/dx-chart-core/src/plugins/layout-manager/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/layout-manager/computeds.ts
@@ -17,6 +17,7 @@ export const bBoxes = (prevBBoxes: BBoxes, { bBox, placeholder }: BBoxesChange) 
   return { ...prevBBoxes, [placeholder]: bBox };
 };
 
+/** @internal */
 export const getRanges = (paneSize: Size): RangesCache => ({
   [ARGUMENT_DOMAIN]: [0, paneSize.width],
   [VALUE_DOMAIN]: [paneSize.height, 0],

--- a/packages/dx-chart-core/src/plugins/scale/computeds.test.ts
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.test.ts
@@ -294,7 +294,7 @@ describe('Scale', () => {
         'test-domain': { domain: 'test-domain-3', factory: () => mockScale3 },
       }, {
         [ARGUMENT_DOMAIN]: [0, 400],
-        [VALUE_DOMAIN]: [300, 0]
+        [VALUE_DOMAIN]: [300, 0],
       });
 
       expect(scales).toEqual({

--- a/packages/dx-chart-core/src/plugins/scale/computeds.test.ts
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.test.ts
@@ -1,24 +1,10 @@
 import {
-  defaultDomains, addDomain, extendDomains, buildScales, scaleLinear, scaleBand,
+  defaultDomains, addDomain, extendDomains, buildScales,
 } from './computeds';
+import {
+  scaleLinear, scaleBand,
+} from '../../utils/scale';
 import { ARGUMENT_DOMAIN, VALUE_DOMAIN } from '../../constants';
-
-jest.mock('d3-scale', () => ({
-  scaleLinear: () => ({ tag: 'scale-linear' }),
-  scaleBand: () => {
-    const ret = { tag: 'scale-band' } as any;
-    ret.paddingInner = (value) => {
-      ret.inner = value;
-      return ret;
-    };
-    ret.paddingOuter = (value) => {
-      ret.outer = value;
-      return ret;
-    };
-    ret.bandwidth = () => 0;
-    return ret;
-  },
-}));
 
 describe('Scale', () => {
   describe('defaultDomains', () => {
@@ -63,23 +49,6 @@ describe('Scale', () => {
         'domain-1': { tag: '1' },
         'domain-2': { tag: '2' },
         'test-domain': { domain: [], factory, isDiscrete: true },
-      });
-    });
-  });
-
-  describe('default scales', () => {
-    it('should provide linear scale', () => {
-      expect(scaleLinear()).toEqual({ tag: 'scale-linear' });
-    });
-
-    it('should provide band scale', () => {
-      expect(scaleBand()).toEqual({
-        tag: 'scale-band',
-        inner: 0.3,
-        outer: 0.15,
-        paddingInner: expect.any(Function),
-        paddingOuter: expect.any(Function),
-        bandwidth: expect.any(Function),
       });
     });
   });
@@ -323,7 +292,10 @@ describe('Scale', () => {
         [ARGUMENT_DOMAIN]: { domain: 'test-domain-1', factory: () => mockScale1 },
         [VALUE_DOMAIN]: { domain: 'test-domain-2', factory: () => mockScale2 },
         'test-domain': { domain: 'test-domain-3', factory: () => mockScale3 },
-      } as any, { width: 400, height: 300 });
+      }, {
+        [ARGUMENT_DOMAIN]: [0, 400],
+        [VALUE_DOMAIN]: [300, 0]
+      });
 
       expect(scales).toEqual({
         [ARGUMENT_DOMAIN]: mockScale1,

--- a/packages/dx-chart-core/src/plugins/scale/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.ts
@@ -1,6 +1,7 @@
 import { extent } from 'd3-array';
-import { scaleLinear as d3ScaleLinear, scaleBand as d3ScaleBand } from 'd3-scale';
-import { getValueDomainName } from '../../utils/scale';
+import {
+  getValueDomainName, scaleLinear, scaleBand, makeScale,
+} from '../../utils/scale';
 import { ARGUMENT_DOMAIN, VALUE_DOMAIN } from '../../constants';
 import {
   Series, PointList, DomainItems, DomainInfoCache, BuildScalesFn, DomainInfo, DomainOptions,
@@ -41,13 +42,6 @@ const mergeDiscreteDomains: MergeDomainsFn = (domain, items) => {
 
 const getArgument: GetItemFn = point => point.argument;
 const getValue: GetItemFn = point => point.value;
-
-/** @internal */
-export const scaleLinear: FactoryFn = d3ScaleLinear as any;
-/** @internal */
-export const scaleBand: FactoryFn = () => (
-  d3ScaleBand().paddingInner(0.3).paddingOuter(0.15) as any
-);
 
 const guessFactory = (points: PointList, getItem: GetItemFn) => (
   points.length && typeof getItem(points[0]) === 'string' ? scaleBand : scaleLinear
@@ -113,10 +107,10 @@ export const extendDomains: ExtendDomainsFn = (domains, series) => {
 export const buildScales: BuildScalesFn = (domains, ranges) => {
   const scales = {};
   Object.keys(domains).forEach((name) => {
-    const { factory, domain } = domains[name];
-    scales[name] = (factory || scaleLinear)()
-      .domain(domain)
-      .range(ranges[name === ARGUMENT_DOMAIN ? ARGUMENT_DOMAIN : VALUE_DOMAIN] as NumberArray);
+    scales[name] = makeScale(
+      domains[name],
+      ranges[name === ARGUMENT_DOMAIN ? ARGUMENT_DOMAIN : VALUE_DOMAIN] as NumberArray,
+    );
   });
   return scales;
 };

--- a/packages/dx-chart-core/src/plugins/scale/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.ts
@@ -1,11 +1,11 @@
 import { extent } from 'd3-array';
 import { scaleLinear as d3ScaleLinear, scaleBand as d3ScaleBand } from 'd3-scale';
-import { isHorizontal, getValueDomainName } from '../../utils/scale';
+import { getValueDomainName } from '../../utils/scale';
 import { ARGUMENT_DOMAIN, VALUE_DOMAIN } from '../../constants';
 import {
   Series, PointList, DomainItems, DomainInfoCache, BuildScalesFn, DomainInfo, DomainOptions,
   AddDomainFn, MergeDomainsFn, GetItemFn, GetDomainItemsFn,
-  FactoryFn, ExtendDomainsFn,
+  FactoryFn, ExtendDomainsFn, NumberArray,
 } from '../../types';
 
 const makeDomain = ({ factory, modifyDomain }: DomainOptions): DomainInfo => ({
@@ -110,13 +110,13 @@ export const extendDomains: ExtendDomainsFn = (domains, series) => {
 };
 
 /** @internal */
-export const buildScales: BuildScalesFn = (domains, { width, height }) => {
+export const buildScales: BuildScalesFn = (domains, ranges) => {
   const scales = {};
   Object.keys(domains).forEach((name) => {
     const { factory, domain } = domains[name];
     scales[name] = (factory || scaleLinear)()
       .domain(domain)
-      .range(isHorizontal(name) ? [0, width] : [height, 0]);
+      .range(ranges[name === ARGUMENT_DOMAIN ? ARGUMENT_DOMAIN : VALUE_DOMAIN] as NumberArray);
   });
   return scales;
 };

--- a/packages/dx-chart-core/src/plugins/viewport/computeds.test.ts
+++ b/packages/dx-chart-core/src/plugins/viewport/computeds.test.ts
@@ -1,0 +1,133 @@
+import {
+  ARGUMENT_DOMAIN, VALUE_DOMAIN,
+} from '../../constants';
+import {
+  getValueDomainName, makeScale, scaleBounds,
+} from '../../utils/scale';
+import { adjustLayout } from './computeds';
+
+jest.mock('../../utils/scale', () => ({
+  getValueDomainName: jest.fn(),
+  makeScale: jest.fn(),
+  scaleBounds: jest.fn(),
+}));
+
+describe('Viewport', () => {
+  const matchFloat = expected => ({
+    $$typeof: Symbol.for('jest.asymmetricMatcher'),
+
+    asymmetricMatch: actual => Math.abs(actual - expected) < 0.01,
+
+    toAsymmetricMatcher: () => `~${expected}`,
+  });
+
+  describe('adjustLayout', () => {
+    afterEach(jest.clearAllMocks);
+
+    it('should return original ranges', () => {
+      const ranges = { tag: 'test-ranges' };
+
+      const result = adjustLayout('test-domains' as any, ranges as any, {});
+
+      expect(result).toBe(ranges);
+    });
+
+    it('should change only argument range', () => {
+      (makeScale as jest.Mock).mockReturnValueOnce('test-scale');
+      (scaleBounds as jest.Mock).mockReturnValueOnce([20, 50]);
+
+      const result = adjustLayout({
+        [ARGUMENT_DOMAIN]: 'test-domain',
+      } as any, {
+        [ARGUMENT_DOMAIN]: [0, 100],
+        [VALUE_DOMAIN]: 'test-range',
+      } as any, {
+        argumentBounds: 'test-bounds',
+      } as any);
+
+      expect(result).toEqual({
+        [ARGUMENT_DOMAIN]: [matchFloat(-66.67), matchFloat(266.67)],
+        [VALUE_DOMAIN]: 'test-range',
+      });
+      expect(makeScale).toBeCalledWith('test-domain', [0, 100]);
+      expect(scaleBounds).toBeCalledWith('test-scale', 'test-bounds');
+    });
+
+    it('should change only value range', () => {
+      (makeScale as jest.Mock).mockReturnValueOnce('test-scale');
+      (scaleBounds as jest.Mock).mockReturnValueOnce([20, 50]);
+      (getValueDomainName as jest.Mock).mockReturnValueOnce('domain-1');
+
+      const result = adjustLayout({
+        'domain-1': 'test-domain',
+      } as any, {
+        [ARGUMENT_DOMAIN]: 'test-range',
+        [VALUE_DOMAIN]: [0, 100],
+      } as any, {
+        scaleName: 'scale-1',
+        valueBounds: 'test-bounds',
+      } as any);
+
+      expect(result).toEqual({
+        [ARGUMENT_DOMAIN]: 'test-range',
+        [VALUE_DOMAIN]: [matchFloat(-66.67), matchFloat(266.67)],
+      });
+      expect(makeScale).toBeCalledWith('test-domain', [0, 100]);
+      expect(scaleBounds).toBeCalledWith('test-scale', 'test-bounds');
+      expect(getValueDomainName).toBeCalledWith('scale-1');
+    });
+
+    it('should change both ranges', () => {
+      (makeScale as jest.Mock).mockReturnValueOnce('test-arg-scale');
+      (makeScale as jest.Mock).mockReturnValueOnce('test-val-scale');
+      (scaleBounds as jest.Mock).mockReturnValueOnce([250, 350]);
+      (scaleBounds as jest.Mock).mockReturnValueOnce([70, 120]);
+      (getValueDomainName as jest.Mock).mockReturnValueOnce('domain-1');
+
+      const result = adjustLayout({
+        [ARGUMENT_DOMAIN]: 'test-arg-domain',
+        'domain-1': 'test-val-domain',
+      } as any, {
+        [ARGUMENT_DOMAIN]: [200, 400],
+        [VALUE_DOMAIN]: [50, 150],
+      } as any, {
+        argumentBounds: 'test-arg-bounds',
+        scaleName: 'scale-1',
+        valueBounds: 'test-val-bounds',
+      } as any);
+
+      expect(result).toEqual({
+        [ARGUMENT_DOMAIN]: [matchFloat(100), matchFloat(500)],
+        [VALUE_DOMAIN]: [matchFloat(10), matchFloat(210)],
+      });
+      expect((makeScale as jest.Mock).mock.calls).toEqual([
+        ['test-arg-domain', [200, 400]],
+        ['test-val-domain', [50, 150]],
+      ]);
+      expect((scaleBounds as jest.Mock).mock.calls).toEqual([
+        ['test-arg-scale', 'test-arg-bounds'],
+        ['test-val-scale', 'test-val-bounds'],
+      ]);
+      expect(getValueDomainName).toBeCalledWith('scale-1');
+    });
+
+    it('should not change range if it is not actually changed', () => {
+      (makeScale as jest.Mock).mockReturnValueOnce('test-scale');
+      (scaleBounds as jest.Mock).mockReturnValueOnce([0, 100]);
+      const ranges = {
+        [ARGUMENT_DOMAIN]: [0, 100],
+        [VALUE_DOMAIN]: 'test-range',
+      };
+
+      const result = adjustLayout({
+        [ARGUMENT_DOMAIN]: 'test-domain',
+      } as any, ranges as any, {
+        argumentBounds: 'test-bounds',
+      } as any);
+
+      expect(result).toBe(ranges);
+      expect(makeScale).toBeCalledWith('test-domain', [0, 100]);
+      expect(scaleBounds).toBeCalledWith('test-scale', 'test-bounds');
+    });
+  });
+});

--- a/packages/dx-chart-core/src/plugins/viewport/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/viewport/computeds.ts
@@ -1,0 +1,51 @@
+import {
+  ARGUMENT_DOMAIN,
+} from '../../constants';
+import {
+  getValueDomainName,
+} from '../../utils/scale';
+import {
+  DomainInfoCache,
+  DomainInfo,
+  DomainBounds,
+  DomainItems,
+} from '../../types';
+
+const floatsEqual = (a: number, b: number) => Math.abs(a - b) < Number.EPSILON;
+
+const adjustContinuousDomain = (domain: DomainItems, bounds: DomainBounds): DomainItems => (
+  floatsEqual(domain[0], bounds[0]) && floatsEqual(domain[1], bounds[1]) ? domain : bounds.slice()
+);
+
+const adjustDiscreteDomain = (domain: DomainItems, bounds: DomainBounds): DomainItems => {
+  const i = domain.indexOf(bounds[0]);
+  const j = domain.indexOf(bounds[1]);
+  return i > 0 || j < domain.length - 1 ? domain.slice(i, j + 1) : domain;
+};
+
+const adjustDomain = (domain: DomainInfo, bounds: DomainBounds): DomainInfo => {
+  const adjust = domain.isDiscrete ? adjustDiscreteDomain : adjustContinuousDomain;
+  const newItems = adjust(domain.domain, bounds);
+  return newItems === domain.domain ? domain : { ...domain, domain: newItems };
+};
+
+export const adjustDomains = (
+  domains: DomainInfoCache,
+  argumentBounds?: DomainBounds, scaleName?: string, valueBounds?: DomainBounds,
+) => {
+  const changes = {};
+  if (argumentBounds) {
+    const newDomain = adjustDomain(domains[ARGUMENT_DOMAIN], argumentBounds);
+    if (newDomain !== domains[ARGUMENT_DOMAIN]) {
+      changes[ARGUMENT_DOMAIN] = newDomain;
+    }
+  }
+  if (valueBounds) {
+    const valueDomainName = getValueDomainName(scaleName);
+    const newDomain = adjustDomain(domains[valueDomainName], valueBounds);
+    if (newDomain !== domains[valueDomainName]) {
+      changes[valueDomainName] = newDomain;
+    }
+  }
+  return Object.keys(changes).length ? { ...domains, ...changes } : domains;
+};

--- a/packages/dx-chart-core/src/types/index.ts
+++ b/packages/dx-chart-core/src/types/index.ts
@@ -6,6 +6,7 @@ export * from './plugins.scale.types';
 export * from './plugins.layout-manager.types';
 export * from './plugins.axis.types';
 export * from './plugins.animation.types';
+export * from './plugins.viewport.types';
 export * from './utils.event-tracker.types';
 export * from './utils.hover-state.types';
 export * from './utils.legend.types';

--- a/packages/dx-chart-core/src/types/plugins.layout-manager.types.ts
+++ b/packages/dx-chart-core/src/types/plugins.layout-manager.types.ts
@@ -1,14 +1,17 @@
-/** @internal */
-export type BBox = {
-  readonly width: number;
-  readonly height: number;
-};
+import { Size } from '@devexpress/dx-react-core';
+import { NumberArray } from './chart-core.types';
+
 /** @internal */
 export type BBoxes = {
-  readonly [placeholder: string]: BBox;
+  readonly [placeholder: string]: Size;
 };
 /** @internal */
 export type BBoxesChange = {
-  readonly bBox: BBox;
+  readonly bBox: Size;
   readonly placeholder: string;
+};
+
+/** @internal */
+export type RangesCache = {
+  readonly [name: string]: NumberArray;
 };

--- a/packages/dx-chart-core/src/types/plugins.scale.types.ts
+++ b/packages/dx-chart-core/src/types/plugins.scale.types.ts
@@ -2,6 +2,9 @@ import { PureComputed } from '@devexpress/dx-core';
 import {
   ScaleObject, DomainItems, ScalesCache, Point, Series,
 } from './chart-core.types';
+import {
+  RangesCache,
+} from './plugins.layout-manager.types';
 
 export type FactoryFn = () => ScaleObject;
 export type ModifyDomainFn = (domain: DomainItems) => DomainItems;
@@ -32,9 +35,4 @@ export type GetItemFn = (point: Point) => any;
 /** @internal */
 export type GetDomainItemsFn = (series: Series) => DomainItems;
 /** @internal */
-export type Layout = {
-  width: number;
-  height: number;
-};
-/** @internal */
-export type BuildScalesFn = PureComputed<[DomainInfoCache, Layout], ScalesCache>;
+export type BuildScalesFn = PureComputed<[DomainInfoCache, RangesCache], ScalesCache>;

--- a/packages/dx-chart-core/src/types/plugins.viewport.types.ts
+++ b/packages/dx-chart-core/src/types/plugins.viewport.types.ts
@@ -1,7 +1,5 @@
-/** @internal */
 export type DomainBounds = Readonly<[any, any]>;
 
-/** @internal */
 export type ViewportOptions = {
   readonly argumentBounds?: DomainBounds;
   readonly scaleName?: string;

--- a/packages/dx-chart-core/src/types/plugins.viewport.types.ts
+++ b/packages/dx-chart-core/src/types/plugins.viewport.types.ts
@@ -1,0 +1,2 @@
+/** @internal */
+export type DomainBounds = Readonly<[any, any]>;

--- a/packages/dx-chart-core/src/types/plugins.viewport.types.ts
+++ b/packages/dx-chart-core/src/types/plugins.viewport.types.ts
@@ -1,2 +1,9 @@
 /** @internal */
 export type DomainBounds = Readonly<[any, any]>;
+
+/** @internal */
+export type ViewportOptions = {
+  readonly argumentBounds?: DomainBounds;
+  readonly scaleName?: string;
+  readonly valueBounds?: DomainBounds;
+};

--- a/packages/dx-chart-core/src/utils/scale.test.ts
+++ b/packages/dx-chart-core/src/utils/scale.test.ts
@@ -1,5 +1,6 @@
 import {
-  isHorizontal, getWidth, getValueDomainName, fixOffset, scaleLinear, scaleBand,
+  isHorizontal, getWidth, getValueDomainName, fixOffset,
+  scaleLinear, scaleBand, makeScale, scaleBounds,
 } from './scale';
 
 jest.mock('d3-scale', () => ({
@@ -80,5 +81,50 @@ describe('default scales', () => {
       paddingOuter: expect.any(Function),
       bandwidth: expect.any(Function),
     });
+  });
+});
+
+describe('#makeScale', () => {
+  it('should create scale', () => {
+    const mock: { domain?: any, range?: any } = {};
+    mock.domain = jest.fn().mockReturnValue(mock);
+    mock.range = jest.fn().mockReturnValue(mock);
+    const factory = jest.fn().mockReturnValue(mock);
+
+    const scale = makeScale({ factory, domain: 'test-domain' } as any, [10, 20]);
+
+    expect(scale).toBe(mock);
+    expect(factory).toBeCalledWith();
+    expect(mock.domain).toBeCalledWith('test-domain');
+    expect(mock.range).toBeCalledWith([10, 20]);
+  });
+});
+
+describe('#scaleBounds', () => {
+  it('should measure continuous scale', () => {
+    const scale = jest.fn();
+    scale.mockReturnValueOnce(30);
+    scale.mockReturnValueOnce(40);
+
+    const range = scaleBounds(scale as any, [1, 2]);
+
+    expect(range).toEqual([30, 40]);
+    expect(scale.mock.calls).toEqual([
+      [1], [2],
+    ]);
+  });
+
+  it('should measure discrete scale', () => {
+    const scale = jest.fn();
+    scale.mockReturnValueOnce(30);
+    scale.mockReturnValueOnce(40);
+    (scale as any).bandwidth = () => 5;
+
+    const range = scaleBounds(scale as any, [1, 2]);
+
+    expect(range).toEqual([30, 45]);
+    expect(scale.mock.calls).toEqual([
+      [1], [2],
+    ]);
   });
 });

--- a/packages/dx-chart-core/src/utils/scale.test.ts
+++ b/packages/dx-chart-core/src/utils/scale.test.ts
@@ -1,6 +1,23 @@
 import {
-  isHorizontal, getWidth, getValueDomainName, fixOffset,
+  isHorizontal, getWidth, getValueDomainName, fixOffset, scaleLinear, scaleBand,
 } from './scale';
+
+jest.mock('d3-scale', () => ({
+  scaleLinear: () => ({ tag: 'scale-linear' }),
+  scaleBand: () => {
+    const ret = { tag: 'scale-band' } as any;
+    ret.paddingInner = (value) => {
+      ret.inner = value;
+      return ret;
+    };
+    ret.paddingOuter = (value) => {
+      ret.outer = value;
+      return ret;
+    };
+    ret.bandwidth = () => 0;
+    return ret;
+  },
+}));
 
 describe('#isHorizontal', () => {
   it('should consider argument scale horizontal', () => {
@@ -46,5 +63,22 @@ describe('#fixOffset', () => {
     expect(wrapped).not.toBe(mock);
     expect(wrapped(0)).toEqual(2);
     expect(wrapped(3)).toEqual(8);
+  });
+});
+
+describe('default scales', () => {
+  it('should provide linear scale', () => {
+    expect(scaleLinear()).toEqual({ tag: 'scale-linear' });
+  });
+
+  it('should provide band scale', () => {
+    expect(scaleBand()).toEqual({
+      tag: 'scale-band',
+      inner: 0.3,
+      outer: 0.15,
+      paddingInner: expect.any(Function),
+      paddingOuter: expect.any(Function),
+      bandwidth: expect.any(Function),
+    });
   });
 });

--- a/packages/dx-chart-core/src/utils/scale.ts
+++ b/packages/dx-chart-core/src/utils/scale.ts
@@ -1,5 +1,19 @@
-import { ARGUMENT_DOMAIN, VALUE_DOMAIN } from '../constants';
-import { ScaleObject } from '../types';
+import {
+  scaleLinear as d3ScaleLinear, scaleBand as d3ScaleBand,
+} from 'd3-scale';
+import {
+  ARGUMENT_DOMAIN, VALUE_DOMAIN,
+} from '../constants';
+import {
+  ScaleObject, FactoryFn, DomainInfo, NumberArray, DomainBounds,
+} from '../types';
+
+/** @internal */
+export const scaleLinear: FactoryFn = d3ScaleLinear as any;
+/** @internal */
+export const scaleBand: FactoryFn = () => (
+  d3ScaleBand().paddingInner(0.3).paddingOuter(0.15) as any
+);
 
 /** @internal */
 export const isHorizontal = (name: string) => name === ARGUMENT_DOMAIN;
@@ -13,9 +27,20 @@ export const getWidth = (scale: ScaleObject) => (
 export const getValueDomainName = (name?: string) => name || VALUE_DOMAIN;
 
 /** @internal */
-type FixedScaleFn = (value: number) => number;
+export const makeScale = ({ factory, domain }: DomainInfo, range: NumberArray) => (
+  (factory || scaleLinear)().domain(domain).range(range)
+);
+
+// Though this function is used only in *Viewport* plugin (and so should be placed right there),
+// it resides here so that internal scale specifics (*getWidth*)
+// are encapsulated in this utility file.
 /** @internal */
-export const fixOffset = (scale: ScaleObject): FixedScaleFn => {
+export const scaleBounds = (scale: ScaleObject, bounds: DomainBounds): NumberArray => (
+  [scale(bounds[0]), scale(bounds[1]) + getWidth(scale)]
+);
+
+/** @internal */
+export const fixOffset = (scale: ScaleObject): ((value: number) => number) => {
   const offset = getWidth(scale) / 2;
   return offset > 0 ? value => scale(value) + offset : scale;
 };

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/basic.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/basic.jsxt
@@ -1,12 +1,5 @@
 import * as React from 'react';<%&additionalImports%>
 import {
-  Plugin,
-  Getter,
-} from '@devexpress/dx-react-core';
-import {
-  ARGUMENT_DOMAIN,
-} from '@devexpress/dx-chart-core';
-import {
   ArgumentAxis,
   ValueAxis,
   Chart,
@@ -17,106 +10,46 @@ import {
   Title,
 } from '@devexpress/dx-react-chart-<%&themeName%>';
 
-const data = [
-  { arg: 0.2, val: 0.4 },
-  { arg: 1.4, val: 2.3 },
-  { arg: 2.7, val: 3.8 },
-  { arg: 3.2, val: 1.1 },
-  { arg: 4.8, val: 2.8 },
-];
-
-const minRangePosition = 0;
-const maxRangePosition = 5;
-const minRangeSize = 2;
-const maxRangeSize = 10;
-
-const getRange = (position, size) => [position - size / 2, position + size / 2];
-
-const sliderStyle = {
-  width: '400px',
-};
-
-const X1 = ({ domain }) => {
-  const adjustDomain = ({ domains }) => ({
-    ...domains,
-    [ARGUMENT_DOMAIN]: domain,
-  });
-  return (
-    <Plugin name="x1">
-      <Getter name="domains" computed={adjustDomain} />
-    </Plugin>
-  );
-};
-
+import { born as data } from '../../../demo-data/data-vizualization';
 
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.state = {
-      rangePosition: 2,
-      rangeSize: 3,
-    };
-    this.changeRangePosition = (e) => {
-      const value = Number(e.target.value);
-      this.setState(() => (
-        minRangePosition <= value && value <= maxRangePosition ? { rangePosition: value } : null
-      ));
-    };
-    this.changeRangeSize = (e) => {
-      const value = Number(e.target.value);
-      this.setState(() => (
-        minRangeSize <= value && value <= maxRangeSize ? { rangeSize: value } : null
-      ));
-    };
-  }
 
-  static getDerivedStateFromProps(props, { rangePosition, rangeSize }) {
-    return {
-      domain: getRange(rangePosition, rangeSize),
+    this.state = {
+      data,
     };
   }
 
   render() {
+    const { data: chartData } = this.state;
+
     return (
       <<%&wrapperTag%><%&wrapperAttributes%>>
         <Chart
-          data={data}
+          data={chartData}
         >
           <Title text="Born amount" />
-          <ArgumentAxis />
+          <Legend placeholder="right" />
+          <ArgumentAxis position="top" />
           <ValueAxis />
 
           <LineSeries
             name="Russia"
-            valueField="val"
-            argumentField="arg"
+            valueField="ru"
+            argumentField="year"
           />
-
-          <X1 domain={this.state.domain} />
+          <SplineSeries
+            name="China"
+            valueField="ch"
+            argumentField="year"
+          />
+          <AreaSeries
+            name="USA"
+            valueField="us"
+            argumentField="year"
+          />
         </Chart>
-
-        <div>
-          <div>
-            <input
-              type="range"
-              id="range-position"
-              style={sliderStyle}
-              min={minRangePosition} max={maxRangePosition} step={0.1}
-              value={this.state.rangePosition} onChange={this.changeRangePosition}
-            />
-            <label htmlFor="range-position">Position</label>
-          </div>
-          <div>
-            <input
-              type="range"
-              id="range-size"
-              style={sliderStyle}
-              min={minRangeSize} max={maxRangeSize} step={0.1}
-              value={this.state.rangeSize} onChange={this.changeRangeSize}
-            />
-            <label htmlFor="range-size">Size</label>
-          </div>
-        </div>
       </<%&wrapperTag%>>
     );
   }

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/basic.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/basic.jsxt
@@ -1,7 +1,11 @@
 import * as React from 'react';<%&additionalImports%>
 import {
-  ArgumentScale,
-} from '@devexpress/dx-react-chart';
+  Plugin,
+  Getter,
+} from '@devexpress/dx-react-core';
+import {
+  ARGUMENT_DOMAIN,
+} from '@devexpress/dx-chart-core';
 import {
   ArgumentAxis,
   ValueAxis,
@@ -32,6 +36,19 @@ const sliderStyle = {
   width: '400px',
 };
 
+const X1 = ({ domain }) => {
+  const adjustDomain = ({ domains }) => ({
+    ...domains,
+    [ARGUMENT_DOMAIN]: domain,
+  });
+  return (
+    <Plugin name="x1">
+      <Getter name="domains" computed={adjustDomain} />
+    </Plugin>
+  );
+};
+
+
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -51,9 +68,11 @@ export default class Demo extends React.PureComponent {
         minRangeSize <= value && value <= maxRangeSize ? { rangeSize: value } : null
       ));
     };
-    this.modifyArgumentDomain = () => {
-      const { rangePosition, rangeSize } = this.state;
-      return getRange(rangePosition, rangeSize);
+  }
+
+  static getDerivedStateFromProps(props, { rangePosition, rangeSize }) {
+    return {
+      domain: getRange(rangePosition, rangeSize),
     };
   }
 
@@ -64,7 +83,6 @@ export default class Demo extends React.PureComponent {
           data={data}
         >
           <Title text="Born amount" />
-          <ArgumentScale modifyDomain={this.modifyArgumentDomain} />
           <ArgumentAxis />
           <ValueAxis />
 
@@ -73,6 +91,8 @@ export default class Demo extends React.PureComponent {
             valueField="val"
             argumentField="arg"
           />
+
+          <X1 domain={this.state.domain} />
         </Chart>
 
         <div>

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/basic.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/basic.jsxt
@@ -10,46 +10,78 @@ import {
   Title,
 } from '@devexpress/dx-react-chart-<%&themeName%>';
 
-import { born as data } from '../../../demo-data/data-vizualization';
+const data = [
+  { arg: 0.2, val: 0.4 },
+  { arg: 1.4, val: 2.3 },
+  { arg: 2.7, val: 3.8 },
+  { arg: 3.2, val: 1.1 },
+  { arg: 4.8, val: 2.8 },
+];
+
+const initialRangeStart = 0;
+const initialRangeEnd = 10;
+const minRangeDelta = 2;
+
+const sliderStyle = {
+  width: '400px',
+};
 
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
-
     this.state = {
-      data,
+      rangeStart: initialRangeStart,
+      rangeEnd: initialRangeEnd,
+    };
+    this.changeRangeStart = (e) => {
+      const value = Number(e.target.value);
+      this.setState(({ rangeEnd }) => (
+        value < rangeEnd - minRangeDelta ? { rangeStart: value } : null
+      ));
+    };
+    this.changeRangeEnd = (e) => {
+      const value = Number(e.target.value);
+      this.setState(({ rangeStart }) => (
+        value > rangeStart + minRangeDelta ? { rangeEnd: value } : null
+      ));
     };
   }
 
   render() {
-    const { data: chartData } = this.state;
-
     return (
       <<%&wrapperTag%><%&wrapperAttributes%>>
         <Chart
-          data={chartData}
+          data={data}
         >
           <Title text="Born amount" />
-          <Legend placeholder="right" />
-          <ArgumentAxis position="top" />
+          <ArgumentAxis />
           <ValueAxis />
 
           <LineSeries
             name="Russia"
-            valueField="ru"
-            argumentField="year"
-          />
-          <SplineSeries
-            name="China"
-            valueField="ch"
-            argumentField="year"
-          />
-          <AreaSeries
-            name="USA"
-            valueField="us"
-            argumentField="year"
+            valueField="val"
+            argumentField="arg"
           />
         </Chart>
+
+        <div>
+          <div>
+            <input
+              type="range"
+              style={sliderStyle}
+              min={initialRangeStart} max={initialRangeEnd} step={0.1}
+              value={this.state.rangeStart} onChange={this.changeRangeStart}
+            />
+          </div>
+          <div>
+            <input
+              type="range"
+              style={sliderStyle}
+              min={initialRangeStart} max={initialRangeEnd} step={0.1}
+              value={this.state.rangeEnd} onChange={this.changeRangeEnd}
+            />
+          </div>
+        </div>
       </<%&wrapperTag%>>
     );
   }

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/basic.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/basic.jsxt
@@ -1,5 +1,8 @@
 import * as React from 'react';<%&additionalImports%>
 import {
+  ArgumentScale,
+} from '@devexpress/dx-react-chart';
+import {
   ArgumentAxis,
   ValueAxis,
   Chart,
@@ -18,9 +21,12 @@ const data = [
   { arg: 4.8, val: 2.8 },
 ];
 
-const initialRangeStart = 0;
-const initialRangeEnd = 10;
-const minRangeDelta = 2;
+const minRangePosition = 0;
+const maxRangePosition = 5;
+const minRangeSize = 2;
+const maxRangeSize = 10;
+
+const getRange = (position, size) => [position - size / 2, position + size / 2];
 
 const sliderStyle = {
   width: '400px',
@@ -30,20 +36,24 @@ export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      rangeStart: initialRangeStart,
-      rangeEnd: initialRangeEnd,
+      rangePosition: 2,
+      rangeSize: 3,
     };
-    this.changeRangeStart = (e) => {
+    this.changeRangePosition = (e) => {
       const value = Number(e.target.value);
-      this.setState(({ rangeEnd }) => (
-        value < rangeEnd - minRangeDelta ? { rangeStart: value } : null
+      this.setState(() => (
+        minRangePosition <= value && value <= maxRangePosition ? { rangePosition: value } : null
       ));
     };
-    this.changeRangeEnd = (e) => {
+    this.changeRangeSize = (e) => {
       const value = Number(e.target.value);
-      this.setState(({ rangeStart }) => (
-        value > rangeStart + minRangeDelta ? { rangeEnd: value } : null
+      this.setState(() => (
+        minRangeSize <= value && value <= maxRangeSize ? { rangeSize: value } : null
       ));
+    };
+    this.modifyArgumentDomain = () => {
+      const { rangePosition, rangeSize } = this.state;
+      return getRange(rangePosition, rangeSize);
     };
   }
 
@@ -54,6 +64,7 @@ export default class Demo extends React.PureComponent {
           data={data}
         >
           <Title text="Born amount" />
+          <ArgumentScale modifyDomain={this.modifyArgumentDomain} />
           <ArgumentAxis />
           <ValueAxis />
 
@@ -68,18 +79,22 @@ export default class Demo extends React.PureComponent {
           <div>
             <input
               type="range"
+              id="range-position"
               style={sliderStyle}
-              min={initialRangeStart} max={initialRangeEnd} step={0.1}
-              value={this.state.rangeStart} onChange={this.changeRangeStart}
+              min={minRangePosition} max={maxRangePosition} step={0.1}
+              value={this.state.rangePosition} onChange={this.changeRangePosition}
             />
+            <label htmlFor="range-position">Position</label>
           </div>
           <div>
             <input
               type="range"
+              id="range-size"
               style={sliderStyle}
-              min={initialRangeStart} max={initialRangeEnd} step={0.1}
-              value={this.state.rangeEnd} onChange={this.changeRangeEnd}
+              min={minRangeSize} max={maxRangeSize} step={0.1}
+              value={this.state.rangeSize} onChange={this.changeRangeSize}
             />
+            <label htmlFor="range-size">Size</label>
           </div>
         </div>
       </<%&wrapperTag%>>

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/viewport.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/viewport.jsxt
@@ -1,23 +1,12 @@
 import * as React from 'react';<%&additionalImports%>
 import {
-  Plugin,
-  Getter,
-} from '@devexpress/dx-react-core';
-import {
-  ARGUMENT_DOMAIN,
-} from '@devexpress/dx-chart-core';
-import {
   Viewport,
 } from '@devexpress/dx-react-chart';
 import {
   ArgumentAxis,
   ValueAxis,
   Chart,
-  Legend,
   LineSeries,
-  AreaSeries,
-  SplineSeries,
-  Title,
 } from '@devexpress/dx-react-chart-<%&themeName%>';
 
 const data = [
@@ -33,16 +22,9 @@ const data = [
   { arg: 'J', val: 2.4 },
 ];
 
-const minRangePosition = 0;
-const maxRangePosition = 5;
-const minRangeSize = 2;
-const maxRangeSize = 10;
-
 const CATEGORIES = data.map(item => item.arg);
 const MIN_VAL = 0;
 const MAX_VAL = 6;
-
-const getRange = (position, size) => [position - size / 2, position + size / 2];
 
 const sliderStyle = {
   width: '400px',
@@ -52,7 +34,7 @@ const MIN_SLIDER_VALUE = 0;
 const MAX_SLIDER_VALUE = 100;
 const SLIDER_STEP = 1;
 
-const translate = (sliderValue) => (
+const translate = sliderValue => (
   (sliderValue - MIN_SLIDER_VALUE) / (MAX_SLIDER_VALUE - MIN_SLIDER_VALUE)
 );
 
@@ -89,6 +71,30 @@ const getValueRange = (positionSlider, sizeSlider) => {
   ];
 };
 
+const renderSlider = (value, onChange) => (
+  <div>
+    <input
+      type="range"
+      style={sliderStyle}
+      min={MIN_SLIDER_VALUE}
+      max={MAX_SLIDER_VALUE}
+      step={SLIDER_STEP}
+      value={value}
+      onChange={onChange}
+    />
+  </div>
+);
+
+const renderLabel = (text, [min, max]) => {
+  const info = `[${min} .. ${max}]`;
+  return (
+    <div>
+      <span>{text}</span>
+      <span>{info}</span>
+    </div>
+  );
+};
+
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -105,12 +111,6 @@ export default class Demo extends React.PureComponent {
     this.changeValSizeSlider = this.makeHandler('valSizeSlider');
   }
 
-  makeHandler(name) {
-    return (e) => this.setState({
-      [name]: e.target.value,
-    });
-  }
-
   static getDerivedStateFromProps(props, {
     argPositionSlider, argSizeSlider, valPositionSlider, valSizeSlider,
   }) {
@@ -120,39 +120,20 @@ export default class Demo extends React.PureComponent {
     };
   }
 
-  renderSlider(value, onChange) {
-    return (
-      <div>
-        <input
-          type="range"
-          style={sliderStyle}
-          min={MIN_SLIDER_VALUE}
-          max={MAX_SLIDER_VALUE}
-          step={SLIDER_STEP}
-          value={value}
-          onChange={onChange}
-        />
-      </div>
-    );
-  }
-
-  renderLabel(text, [min, max]) {
-    const data = `[${min} .. ${max}]`;
-    return (
-      <div>
-        <span>{text}</span>
-        <span>{data}</span>
-      </div>
-    )
+  makeHandler(name) {
+    return e => this.setState({
+      [name]: e.target.value,
+    });
   }
 
   render() {
+    const {
+      argBounds, valBounds,
+      argPositionSlider, argSizeSlider, valPositionSlider, valSizeSlider,
+    } = this.state;
     return (
       <<%&wrapperTag%><%&wrapperAttributes%>>
-        <Chart
-          data={data}
-        >
-          <Title text="Born amount" />
+        <Chart data={data}>
           <ArgumentAxis />
           <ValueAxis />
 
@@ -164,19 +145,19 @@ export default class Demo extends React.PureComponent {
 
           <Viewport
             viewport={{
-              argumentBounds: this.state.argBounds,
-              valueBounds: this.state.valBounds,
+              argumentBounds: argBounds,
+              valueBounds: valBounds,
             }}
           />
         </Chart>
 
         <div>
-          {this.renderSlider(this.state.argPositionSlider, this.changeArgPositionSlider)}
-          {this.renderSlider(this.state.argSizeSlider, this.changeArgSizeSlider)}
-          {this.renderLabel('ARG', this.state.argBounds)}
-          {this.renderSlider(this.state.valPositionSlider, this.changeValPositionSlider)}
-          {this.renderSlider(this.state.valSizeSlider, this.changeValSizeSlider)}
-          {this.renderLabel('VAL', this.state.valBounds)}
+          {renderSlider(argPositionSlider, this.changeArgPositionSlider)}
+          {renderSlider(argSizeSlider, this.changeArgSizeSlider)}
+          {renderLabel('ARG', argBounds)}
+          {renderSlider(valPositionSlider, this.changeValPositionSlider)}
+          {renderSlider(valSizeSlider, this.changeValSizeSlider)}
+          {renderLabel('VAL', valBounds)}
         </div>
       </<%&wrapperTag%>>
     );

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/viewport.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/viewport.jsxt
@@ -21,11 +21,16 @@ import {
 } from '@devexpress/dx-react-chart-<%&themeName%>';
 
 const data = [
-  { arg: 0.2, val: 0.4 },
-  { arg: 1.4, val: 2.3 },
-  { arg: 2.7, val: 3.8 },
-  { arg: 3.2, val: 1.1 },
-  { arg: 4.8, val: 2.8 },
+  { arg: 'A', val: 0.4 },
+  { arg: 'B', val: 2.3 },
+  { arg: 'C', val: 3.8 },
+  { arg: 'D', val: 1.1 },
+  { arg: 'E', val: 2.8 },
+  { arg: 'F', val: 1.3 },
+  { arg: 'G', val: 3.2 },
+  { arg: 'H', val: 4.2 },
+  { arg: 'I', val: 5.1 },
+  { arg: 'J', val: 2.4 },
 ];
 
 const minRangePosition = 0;
@@ -33,37 +38,112 @@ const maxRangePosition = 5;
 const minRangeSize = 2;
 const maxRangeSize = 10;
 
+const CATEGORIES = data.map(item => item.arg);
+const MIN_VAL = 0;
+const MAX_VAL = 6;
+
 const getRange = (position, size) => [position - size / 2, position + size / 2];
 
 const sliderStyle = {
   width: '400px',
 };
 
+const MIN_SLIDER_VALUE = 0;
+const MAX_SLIDER_VALUE = 100;
+const SLIDER_STEP = 1;
+
+const translate = (sliderValue) => (
+  (sliderValue - MIN_SLIDER_VALUE) / (MAX_SLIDER_VALUE - MIN_SLIDER_VALUE)
+);
+
+const getVirtualRange = (positionSlider, sizeSlider) => {
+  const position = translate(positionSlider);
+  const size = translate(sizeSlider);
+  const delta = -0.4 * size + 0.5;
+  let min = position - delta;
+  let max = position + delta;
+  if (min < 0) {
+    max += 0 - min;
+    min = 0;
+  }
+  if (max > 1) {
+    min -= max - 1;
+    max = 1;
+  }
+  return [min, max];
+};
+
+const getArgumentRange = (positionSlider, sizeSlider) => {
+  const [min, max] = getVirtualRange(positionSlider, sizeSlider);
+  return [
+    CATEGORIES[Math.round((CATEGORIES.length - 1) * min)],
+    CATEGORIES[Math.round((CATEGORIES.length - 1) * max)],
+  ];
+};
+
+const getValueRange = (positionSlider, sizeSlider) => {
+  const [min, max] = getVirtualRange(positionSlider, sizeSlider);
+  return [
+    Number(((MAX_VAL - MIN_VAL) * min).toFixed(2)),
+    Number(((MAX_VAL - MIN_VAL) * max).toFixed(2)),
+  ];
+};
+
 export default class Demo extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      rangePosition: 2,
-      rangeSize: 3,
+      argPositionSlider: (MIN_SLIDER_VALUE + MAX_SLIDER_VALUE) / 2,
+      argSizeSlider: 0,
+      valPositionSlider: (MIN_SLIDER_VALUE + MAX_SLIDER_VALUE) / 2,
+      valSizeSlider: 0,
     };
-    this.changeRangePosition = (e) => {
-      const value = Number(e.target.value);
-      this.setState(() => (
-        minRangePosition <= value && value <= maxRangePosition ? { rangePosition: value } : null
-      ));
-    };
-    this.changeRangeSize = (e) => {
-      const value = Number(e.target.value);
-      this.setState(() => (
-        minRangeSize <= value && value <= maxRangeSize ? { rangeSize: value } : null
-      ));
+
+    this.changeArgPositionSlider = this.makeHandler('argPositionSlider');
+    this.changeArgSizeSlider = this.makeHandler('argSizeSlider');
+    this.changeValPositionSlider = this.makeHandler('valPositionSlider');
+    this.changeValSizeSlider = this.makeHandler('valSizeSlider');
+  }
+
+  makeHandler(name) {
+    return (e) => this.setState({
+      [name]: e.target.value,
+    });
+  }
+
+  static getDerivedStateFromProps(props, {
+    argPositionSlider, argSizeSlider, valPositionSlider, valSizeSlider,
+  }) {
+    return {
+      argBounds: getArgumentRange(argPositionSlider, argSizeSlider),
+      valBounds: getValueRange(valPositionSlider, valSizeSlider),
     };
   }
 
-  static getDerivedStateFromProps(props, { rangePosition, rangeSize }) {
-    return {
-      domain: getRange(rangePosition, rangeSize),
-    };
+  renderSlider(value, onChange) {
+    return (
+      <div>
+        <input
+          type="range"
+          style={sliderStyle}
+          min={MIN_SLIDER_VALUE}
+          max={MAX_SLIDER_VALUE}
+          step={SLIDER_STEP}
+          value={value}
+          onChange={onChange}
+        />
+      </div>
+    );
+  }
+
+  renderLabel(text, [min, max]) {
+    const data = `[${min} .. ${max}]`;
+    return (
+      <div>
+        <span>{text}</span>
+        <span>{data}</span>
+      </div>
+    )
   }
 
   render() {
@@ -82,30 +162,19 @@ export default class Demo extends React.PureComponent {
             argumentField="arg"
           />
 
-          <Viewport valueBounds={this.state.domain} />
+          <Viewport
+            argumentBounds={this.state.argBounds}
+            valueBounds={this.state.valBounds}
+          />
         </Chart>
 
         <div>
-          <div>
-            <input
-              type="range"
-              id="range-position"
-              style={sliderStyle}
-              min={minRangePosition} max={maxRangePosition} step={0.1}
-              value={this.state.rangePosition} onChange={this.changeRangePosition}
-            />
-            <label htmlFor="range-position">Position</label>
-          </div>
-          <div>
-            <input
-              type="range"
-              id="range-size"
-              style={sliderStyle}
-              min={minRangeSize} max={maxRangeSize} step={0.1}
-              value={this.state.rangeSize} onChange={this.changeRangeSize}
-            />
-            <label htmlFor="range-size">Size</label>
-          </div>
+          {this.renderSlider(this.state.argPositionSlider, this.changeArgPositionSlider)}
+          {this.renderSlider(this.state.argSizeSlider, this.changeArgSizeSlider)}
+          {this.renderLabel('ARG', this.state.argBounds)}
+          {this.renderSlider(this.state.valPositionSlider, this.changeValPositionSlider)}
+          {this.renderSlider(this.state.valSizeSlider, this.changeValSizeSlider)}
+          {this.renderLabel('VAL', this.state.valBounds)}
         </div>
       </<%&wrapperTag%>>
     );

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/viewport.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/viewport.jsxt
@@ -1,0 +1,113 @@
+import * as React from 'react';<%&additionalImports%>
+import {
+  Plugin,
+  Getter,
+} from '@devexpress/dx-react-core';
+import {
+  ARGUMENT_DOMAIN,
+} from '@devexpress/dx-chart-core';
+import {
+  Viewport,
+} from '@devexpress/dx-react-chart';
+import {
+  ArgumentAxis,
+  ValueAxis,
+  Chart,
+  Legend,
+  LineSeries,
+  AreaSeries,
+  SplineSeries,
+  Title,
+} from '@devexpress/dx-react-chart-<%&themeName%>';
+
+const data = [
+  { arg: 0.2, val: 0.4 },
+  { arg: 1.4, val: 2.3 },
+  { arg: 2.7, val: 3.8 },
+  { arg: 3.2, val: 1.1 },
+  { arg: 4.8, val: 2.8 },
+];
+
+const minRangePosition = 0;
+const maxRangePosition = 5;
+const minRangeSize = 2;
+const maxRangeSize = 10;
+
+const getRange = (position, size) => [position - size / 2, position + size / 2];
+
+const sliderStyle = {
+  width: '400px',
+};
+
+export default class Demo extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      rangePosition: 2,
+      rangeSize: 3,
+    };
+    this.changeRangePosition = (e) => {
+      const value = Number(e.target.value);
+      this.setState(() => (
+        minRangePosition <= value && value <= maxRangePosition ? { rangePosition: value } : null
+      ));
+    };
+    this.changeRangeSize = (e) => {
+      const value = Number(e.target.value);
+      this.setState(() => (
+        minRangeSize <= value && value <= maxRangeSize ? { rangeSize: value } : null
+      ));
+    };
+  }
+
+  static getDerivedStateFromProps(props, { rangePosition, rangeSize }) {
+    return {
+      domain: getRange(rangePosition, rangeSize),
+    };
+  }
+
+  render() {
+    return (
+      <<%&wrapperTag%><%&wrapperAttributes%>>
+        <Chart
+          data={data}
+        >
+          <Title text="Born amount" />
+          <ArgumentAxis />
+          <ValueAxis />
+
+          <LineSeries
+            name="Russia"
+            valueField="val"
+            argumentField="arg"
+          />
+
+          <Viewport valueBounds={this.state.domain} />
+        </Chart>
+
+        <div>
+          <div>
+            <input
+              type="range"
+              id="range-position"
+              style={sliderStyle}
+              min={minRangePosition} max={maxRangePosition} step={0.1}
+              value={this.state.rangePosition} onChange={this.changeRangePosition}
+            />
+            <label htmlFor="range-position">Position</label>
+          </div>
+          <div>
+            <input
+              type="range"
+              id="range-size"
+              style={sliderStyle}
+              min={minRangeSize} max={maxRangeSize} step={0.1}
+              value={this.state.rangeSize} onChange={this.changeRangeSize}
+            />
+            <label htmlFor="range-size">Size</label>
+          </div>
+        </div>
+      </<%&wrapperTag%>>
+    );
+  }
+}

--- a/packages/dx-react-chart-demos/src/demo-sources/chart-basic/viewport.jsxt
+++ b/packages/dx-react-chart-demos/src/demo-sources/chart-basic/viewport.jsxt
@@ -163,8 +163,10 @@ export default class Demo extends React.PureComponent {
           />
 
           <Viewport
-            argumentBounds={this.state.argBounds}
-            valueBounds={this.state.valBounds}
+            viewport={{
+              argumentBounds: this.state.argBounds,
+              valueBounds: this.state.valBounds,
+            }}
           />
         </Chart>
 

--- a/packages/dx-react-chart/api/dx-react-chart.api.ts
+++ b/packages/dx-react-chart/api/dx-react-chart.api.ts
@@ -143,6 +143,9 @@ declare type DataItem = {
 declare type DataItems = ReadonlyArray<DataItem>;
 
 // @public (undocumented)
+declare type DomainBounds = Readonly<[any, any]>;
+
+// @public (undocumented)
 declare type DomainItems = ReadonlyArray<any>;
 
 // @public (undocumented)
@@ -602,6 +605,32 @@ declare const ValueScale: React.ComponentType<ValueScaleProps>;
 // @public (undocumented)
 interface ValueScaleProps extends ScaleProps {
 }
+
+// @public (undocumented)
+declare const Viewport: React.ComponentType<ViewportProps>;
+
+// @public (undocumented)
+declare type ViewportOptions = {
+  // (undocumented)
+  readonly argumentBounds?: DomainBounds;
+  // (undocumented)
+  readonly scaleName?: string;
+  // (undocumented)
+  readonly valueBounds?: DomainBounds;
+};
+
+// @public (undocumented)
+interface ViewportProps {
+  defaultViewport?: ViewportOptions;
+  onViewportChange?: (viewport: ViewportOptions) => void;
+  viewport?: ViewportOptions;
+}
+
+// @public (undocumented)
+type ViewportState = {
+  // (undocumented)
+  viewport?: ViewportOptions;
+};
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/dx-react-chart/src/index.ts
+++ b/packages/dx-react-chart/src/index.ts
@@ -21,4 +21,6 @@ export * from './plugins/event-tracker';
 export * from './plugins/hover-state';
 export * from './plugins/selection-state';
 
+export * from './plugins/viewport';
+
 export { withPatchedProps } from './utils';

--- a/packages/dx-react-chart/src/plugins/axis.test.tsx
+++ b/packages/dx-react-chart/src/plugins/axis.test.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { PluginHost } from '@devexpress/dx-react-core';
-import { axisCoordinates, getGridCoordinates } from '@devexpress/dx-chart-core';
+import { axisCoordinates, createTickFilter, getGridCoordinates } from '@devexpress/dx-chart-core';
 import { pluginDepsToComponents } from '@devexpress/dx-testing';
 import { Axis } from './axis';
 
 jest.mock('@devexpress/dx-chart-core', () => ({
   axisCoordinates: jest.fn(),
+  createTickFilter: jest.fn().mockReturnValue(() => true),
   LEFT: 'left',
   BOTTOM: 'bottom',
   getGridCoordinates: jest.fn(),
@@ -249,6 +250,7 @@ describe('Axis', () => {
       tickFormat: mockTickFormat,
       indentFromAxis: 10,
     });
+    expect(createTickFilter).toBeCalledWith([0, 0]);
   });
 
   it('should pass axisCoordinates method correct parameters, vertical orientation', () => {
@@ -268,6 +270,7 @@ describe('Axis', () => {
       tickSize: 6,
       indentFromAxis: 3,
     });
+    expect(createTickFilter).toBeCalledWith([0, 0]);
   });
 
   it('should render tick component', () => {

--- a/packages/dx-react-chart/src/plugins/axis.tsx
+++ b/packages/dx-react-chart/src/plugins/axis.tsx
@@ -10,9 +10,8 @@ import {
 } from '@devexpress/dx-react-core';
 import {
   axisCoordinates, LEFT, BOTTOM, ARGUMENT_DOMAIN, getValueDomainName, getGridCoordinates,
-  NumberArray,
 } from '@devexpress/dx-chart-core';
-import { RawAxisProps, ArgumentAxisProps, ValueAxisProps, ScaleObject } from '../types';
+import { RawAxisProps, ArgumentAxisProps, ValueAxisProps } from '../types';
 import { Root } from '../templates/axis/root';
 import { Label } from '../templates/axis/label';
 import { Line } from '../templates/axis/line';
@@ -20,20 +19,7 @@ import { Line } from '../templates/axis/line';
 import { withPatchedProps } from '../utils';
 
 const SVG_STYLE: React.CSSProperties = {
-  position: 'absolute', left: 0, top: 0, overflow: 'visible',
-};
-
-const adjustScaleRange = (scale: ScaleObject, [width, height]: NumberArray) => {
-  const range = scale.range().slice() as NumberArray;
-  if (Math.abs(range[0] - range[1]) < 0.01) {
-    return scale;
-  }
-  if (range[1] > 0) {
-    range[1] = width;
-  } else {
-    range[0] = height;
-  }
-  return scale.copy().range(range);
+  position: 'absolute', left: 0, top: 0, overflow: 'hidden',
 };
 
 class RawAxis extends React.PureComponent<RawAxisProps> {
@@ -89,8 +75,7 @@ class RawAxis extends React.PureComponent<RawAxisProps> {
                 tickSize: tickSize!,
                 tickFormat,
                 indentFromAxis: indentFromAxis!,
-                // Isn't it too late to adjust sizes?
-                scale: adjustScaleRange(scale, [this.adjustedWidth, this.adjustedHeight]),
+                scale,
               });
               const handleSizeChange: onSizeChangeFn = (size) => {
                 // The callback is called when DOM is available -

--- a/packages/dx-react-chart/src/plugins/chart-core.test.tsx
+++ b/packages/dx-react-chart/src/plugins/chart-core.test.tsx
@@ -17,7 +17,7 @@ describe('Chart Core', () => {
     getter: {
       domains: 'test-domains',
       series: 'test-series',
-      layouts: { pane: 'test-pane' },
+      ranges: 'test-ranges',
     },
   };
 
@@ -34,7 +34,7 @@ describe('Chart Core', () => {
       scales: 'built-scales',
       series: 'scaled-series',
     });
-    expect(buildScales).toBeCalledWith('test-domains', 'test-pane');
+    expect(buildScales).toBeCalledWith('test-domains', 'test-ranges');
     expect(scaleSeriesPoints).toBeCalledWith('test-series', 'built-scales');
   });
 });

--- a/packages/dx-react-chart/src/plugins/chart-core.tsx
+++ b/packages/dx-react-chart/src/plugins/chart-core.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Plugin, Getter, Getters } from '@devexpress/dx-react-core';
 import { buildScales, scaleSeriesPoints } from '@devexpress/dx-chart-core';
 
-const getScales = ({ domains, layouts }: Getters) => buildScales(domains, layouts.pane);
+const getScales = ({ domains, ranges }: Getters) => buildScales(domains, ranges);
 
 const getSeries = ({ series, scales }: Getters) => scaleSeriesPoints(series, scales);
 

--- a/packages/dx-react-chart/src/plugins/layout-manager.test.tsx
+++ b/packages/dx-react-chart/src/plugins/layout-manager.test.tsx
@@ -2,12 +2,16 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { PluginHost } from '@devexpress/dx-react-core';
 import { pluginDepsToComponents, getComputedState } from '@devexpress/dx-testing';
+import { getRanges } from '@devexpress/dx-chart-core';
 import { LayoutManager } from './layout-manager';
 
+jest.mock('@devexpress/dx-chart-core', () => ({
+  getRanges: jest.fn().mockReturnValue('test-ranges'),
+}));
+
 describe('LayoutManager', () => {
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
+  afterEach(jest.clearAllMocks);
+
   const defaultDeps = {
     getter: {
     },
@@ -31,6 +35,12 @@ describe('LayoutManager', () => {
       </PluginHost>
     ));
 
-    expect(getComputedState(tree).layouts.pane).toEqual({ width: 200, height: 100 });
+    expect(getComputedState(tree)).toEqual({
+      layouts: {
+        pane: { width: 200, height: 100 },
+      },
+      ranges: 'test-ranges',
+    });
+    expect(getRanges).toBeCalledWith({ width: 200, height: 100 });
   });
 });

--- a/packages/dx-react-chart/src/plugins/layout-manager.tsx
+++ b/packages/dx-react-chart/src/plugins/layout-manager.tsx
@@ -6,10 +6,13 @@ import {
   Template,
   TemplatePlaceholder,
   createStateHelper,
+  Getters,
   ActionFn,
 } from '@devexpress/dx-react-core';
-import { bBoxes } from '@devexpress/dx-chart-core';
+import { bBoxes, getRanges } from '@devexpress/dx-chart-core';
 import { LayoutManagerProps, LayoutManagerState, BBoxesChange } from '../types';
+
+const doGetRanges = ({ layouts }: Getters) => getRanges(layouts.pane);
 
 export class LayoutManager extends React.Component<LayoutManagerProps, LayoutManagerState> {
   static defaultProps: Partial<LayoutManagerProps> = {
@@ -40,6 +43,7 @@ export class LayoutManager extends React.Component<LayoutManagerProps, LayoutMan
     return (
       <Plugin>
         <Getter name="layouts" value={stateBBoxes} />
+        <Getter name="ranges" computed={doGetRanges} />
         <Action name="changeBBox" action={this.changeBBox} />
 
         <Template name="root">

--- a/packages/dx-react-chart/src/plugins/pane-layout.test.tsx
+++ b/packages/dx-react-chart/src/plugins/pane-layout.test.tsx
@@ -27,7 +27,7 @@ describe('PaneLayout', () => {
       width: 400,
       height: 300,
       style: {
-        left: 0, top: 0, overflow: 'visible', position: 'absolute',
+        left: 0, top: 0, overflow: 'hidden', position: 'absolute',
       },
       children: expect.anything(),
     });

--- a/packages/dx-react-chart/src/plugins/pane-layout.tsx
+++ b/packages/dx-react-chart/src/plugins/pane-layout.tsx
@@ -16,7 +16,6 @@ const DIV_STYLE: React.CSSProperties = {
   flex: 1, zIndex: 1, position: 'relative', width: '100%',
 };
 
-
 const SVG_STYLE: React.CSSProperties = {
   position: 'absolute', left: 0, top: 0, overflow: 'hidden',
 };

--- a/packages/dx-react-chart/src/plugins/pane-layout.tsx
+++ b/packages/dx-react-chart/src/plugins/pane-layout.tsx
@@ -16,8 +16,9 @@ const DIV_STYLE: React.CSSProperties = {
   flex: 1, zIndex: 1, position: 'relative', width: '100%',
 };
 
+
 const SVG_STYLE: React.CSSProperties = {
-  position: 'absolute', left: 0, top: 0, overflow: 'visible',
+  position: 'absolute', left: 0, top: 0, overflow: 'hidden',
 };
 
 const SizerContainer: React.SFC = ({ children }) => (

--- a/packages/dx-react-chart/src/plugins/viewport.test.tsx
+++ b/packages/dx-react-chart/src/plugins/viewport.test.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { PluginHost } from '@devexpress/dx-react-core';
+import { pluginDepsToComponents, getComputedState } from '@devexpress/dx-testing';
+import { adjustLayout } from '@devexpress/dx-chart-core';
+import { Viewport } from './viewport';
+
+jest.mock('@devexpress/dx-chart-core', () => ({
+  adjustLayout: jest.fn().mockReturnValue('adjusted-ranges'),
+}));
+
+describe('Viewport', () => {
+  const defaultDeps = {
+    getter: {
+      domains: 'test-domains',
+      ranges: 'test-ranges',
+    },
+  };
+
+  afterEach(jest.clearAllMocks);
+
+  it('should provide getter', () => {
+    const tree = mount((
+      <PluginHost>
+        {pluginDepsToComponents(defaultDeps)}
+        <Viewport
+          argumentBounds={'test-arg-bounds' as any}
+          scaleName="scale-1"
+          valueBounds={'test-val-bounds' as any}
+        />
+      </PluginHost>
+    ));
+
+    expect(getComputedState(tree)).toEqual({
+      ...defaultDeps.getter,
+      ranges: 'adjusted-ranges',
+    });
+    expect(adjustLayout).toBeCalledWith('test-domains', 'test-ranges', {
+      argumentBounds: 'test-arg-bounds',
+      scaleName: 'scale-1',
+      valueBounds: 'test-val-bounds',
+    });
+  });
+});

--- a/packages/dx-react-chart/src/plugins/viewport.test.tsx
+++ b/packages/dx-react-chart/src/plugins/viewport.test.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { PluginHost } from '@devexpress/dx-react-core';
-import { pluginDepsToComponents, getComputedState } from '@devexpress/dx-testing';
+import {
+  pluginDepsToComponents, getComputedState, executeComputedAction,
+} from '@devexpress/dx-testing';
 import { adjustLayout } from '@devexpress/dx-chart-core';
 import { Viewport } from './viewport';
 
@@ -24,9 +26,11 @@ describe('Viewport', () => {
       <PluginHost>
         {pluginDepsToComponents(defaultDeps)}
         <Viewport
-          argumentBounds={'test-arg-bounds' as any}
-          scaleName="scale-1"
-          valueBounds={'test-val-bounds' as any}
+          viewport={{
+            argumentBounds: 'test-arg-bounds' as any,
+            scaleName: 'scale-1',
+            valueBounds: 'test-val-bounds' as any,
+          }}
         />
       </PluginHost>
     ));
@@ -39,6 +43,55 @@ describe('Viewport', () => {
       argumentBounds: 'test-arg-bounds',
       scaleName: 'scale-1',
       valueBounds: 'test-val-bounds',
+    });
+  });
+
+  it('should handle *defaultViewport* property', () => {
+    const tree = mount((
+      <PluginHost>
+        {pluginDepsToComponents(defaultDeps)}
+        <Viewport
+          defaultViewport={{
+            argumentBounds: 'test-arg-bounds' as any,
+            scaleName: 'scale-1',
+            valueBounds: 'test-val-bounds' as any,
+          }}
+        />
+      </PluginHost>
+    ));
+
+    expect(getComputedState(tree)).toEqual({
+      ...defaultDeps.getter,
+      ranges: 'adjusted-ranges',
+    });
+  });
+
+  it('should provide action', () => {
+    const mock = jest.fn();
+    const tree = mount((
+      <PluginHost>
+        {pluginDepsToComponents(defaultDeps)}
+        <Viewport
+          viewport={{
+            argumentBounds: 'test-arg-bounds' as any,
+            scaleName: 'scale-1',
+            valueBounds: 'test-val-bounds' as any,
+          }}
+          onViewportChange={mock}
+        />
+      </PluginHost>
+    ));
+
+    executeComputedAction(tree, actions => actions.changeViewport({
+      argumentBounds: 'new-arg-bounds' as any,
+      scaleName: 'scale-2',
+      valueBounds: 'new-val-bounds' as any,
+    }));
+
+    expect(mock).toBeCalledWith({
+      argumentBounds: 'new-arg-bounds',
+      scaleName: 'scale-2',
+      valueBounds: 'new-val-bounds',
     });
   });
 });

--- a/packages/dx-react-chart/src/plugins/viewport.tsx
+++ b/packages/dx-react-chart/src/plugins/viewport.tsx
@@ -2,25 +2,48 @@ import * as React from 'react';
 import {
   Plugin,
   Getter,
+  Action,
   Getters,
+  ActionFn,
 } from '@devexpress/dx-react-core';
-import { adjustLayout } from '@devexpress/dx-chart-core';
-import { ViewportProps } from '../types';
+import { adjustLayout, ViewportOptions } from '@devexpress/dx-chart-core';
+import { ViewportProps, ViewportState } from '../types';
 
-class ViewportBase extends React.PureComponent<ViewportProps> {
+class ViewportBase extends React.PureComponent<ViewportProps, ViewportState> {
+  changeViewport: ActionFn<ViewportOptions> = (viewport) => {
+    this.setState((state, { onViewportChange }) => {
+      // There should be some check that viewport is actually changed.
+      // But *viewport* is built outside and most like will always be new instance.
+      // So it should be fieldwise equality check.
+      // For now action is expected to be called only when *viewport* is really changed.
+      if (onViewportChange) {
+        onViewportChange(viewport as ViewportOptions);
+      }
+      return { viewport: viewport as ViewportOptions };
+    });
+  }
+
+  constructor(props: ViewportProps) {
+    super(props);
+    this.state = {
+      viewport: props.viewport || props.defaultViewport,
+    };
+  }
+
+  static getDerivedStateFromProps(props: ViewportProps, state: ViewportState): ViewportState {
+    return { viewport: props.viewport !== undefined ? props.viewport : state.viewport };
+  }
+
   render() {
-    const {
-      argumentBounds,
-      valueBounds,
-      scaleName,
-    } = this.props;
+    const { viewport } = this.state;
     const doAdjustLayout = ({
       domains,
       ranges,
-    }: Getters) => adjustLayout(domains, ranges, { argumentBounds, scaleName, valueBounds });
+    }: Getters) => adjustLayout(domains, ranges, viewport!);
     return (
       <Plugin name="viewport">
         <Getter name="ranges" computed={doAdjustLayout} />
+        <Action name="changeViewport" action={this.changeViewport} />
       </Plugin>
     );
   }

--- a/packages/dx-react-chart/src/plugins/viewport.tsx
+++ b/packages/dx-react-chart/src/plugins/viewport.tsx
@@ -4,7 +4,7 @@ import {
   Getter,
   Getters,
 } from '@devexpress/dx-react-core';
-import { adjustDomains } from '@devexpress/dx-chart-core';
+import { adjustLayout } from '@devexpress/dx-chart-core';
 import { ViewportProps } from '../types';
 
 class ViewportBase extends React.PureComponent<ViewportProps> {
@@ -14,12 +14,13 @@ class ViewportBase extends React.PureComponent<ViewportProps> {
       valueBounds,
       scaleName,
     } = this.props;
-    const doAdjustBounds = ({
+    const doAdjustLayout = ({
       domains,
-    }: Getters) => adjustDomains(domains, argumentBounds, scaleName, valueBounds);
+      ranges,
+    }: Getters) => adjustLayout(domains, ranges, { argumentBounds, scaleName, valueBounds });
     return (
       <Plugin name="viewport">
-        <Getter name="domains" computed={doAdjustBounds} />
+        <Getter name="ranges" computed={doAdjustLayout} />
       </Plugin>
     );
   }

--- a/packages/dx-react-chart/src/plugins/viewport.tsx
+++ b/packages/dx-react-chart/src/plugins/viewport.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import {
+  Plugin,
+  Getter,
+  Getters,
+} from '@devexpress/dx-react-core';
+import { adjustDomains } from '@devexpress/dx-chart-core';
+import { ViewportProps } from '../types';
+
+class ViewportBase extends React.PureComponent<ViewportProps> {
+  render() {
+    const {
+      argumentBounds,
+      valueBounds,
+      scaleName,
+    } = this.props;
+    const doAdjustBounds = ({
+      domains,
+    }: Getters) => adjustDomains(domains, argumentBounds, scaleName, valueBounds);
+    return (
+      <Plugin name="viewport">
+        <Getter name="domains" computed={doAdjustBounds} />
+      </Plugin>
+    );
+  }
+}
+
+export const Viewport: React.ComponentType<ViewportProps> = ViewportBase;

--- a/packages/dx-react-chart/src/types/index.ts
+++ b/packages/dx-react-chart/src/types/index.ts
@@ -7,6 +7,7 @@ export {
   BBox, BBoxes, BBoxesChange,
   StackList, StacksOptions, OffsetFn, OrderFn,
   EventHandlers,
+  DomainBounds,
 
   AreaSeries, LineSeries, SplineSeries, BarSeries, ScatterSeries, PieSeries,
   SeriesProps, PathComponentProps, PathComponentPathProps, PointComponentProps,
@@ -20,6 +21,7 @@ export {
 
 export * from './plugins.animation.types';
 export * from './plugins.axis.types';
+export * from './plugins.basic-data.types';
 export * from './plugins.event-tracker.types';
 export * from './plugins.hover-state.types';
 export * from './plugins.layout-manager.types';
@@ -29,9 +31,9 @@ export * from './plugins.scales.types';
 export * from './plugins.selection-state.types';
 export * from './plugins.space-filling-rects.types';
 export * from './plugins.stack.types';
-export * from './plugins.tooltip.types';
 export * from './plugins.title.types';
-export * from './plugins.basic-data.types';
+export * from './plugins.tooltip.types';
+export * from './plugins.viewport.types';
 export * from './utils.series-helpers.types';
 export * from './templates.axis.types';
 export * from './templates.core.types';

--- a/packages/dx-react-chart/src/types/index.ts
+++ b/packages/dx-react-chart/src/types/index.ts
@@ -7,7 +7,7 @@ export {
   BBoxes, BBoxesChange,
   StackList, StacksOptions, OffsetFn, OrderFn,
   EventHandlers,
-  DomainBounds,
+  DomainBounds, ViewportOptions,
 
   AreaSeries, LineSeries, SplineSeries, BarSeries, ScatterSeries, PieSeries,
   SeriesProps, PathComponentProps, PathComponentPathProps, PointComponentProps,

--- a/packages/dx-react-chart/src/types/index.ts
+++ b/packages/dx-react-chart/src/types/index.ts
@@ -4,7 +4,7 @@ export {
   TransformedPoint, GetPointTransformerFn, CreateHitTesterFn, Series,
   ScaleObject, TooltipReference,
   FactoryFn, ModifyDomainFn,
-  BBox, BBoxes, BBoxesChange,
+  BBoxes, BBoxesChange,
   StackList, StacksOptions, OffsetFn, OrderFn,
   EventHandlers,
   DomainBounds,

--- a/packages/dx-react-chart/src/types/plugins.viewport.types.ts
+++ b/packages/dx-react-chart/src/types/plugins.viewport.types.ts
@@ -1,12 +1,16 @@
 import {
-  DomainBounds,
+  ViewportOptions,
 } from './index';
 
 export interface ViewportProps {
-  /** An argument bounds */
-  argumentBounds?: DomainBounds;
-  /** A scale name */
-  scaleName?: string;
-  /** A value bounds */
-  valueBounds?: DomainBounds;
+  /** A default viewport */
+  defaultViewport?: ViewportOptions;
+  /** A viewport */
+  viewport?: ViewportOptions;
+  /** A function that is executed when viewport changes */
+  onViewportChange?: (viewport: ViewportOptions) => void;
 }
+
+export type ViewportState = {
+  viewport?: ViewportOptions;
+};

--- a/packages/dx-react-chart/src/types/plugins.viewport.types.ts
+++ b/packages/dx-react-chart/src/types/plugins.viewport.types.ts
@@ -1,0 +1,12 @@
+import {
+  DomainBounds,
+} from './index';
+
+export interface ViewportProps {
+  /** An argument bounds */
+  argumentBounds?: DomainBounds;
+  /** A scale name */
+  scaleName?: string;
+  /** A value bounds */
+  valueBounds?: DomainBounds;
+}

--- a/packages/dx-react-chart/src/utils/series-helper.tsx
+++ b/packages/dx-react-chart/src/utils/series-helper.tsx
@@ -16,6 +16,10 @@ import {
   ExtraSeriesParameters, SeriesProps, PathComponentProps, Scales,
 } from '../types';
 
+const getDomains = ({
+  series, domains,
+}: Getters) => extendDomains(domains, series[series.length - 1]);
+
 /** @internal */
 export const declareSeries = <T extends SeriesProps>(
   pluginName: string,

--- a/packages/dx-react-chart/src/utils/series-helper.tsx
+++ b/packages/dx-react-chart/src/utils/series-helper.tsx
@@ -16,10 +16,6 @@ import {
   ExtraSeriesParameters, SeriesProps, PathComponentProps, Scales,
 } from '../types';
 
-const getDomains = ({
-  series, domains,
-}: Getters) => extendDomains(domains, series[series.length - 1]);
-
 /** @internal */
 export const declareSeries = <T extends SeriesProps>(
   pluginName: string,


### PR DESCRIPTION
```js
const viewport = {
  argumentBounds: ['B', 'E'],
  scaleName: ...,
  valueBounds: [3, 8],
};

const handleViewportChange = ({
  argumentBounds, scaleName, valueBounds
}) => {
  ...
}

<Viewport
  defaultViewport={viewport}
  viewport={viewport}
  onViewportChange=(handleViewportChange)
/>

<TemplateConnector>
  {({}, { changeViewport }) => {
    ...
  }}
</TemplateConnector>
```