### PR TITLE
chore(react-chart): fix series remounting on tooltip update

### DIFF
--- a/packages/dx-react-chart-demos/src/demo-sources/bar-chart/bootstrap4/series-interaction.jsx
+++ b/packages/dx-react-chart-demos/src/demo-sources/bar-chart/bootstrap4/series-interaction.jsx
@@ -197,7 +197,7 @@ export default class Demo extends React.PureComponent {
           <EventTracker onClick={this.click} />
           <HoverState hover={hover} onHoverChange={this.changeHover} />
           <Tooltip
-            targetItem={tooltipEnabled ? tooltipTarget : null}
+            targetItem={tooltipEnabled && tooltipTarget}
             onTargetItemChange={this.changeTooltip}
             contentComponent={TooltipContent}
           />

--- a/packages/dx-react-chart-demos/src/demo-sources/bar-chart/bootstrap4/series-interaction.jsx
+++ b/packages/dx-react-chart-demos/src/demo-sources/bar-chart/bootstrap4/series-interaction.jsx
@@ -124,6 +124,7 @@ export default class Demo extends React.PureComponent {
     this.state = {
       hover: null,
       selection: [{ series: 'USA', point: 3 }],
+      tooltipTarget: null,
       tooltipEnabled: true,
     };
 
@@ -136,6 +137,7 @@ export default class Demo extends React.PureComponent {
       }
     };
     this.changeHover = hover => this.setState({ hover });
+    this.changeTooltip = targetItem => this.setState({ tooltipTarget: targetItem });
 
     this.clearSelection = () => this.setState({ selection: [] });
     this.turnPrevSelection = () => this.setState(({ selection }) => {
@@ -157,11 +159,14 @@ export default class Demo extends React.PureComponent {
 
     this.toggleTooltip = () => this.setState(({ tooltipEnabled }) => ({
       tooltipEnabled: !tooltipEnabled,
+      tooltipTarget: null,
     }));
   }
 
   render() {
-    const { hover, selection, tooltipEnabled } = this.state;
+    const {
+      hover, selection, tooltipTarget, tooltipEnabled,
+    } = this.state;
 
     return (
       <div className="card">
@@ -191,7 +196,11 @@ export default class Demo extends React.PureComponent {
           <Legend position="bottom" rootComponent={Root} />
           <EventTracker onClick={this.click} />
           <HoverState hover={hover} onHoverChange={this.changeHover} />
-          {tooltipEnabled && <Tooltip contentComponent={TooltipContent} />}
+          <Tooltip
+            targetItem={tooltipEnabled ? tooltipTarget : null}
+            onTargetItemChange={this.changeTooltip}
+            contentComponent={TooltipContent}
+          />
           <SelectionState selection={selection} />
           <Animation />
         </Chart>

--- a/packages/dx-react-chart-demos/src/demo-sources/bar-chart/material-ui/series-interaction.jsx
+++ b/packages/dx-react-chart-demos/src/demo-sources/bar-chart/material-ui/series-interaction.jsx
@@ -248,7 +248,7 @@ class Demo extends React.PureComponent {
           <EventTracker onClick={this.click} />
           <HoverState hover={hover} onHoverChange={this.changeHover} />
           <Tooltip
-            targetItem={tooltipEnabled ? tooltipTarget : null}
+            targetItem={tooltipEnabled && tooltipTarget}
             onTargetItemChange={this.changeTooltip}
             contentComponent={TooltipContent}
           />

--- a/packages/dx-react-chart-demos/src/demo-sources/bar-chart/material-ui/series-interaction.jsx
+++ b/packages/dx-react-chart-demos/src/demo-sources/bar-chart/material-ui/series-interaction.jsx
@@ -174,6 +174,7 @@ class Demo extends React.PureComponent {
     this.state = {
       hover: null,
       selection: [{ series: 'USA', point: 3 }],
+      tooltipTarget: null,
       tooltipEnabled: true,
     };
 
@@ -186,6 +187,7 @@ class Demo extends React.PureComponent {
       }
     };
     this.changeHover = hover => this.setState({ hover });
+    this.changeTooltip = targetItem => this.setState({ tooltipTarget: targetItem });
 
     this.clearSelection = () => this.setState({ selection: [] });
     this.turnPrevSelection = () => this.setState(({ selection }) => {
@@ -207,11 +209,14 @@ class Demo extends React.PureComponent {
 
     this.toggleTooltip = () => this.setState(({ tooltipEnabled }) => ({
       tooltipEnabled: !tooltipEnabled,
+      tooltipTarget: null,
     }));
   }
 
   render() {
-    const { hover, selection, tooltipEnabled } = this.state;
+    const {
+      hover, selection, tooltipTarget, tooltipEnabled,
+    } = this.state;
     const { classes } = this.props;
 
     return (
@@ -242,7 +247,11 @@ class Demo extends React.PureComponent {
           <Legend position="bottom" rootComponent={Root} labelComponent={Label} />
           <EventTracker onClick={this.click} />
           <HoverState hover={hover} onHoverChange={this.changeHover} />
-          {tooltipEnabled && <Tooltip contentComponent={TooltipContent} />}
+          <Tooltip
+            targetItem={tooltipEnabled ? tooltipTarget : null}
+            onTargetItemChange={this.changeTooltip}
+            contentComponent={TooltipContent}
+          />
           <SelectionState selection={selection} />
           <Animation />
         </Chart>


### PR DESCRIPTION
The current (in *master*) version is actually correct and better than the new one. But due to a [side effect](https://github.com/DevExpress/devextreme-reactive/pull/1975#issuecomment-483631146) there are unexpected animations.