### PR TITLE
chore(react-core): fix TemplatePlaceholder updating

### DIFF
--- a/packages/dx-react-core/src/plugin-based/template-placeholder.test.tsx
+++ b/packages/dx-react-core/src/plugin-based/template-placeholder.test.tsx
@@ -322,4 +322,40 @@ describe('TemplatePlaceholder', () => {
     expect(() => { wrapper.unmount(); })
       .not.toThrow();
   });
+
+  it('should return content of the associated template', () => {
+    const Tester = ({ name }) => {
+      return (
+        <Plugin name="Tester">
+          <Template name="test">
+            <TemplatePlaceholder />
+            <div className={name}>{name}</div>
+          </Template>
+        </Plugin>
+      );
+    };
+
+    const Root = ({ enabled }) => (
+      <div className="container">
+        <PluginHost>
+          <Template name="root">
+            <TemplatePlaceholder  name="test" />
+          </Template>
+          <Template name="test">
+            <div className="root">root</div>
+          </Template>
+
+          <Tester name="t1" />
+          {enabled && <Tester name="t2" />}
+        </PluginHost>
+      </div>
+    );
+
+    const tree = mount(<Root enabled={true} />);
+    tree.setProps({ enabled: false });
+
+    expect(tree.find('.container').html()).toEqual((
+      '<div class="container"><div class="root">root</div><div class="t1">t1</div></div>'
+    ));
+  });
 });

