### PR TITLE
chore(react-chart): fix stacks processing after "domains" Getter movement

### DIFF
--- a/packages/dx-chart-core/src/plugins/scale/computeds.test.ts
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.test.ts
@@ -111,28 +111,6 @@ describe('Scale', () => {
       });
     });
 
-    it('should compute domains from series points (temporary workaround for Stack)', () => {
-      const getValueDomain = jest.fn().mockReturnValue([11, 15, 19, 23]);
-      const points = [
-        { argument: 1, value: 9 },
-        { argument: 2, value: 2 },
-        { argument: 3, value: 7 },
-      ];
-      const domains = extendDomains(testDomains as any, {
-        getPointTransformer, getValueDomain, points,
-      } as any);
-
-      expect(domains).toEqual({
-        [ARGUMENT_DOMAIN]: {
-          domain: [1, 3], factory: scaleLinear, isDiscrete: false,
-        },
-        [VALUE_DOMAIN]: {
-          domain: [11, 23], factory: scaleLinear, isDiscrete: false,
-        },
-      });
-      expect(getValueDomain).toBeCalledWith(points);
-    });
-
     it('should compute domains from series points, negative values', () => {
       const domains = extendDomains(testDomains as any, {
         getPointTransformer, points: [{ argument: 1, value: 9 }, { argument: 2, value: -10 }],

--- a/packages/dx-chart-core/src/plugins/scale/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.ts
@@ -67,7 +67,8 @@ const updateDomainFactory = (domain: DomainInfo, series: Series, getItem: GetIte
   };
 };
 
-const updateDomainItems = (domain: DomainInfo, items: DomainItems): DomainInfo => {
+/** @internal */
+export const updateDomainItems = (domain: DomainInfo, items: DomainItems): DomainInfo => {
   const merge = domain.isDiscrete ? mergeDiscreteDomains : mergeContinuousDomains;
   const merged = merge(domain.domain, items);
   return merged === domain.domain ? domain : {
@@ -79,12 +80,7 @@ const updateDomainItems = (domain: DomainInfo, items: DomainItems): DomainInfo =
 const getArgumentDomainItems: GetDomainItemsFn = series => series.points.map(getArgument);
 
 const getValueDomainItems: GetDomainItemsFn = (series) => {
-  // TODO: This is a temporary workaround for Stack plugin.
-  // Once scales (or domains) are exposed for modification Stack will modify scale and
-  // this code will be removed.
-  const items = series.getValueDomain
-    ? series.getValueDomain(series.points) : series.points.map(getValue);
-  // TODO: It is also a part of that workaround.
+  const items = series.points.map(getValue);
   return series.getPointTransformer.isStartedFromZero ? [0, ...items] : items;
 };
 

--- a/packages/dx-chart-core/src/plugins/stack/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/stack/computeds.ts
@@ -195,7 +195,7 @@ const extendDomainsWithAdditionalItems = (domains: DomainInfoCache, series: Seri
 // and recalculated from the new stacked data.
 /** @internal */
 export const getStackedDomains: GetStackedDomainsFn = (domains, seriesList) => {
-  const stackedSeries = seriesList.filter(series => series.isStacked);
+  const stackedSeries = seriesList.filter(series => (series as any).isStacked);
   if (!stackedSeries.length) {
     return domains;
   }

--- a/packages/dx-chart-core/src/types/plugins.stack.types.ts
+++ b/packages/dx-chart-core/src/types/plugins.stack.types.ts
@@ -2,6 +2,7 @@ import { PureComputed } from '@devexpress/dx-core';
 import {
   Point, SeriesList, DataItems,
 } from './chart-core.types';
+import { DomainInfoCache } from './plugins.scale.types';
 
 /** @internal */
 export interface StackedPoint extends Point {
@@ -45,3 +46,5 @@ export type StacksOptions = {
 };
 /** @internal */
 export type GetStackedSeriesFn = PureComputed<[SeriesList, DataItems, StacksOptions]>;
+/** @internal */
+export type GetStackedDomainsFn = PureComputed<[DomainInfoCache, SeriesList]>;

--- a/packages/dx-react-chart/src/plugins/stack.test.tsx
+++ b/packages/dx-react-chart/src/plugins/stack.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import { PluginHost } from '@devexpress/dx-react-core';
 import { pluginDepsToComponents, getComputedState } from '@devexpress/dx-testing';
 import { stackOrderNone, stackOffsetDiverging } from 'd3-shape';
-import { getStackedSeries } from '@devexpress/dx-chart-core';
+import { getStackedSeries, getStackedDomains } from '@devexpress/dx-chart-core';
 import { Stack } from './stack';
 
 jest.mock('d3-shape', () => ({
@@ -13,6 +13,7 @@ jest.mock('d3-shape', () => ({
 
 jest.mock('@devexpress/dx-chart-core', () => ({
   getStackedSeries: jest.fn().mockReturnValue('stacked-series'),
+  getStackedDomains: jest.fn().mockReturnValue('stacked-domains'),
 }));
 
 describe('Stack', () => {
@@ -20,6 +21,7 @@ describe('Stack', () => {
 
   const deps = {
     getter: {
+      domains: 'test-domains',
       series: 'test-series',
       data: 'test-data',
     },
@@ -41,14 +43,16 @@ describe('Stack', () => {
     ));
 
     expect(getComputedState(tree)).toEqual({
-      data: 'test-data',
+      ...deps.getter,
       series: 'stacked-series',
+      domains: 'stacked-domains',
     });
     expect(getStackedSeries).toBeCalledWith('test-series', 'test-data', {
       stacks: testStacks,
       offset: testOffset,
       order: testOrder,
     });
+    expect(getStackedDomains).toBeCalledWith('test-domains', 'stacked-series');
   });
 
   it('should provide default options', () => {
@@ -60,13 +64,15 @@ describe('Stack', () => {
     ));
 
     expect(getComputedState(tree)).toEqual({
-      data: 'test-data',
+      ...deps.getter,
       series: 'stacked-series',
+      domains: 'stacked-domains',
     });
     expect(getStackedSeries).toBeCalledWith('test-series', 'test-data', {
       stacks: [],
       offset: stackOffsetDiverging,
       order: stackOrderNone,
     });
+    expect(getStackedDomains).toBeCalledWith('test-domains', 'stacked-series');
   });
 });

--- a/packages/dx-react-chart/src/plugins/stack.tsx
+++ b/packages/dx-react-chart/src/plugins/stack.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { Plugin, Getter, Getters } from '@devexpress/dx-react-core';
-import { getStackedSeries } from '@devexpress/dx-chart-core';
+import { getStackedSeries, getStackedDomains } from '@devexpress/dx-chart-core';
 import { StackProps, StacksOptions, OffsetFn, OrderFn } from '../types';
 import {
   stackOrderNone,
   stackOffsetDiverging,
 } from 'd3-shape';
+
+const doGetStackedDomains = ({ domains, series }: Getters) => getStackedDomains(domains, series);
 
 class StackBase extends React.PureComponent<StackProps> {
   static defaultProps: Partial<StackProps> = {
@@ -25,6 +27,7 @@ class StackBase extends React.PureComponent<StackProps> {
     return (
       <Plugin name="Stack">
         <Getter name="series" computed={getSeries} />
+        <Getter name="domains" computed={doGetStackedDomains} />
       </Plugin>
     );
   }

--- a/packages/dx-react-chart/src/plugins/stack.tsx
+++ b/packages/dx-react-chart/src/plugins/stack.tsx
@@ -7,7 +7,7 @@ import {
   stackOffsetDiverging,
 } from 'd3-shape';
 
-const doGetStackedDomains = ({ domains, series }: Getters) => getStackedDomains(domains, series);
+const getDomains = ({ domains, series }: Getters) => getStackedDomains(domains, series);
 
 class StackBase extends React.PureComponent<StackProps> {
   static defaultProps: Partial<StackProps> = {
@@ -27,7 +27,7 @@ class StackBase extends React.PureComponent<StackProps> {
     return (
       <Plugin name="Stack">
         <Getter name="series" computed={getSeries} />
-        <Getter name="domains" computed={doGetStackedDomains} />
+        <Getter name="domains" computed={getDomains} />
       </Plugin>
     );
   }


### PR DESCRIPTION
`getPointTransformer.getValueDomains` is removed.