### PR TITLE
Fix drag and drop transform for IE11

### DIFF
--- a/packages/dx-react-grid-material-ui/src/templates/drag-drop.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/drag-drop.jsx
@@ -28,6 +28,7 @@ const ContainerBase = ({
     className={classNames(classes.container, className)}
     style={{
       transform: `translate(calc(${clientOffset.x}px - 50%), calc(${clientOffset.y}px - 50%))`,
+      msTransform: `translateX(${clientOffset.x}px) translateX(-50%) translateY(${clientOffset.y}px) translateY(-50%)`,
       ...style,
     }}
     {...restProps}


### PR DESCRIPTION
Fixes drag and drop transform on IE11. Otherwise element being dragged is stuck in top left corner