--- a/packages/dx-react-core/src/plugin-based/template-placeholder.test.tsx
+++ b/packages/dx-react-core/src/plugin-based/template-placeholder.test.tsx
@@ -339,7 +339,7 @@ describe('TemplatePlaceholder', () => {
       <div className="container">
         <PluginHost>
           <Template name="root">
-            <TemplatePlaceholder  name="test" />
+            <TemplatePlaceholder name="test" />
           </Template>
           <Template name="test">
             <div className="root">root</div>

--- a/packages/dx-react-core/src/plugin-based/template-placeholder.tsx
+++ b/packages/dx-react-core/src/plugin-based/template-placeholder.tsx
@@ -63,9 +63,11 @@ class TemplatePlaceholderBase extends React.Component<Props> {
   }
 
   shouldComponentUpdate(nextProps: Props) {
-    const { params } = getRenderingData(nextProps);
+    const { params, templates } = getRenderingData(nextProps);
     const { children } = this.props;
-    return !shallowEqual(params, this.params) || children !== nextProps.children;
+    const [template] = templates;
+    return children !== nextProps.children || this.template !== template
+      || !shallowEqual(this.params, params);
   }
 
   componentWillUnmount() {

--- a/packages/dx-react-core/src/plugin-based/template-placeholder.tsx
+++ b/packages/dx-react-core/src/plugin-based/template-placeholder.tsx
@@ -38,7 +38,6 @@ class TemplatePlaceholderBase extends React.Component<Props> {
   };
   template: TemplateBase | null = null;
   params: object = {};
-  restTemplates: TemplateBase[] = [];
 
   componentDidMount() {
     const { [PLUGIN_HOST_CONTEXT]: pluginHost } = this.props;
@@ -79,7 +78,7 @@ class TemplatePlaceholderBase extends React.Component<Props> {
 
     this.params = params;
     [this.template] = templates;
-    this.restTemplates = templates.slice(1);
+    const restTemplates = templates.slice(1);
 
     let content: ((...args) => any) | null = null;
     if (this.template) {
@@ -95,7 +94,7 @@ class TemplatePlaceholderBase extends React.Component<Props> {
     return (
       <TemplateHostContext.Provider
         value={{
-          templates: () => this.restTemplates,
+          templates: () => restTemplates,
           params: () => this.params,
         }}
       >

--- a/packages/dx-react-core/src/plugin-based/template-placeholder.tsx
+++ b/packages/dx-react-core/src/plugin-based/template-placeholder.tsx
@@ -20,25 +20,25 @@ interface TemplateHostContextProps {
   [TEMPLATE_HOST_CONTEXT: string]: TemplateHostInterface;
 }
 
-class TemplatePlaceholderBase extends React.Component<
-  TemplatePlaceholderProps & PluginContextProps & TemplateHostContextProps
-> {
+type Props = TemplatePlaceholderProps & PluginContextProps & TemplateHostContextProps;
+
+class TemplatePlaceholderBase extends React.Component<Props> {
   subscription: { [key: string]: (args) => void };
   template: TemplateBase | null = null;
   params: object = {};
   restTemplates: TemplateBase[] = [];
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
-    const { name: propsName } = this.props;
+    const { name: propsName } = props;
 
     this.subscription = {
-      [RERENDER_TEMPLATE_EVENT]: (id) => {
+      [RERENDER_TEMPLATE_EVENT]: (id: number) => {
         if (this.template && this.template.id === id) {
           this.forceUpdate();
         }
       },
-      [RERENDER_TEMPLATE_SCOPE_EVENT]: (name) => {
+      [RERENDER_TEMPLATE_SCOPE_EVENT]: (name: string) => {
         if (propsName === name) {
           this.forceUpdate();
         }
@@ -51,7 +51,7 @@ class TemplatePlaceholderBase extends React.Component<
     pluginHost.registerSubscription(this.subscription);
   }
 
-  shouldComponentUpdate(nextProps) {
+  shouldComponentUpdate(nextProps: Props) {
     const { params } = this.getRenderingData(nextProps);
     const { children } = this.props;
     return !shallowEqual(params, this.params) || children !== nextProps.children;
@@ -62,7 +62,7 @@ class TemplatePlaceholderBase extends React.Component<
     pluginHost.unregisterSubscription(this.subscription);
   }
 
-  getRenderingData(props) {
+  getRenderingData(props: Props) {
     const { name, params } = props;
     if (name) {
       const { [PLUGIN_HOST_CONTEXT]: pluginHost } = this.props;
@@ -87,7 +87,7 @@ class TemplatePlaceholderBase extends React.Component<
     [this.template] = templates;
     this.restTemplates = templates.slice(1);
 
-    let content: ((...args) => any)| null = null;
+    let content: ((...args) => any) | null = null;
     if (this.template) {
       const { children: templateContent } = this.template;
 

--- a/packages/dx-react-core/src/plugin-based/template-placeholder.tsx
+++ b/packages/dx-react-core/src/plugin-based/template-placeholder.tsx
@@ -23,28 +23,22 @@ interface TemplateHostContextProps {
 type Props = TemplatePlaceholderProps & PluginContextProps & TemplateHostContextProps;
 
 class TemplatePlaceholderBase extends React.Component<Props> {
-  subscription: { [key: string]: (args) => void };
+  subscription = {
+    [RERENDER_TEMPLATE_EVENT]: (id: number) => {
+      if (this.template && this.template.id === id) {
+        this.forceUpdate();
+      }
+    },
+    [RERENDER_TEMPLATE_SCOPE_EVENT]: (name: string) => {
+      const { name: propsName } = this.props;
+      if (propsName === name) {
+        this.forceUpdate();
+      }
+    },
+  };
   template: TemplateBase | null = null;
   params: object = {};
   restTemplates: TemplateBase[] = [];
-
-  constructor(props: Props) {
-    super(props);
-    const { name: propsName } = props;
-
-    this.subscription = {
-      [RERENDER_TEMPLATE_EVENT]: (id: number) => {
-        if (this.template && this.template.id === id) {
-          this.forceUpdate();
-        }
-      },
-      [RERENDER_TEMPLATE_SCOPE_EVENT]: (name: string) => {
-        if (propsName === name) {
-          this.forceUpdate();
-        }
-      },
-    };
-  }
 
   componentDidMount() {
     const { [PLUGIN_HOST_CONTEXT]: pluginHost } = this.props;


### PR DESCRIPTION
## What

Given a plugin

```jsx
const Tester = ({ data }) => (
  <Plugin name="Tester">
    <Template name="test">
      <TemplatePlaceholder />
      <div>{data}</div>
    </Template>
  </Plugin>
);
```

The content is changed from

```jsx
<Tester data={1} />
<Tester data={2} />
<Tester data={3} />
```

to

```jsx
<Tester data={1} />
<Tester data={2} />
```

The resulting markup is expected to change from

```jsx
<div>1</div>
<div>2</div>
<div>3</div>
```

to

```jsx
<div>1</div>
<div>2</div>
```

Though it actually is

```jsx
<div>1</div>
<div>2</div>
<div>2</div>
```

## Why

When *Tester (3)* is removed the *previous* state

```jsx
<TemplatePlaceholder /> (from 3)
<div>3</div>
```

is compared to the *next* state

```jsx
<TemplatePlaceholder /> (from 2)
<div>2</div>
```

As a result, *TemplatePlaceholder* element is taken from the *previous* state (because it is considered as **not changed**) and *div* is updated (content is changed from *3* to *2*).
*TemplatePlaceholder (from 3)* then translates to

```jsx
<div>1</div>
<div>2</div>
```

(because it is *TemplatePlaceholder* from `<Tester data={3} />`).
And so we have

```jsx
<div>1</div>
<div>2</div>
<div>2</div> (updated from 3)
```

If it was *TemplatePlaceholder (from 2)* then it would translate to

```jsx
<div>1</div>
```

and result would be

```jsx
<div>1</div>
<div>2</div> (updated from 3)
```

## Expected

*TemplatePlaceholder* should take into account the template it belongs to.
It already has custom `shouldComponentUpdate` - method should be updated.

