### PR TITLE
chore(react-chart): fix bar margins in viewport

### DIFF
--- a/packages/dx-chart-core/src/plugins/scale/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/scale/computeds.ts
@@ -1,6 +1,6 @@
 import { extent } from 'd3-array';
 import {
-  getValueDomainName, scaleLinear, scaleBand, makeScale,
+  getValueDomainName, scaleLinear, scaleBand, rangesEqual, makeScale,
 } from '../../utils/scale';
 import { ARGUMENT_DOMAIN, VALUE_DOMAIN } from '../../constants';
 import {
@@ -27,12 +27,9 @@ export const addDomain: AddDomainFn = (domains, name, options) => ({
   [name]: makeDomain(options),
 });
 
-const floatsEqual = (a: number, b: number) => Math.abs(a - b) < Number.EPSILON;
-
 const mergeContinuousDomains: MergeDomainsFn = (domain, items) => {
   const newDomain = extent([...domain, ...items]);
-  return floatsEqual(newDomain[0], domain[0]) && floatsEqual(newDomain[1], domain[1])
-    ? domain : newDomain;
+  return rangesEqual(newDomain as any, domain as any) ? domain : newDomain;
 };
 
 const mergeDiscreteDomains: MergeDomainsFn = (domain, items) => {

--- a/packages/dx-chart-core/src/plugins/viewport/computeds.test.ts
+++ b/packages/dx-chart-core/src/plugins/viewport/computeds.test.ts
@@ -7,6 +7,7 @@ import {
 import { adjustLayout } from './computeds';
 
 jest.mock('../../utils/scale', () => ({
+  ...require.requireActual('../../utils/scale'),  // for `rangesEqual`
   getValueDomainName: jest.fn(),
   makeScale: jest.fn(),
   scaleBounds: jest.fn(),

--- a/packages/dx-chart-core/src/plugins/viewport/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/viewport/computeds.ts
@@ -2,7 +2,7 @@ import {
   ARGUMENT_DOMAIN, VALUE_DOMAIN,
 } from '../../constants';
 import {
-  getValueDomainName, makeScale, scaleBounds,
+  getValueDomainName, rangesEqual, makeScale, scaleBounds,
 } from '../../utils/scale';
 import {
   DomainInfoCache,
@@ -12,9 +12,6 @@ import {
   NumberArray,
   ViewportOptions,
 } from '../../types';
-
-// TODO: Copypaste!
-const floatsEqual = (a: number, b: number) => Math.abs(a - b) < Number.EPSILON;
 
 // Given original scale
 //   f(domain) = range
@@ -39,10 +36,7 @@ const proportionallyExtendRange = (range: NumberArray, subRange: NumberArray): N
 const adjustRange = (domain: DomainInfo, bounds: DomainBounds, range: NumberArray) => {
   const scale = makeScale(domain, range);
   const subRange = scaleBounds(scale, bounds);
-  if (floatsEqual(subRange[0], range[0]) && floatsEqual(subRange[1], range[1])) {
-    return range;
-  }
-  return proportionallyExtendRange(range, subRange);
+  return rangesEqual(subRange, range) ? range : proportionallyExtendRange(range, subRange);
 };
 
 const update = (

--- a/packages/dx-chart-core/src/utils/scale.test.ts
+++ b/packages/dx-chart-core/src/utils/scale.test.ts
@@ -106,25 +106,33 @@ describe('#scaleBounds', () => {
     scale.mockReturnValueOnce(30);
     scale.mockReturnValueOnce(40);
 
-    const range = scaleBounds(scale as any, [1, 2]);
+    const range = scaleBounds(scale as any, [40, 30]);
 
     expect(range).toEqual([30, 40]);
     expect(scale.mock.calls).toEqual([
-      [1], [2],
+      [40, 0, expect.anything()],
+      [30, 1, expect.anything()],
     ]);
   });
 
   it('should measure discrete scale', () => {
-    const scale = jest.fn();
+    const scale = jest.fn() as any;
+    scale.copy = jest.fn().mockReturnThis();
+    scale.paddingInner = jest.fn().mockReturnThis();
+    scale.paddingOuter = jest.fn().mockReturnThis();
     scale.mockReturnValueOnce(30);
     scale.mockReturnValueOnce(40);
-    (scale as any).bandwidth = () => 5;
+    scale.bandwidth = () => 5;
 
-    const range = scaleBounds(scale as any, [1, 2]);
+    const range = scaleBounds(scale, ['A', 'B']);
 
     expect(range).toEqual([30, 45]);
     expect(scale.mock.calls).toEqual([
-      [1], [2],
+      ['A'],
+      ['B'],
     ]);
+    expect(scale.copy).toBeCalledWith();
+    expect(scale.paddingInner).toBeCalledWith(0);
+    expect(scale.paddingOuter).toBeCalledWith(0);
   });
 });

--- a/packages/dx-chart-core/src/utils/scale.ts
+++ b/packages/dx-chart-core/src/utils/scale.ts
@@ -35,9 +35,13 @@ export const makeScale = ({ factory, domain }: DomainInfo, range: NumberArray) =
 // it resides here so that internal scale specifics (*getWidth*)
 // are encapsulated in this utility file.
 /** @internal */
-export const scaleBounds = (scale: ScaleObject, bounds: DomainBounds): NumberArray => (
-  [scale(bounds[0]), scale(bounds[1]) + getWidth(scale)]
-);
+export const scaleBounds = (scale: ScaleObject, bounds: DomainBounds): NumberArray => {
+  if (scale.bandwidth) {
+    const cleanScale = scale.copy().paddingInner!(0).paddingOuter!(0);
+    return [cleanScale(bounds[0]), cleanScale(bounds[1]) + cleanScale.bandwidth!()];
+  }
+  return bounds.map(scale) as NumberArray;
+};
 
 /** @internal */
 export const fixOffset = (scale: ScaleObject): ((value: number) => number) => {

--- a/packages/dx-chart-core/src/utils/scale.ts
+++ b/packages/dx-chart-core/src/utils/scale.ts
@@ -26,6 +26,12 @@ export const getWidth = (scale: ScaleObject) => (
 /** @internal */
 export const getValueDomainName = (name?: string) => name || VALUE_DOMAIN;
 
+const floatsEqual = (a: number, b: number) => Math.abs(a - b) < Number.EPSILON;
+
+/** @internal */
+export const rangesEqual = (r1: NumberArray, r2: NumberArray) =>
+  floatsEqual(r1[0], r2[0]) && floatsEqual(r1[1], r2[1]);
+
 /** @internal */
 export const makeScale = ({ factory, domain }: DomainInfo, range: NumberArray) => (
   (factory || scaleLinear)().domain(domain).range(range)


### PR DESCRIPTION
Band scale paddings are reset before bounds are scaled.