### PR TITLE
fix(react-core): prevent Getter losing on Plugin adding

### DIFF
--- a/packages/dx-core/src/plugin-host.ts
+++ b/packages/dx-core/src/plugin-host.ts
@@ -1,4 +1,4 @@
-import { insertPlugin } from './utils';
+import { insertPlugin, removePlugin } from './utils';
 import { Getters } from '@devexpress/dx-react-core';
 
 const getDependencyError = (
@@ -65,7 +65,7 @@ export class PluginHost {
   }
 
   unregisterPlugin(plugin) {
-    this.plugins.splice(this.plugins.indexOf(plugin), 1);
+    this.plugins = removePlugin(this.plugins, plugin);
     this.cleanPluginsCache();
   }
 

--- a/packages/dx-core/src/utils.test.ts
+++ b/packages/dx-core/src/utils.test.ts
@@ -1,13 +1,14 @@
-import { insertPlugin, createClickHandlers, isEdgeBrowser } from './utils';
+import { insertPlugin, removePlugin, createClickHandlers, isEdgeBrowser } from './utils';
 
 describe('utils', () => {
   afterEach(() => {
     jest.resetAllMocks();
   });
-  describe('#insertPlugin', () => {
+
+  describe('#insertPlugin and #removePlugin', () => {
     const mapPlugins = plugins => plugins.map(p => p.position().join());
 
-    it('should work correctly', () => {
+    it('should correctly insert plugin', () => {
       const plugins = [
         { position: () => [1] },
         { position: () => [5, 3] },
@@ -25,6 +26,23 @@ describe('utils', () => {
         .toEqual(['1', '5,3', '7']);
       expect(mapPlugins(insertPlugin(plugins, { position: () => [1] })))
         .toEqual(['1', '5,3']);
+    });
+
+    it('should correctly remove plugin', () => {
+      const plugins = [
+        { position: () => [1] },
+        { position: () => [5, 3] },
+        { position: () => [5, 4] },
+        { position: () => [6] },
+        { position: () => [6, 1] },
+      ];
+
+      expect(mapPlugins(removePlugin(plugins, plugins[1])))
+        .toEqual(['1', '5,4', '6', '6,1']);
+      expect(mapPlugins(removePlugin(plugins, plugins[4])))
+        .toEqual(['1', '5,3', '5,4', '6']);
+      expect(mapPlugins(removePlugin(plugins, { ...plugins[4] })))
+        .toEqual(['1', '5,3', '5,4', '6', '6,1']);
     });
   });
 

--- a/packages/dx-core/src/utils.ts
+++ b/packages/dx-core/src/utils.ts
@@ -23,8 +23,8 @@ export const insertPlugin = (array, newItem) => {
 
 /** @internal */
 export const removePlugin = (array, item) => {
-  const i = array.indexOf(item);
-  return i >= 0 ? [...array.slice(0, i), ...array.slice(i + 1)] : array;
+  const itemIndex = array.indexOf(item);
+  return itemIndex >= 0 ? [...array.slice(0, itemIndex), ...array.slice(itemIndex + 1)] : array;
 };
 
 /** @internal */

--- a/packages/dx-core/src/utils.ts
+++ b/packages/dx-core/src/utils.ts
@@ -1,7 +1,5 @@
-/** @internal */
 const DELAY = 200;
 
-/** @internal */
 const compare = (a, b) => {
   const aPosition = a.position();
   const bPosition = b.position();
@@ -21,6 +19,12 @@ export const insertPlugin = (array, newItem) => {
     && compare(newItem, array[targetIndex]) === 0;
   result.splice(targetIndex, alreadyExists ? 1 : 0, newItem);
   return result;
+};
+
+/** @internal */
+export const removePlugin = (array, item) => {
+  const i = array.indexOf(item);
+  return i >= 0 ? [...array.slice(0, i), ...array.slice(i + 1)] : array;
 };
 
 /** @internal */

--- a/packages/dx-react-core/src/plugin-based/getter.test.tsx
+++ b/packages/dx-react-core/src/plugin-based/getter.test.tsx
@@ -211,4 +211,37 @@ describe('Getter', () => {
     expect(() => { wrapper.unmount(); })
       .not.toThrow();
   });
+
+  it('should not lose Getter when Plugin is inserted', () => {
+    const Tester = ({ enabled }) => (
+      <PluginHost>
+        <Template name="root">
+          <TemplateConnector>
+            {({ a, b }) => (
+              <React.Fragment>
+                <h1 className="a">{a}</h1>
+                <h1 className="b">{b}</h1>
+              </React.Fragment>
+            )}
+          </TemplateConnector>
+        </Template>
+
+        {enabled ? (
+          <Plugin>
+            <Getter name="b" value={3} />
+          </Plugin>
+        ) : []}
+        <Plugin>
+          <Getter name="a" value={1} />
+          <Getter name="b" value={2} />
+        </Plugin>
+      </PluginHost>
+    );
+
+    const tree = mount(<Tester enabled={false} />);
+    tree.setProps({ enabled: true });
+
+    expect(tree.find('.a').text()).toEqual('1');
+    expect(tree.find('.b').text()).toEqual('2');
+  });
 });

--- a/packages/dx-react-core/src/plugin-based/plugin-indexer.tsx
+++ b/packages/dx-react-core/src/plugin-based/plugin-indexer.tsx
@@ -33,7 +33,7 @@ export class PluginIndexer extends React.PureComponent<PluginIndexerProps> {
             const childPosition = this.memoize(index, positionContext);
 
             return (
-              <PositionContext.Provider value={childPosition}>
+              <PositionContext.Provider key={String(index)} value={childPosition}>
                 {child}
               </PositionContext.Provider>
             );


### PR DESCRIPTION
## What happens

`Plugin`, `Getter` and `Template` have internal objects (`this.plugin`) which ordered within `PluginHost` internal object (`this.plugins`) based on corresponding *positions*.
Position originates from component index within its parent children.

For this tree

```jsx
<PluginHost>
  <PluginA />
  <PluginC />
</PluginHost>
```

the list is the following

```js
[ A(0), C(1) ]
```

When tree changes to

```jsx
<PluginHost>
  <PluginA />
  <PluginB />
  <PluginC />
</PluginHost>
```

`PluginB` is created (internal object is created and added to list) and `PluginC` is updated (index changes).
During `PluginB` creation its internal object is created and has position `(1)`. But `PluginC` is not updated by that moment and its internal object position is `(1)` too.
Such position collision is resolved in such a way that `B(1)` replaces `C(1)`. The list is

```js
[ A(0), B(1) ]
```

----
Here is a [sample](https://codesandbox.io/s/py8k0qwy50) of React behavior.
Click the *Change* button and note that *C2* and *C3* are created *C4* and *C5* have outdated indexes.

## What is done

- `key` property is used to force recreation all items going after newly added
- `unregisterPlugin` fixed so that it does not accidentally remove last list item

Because of `key` `PluginC` is destroyed (and `C(1)` is remove from list) and created (and `C(2)` is added to to list) after `PluginB` is created. So the list is

```js
[ A(0), B(1), C(2) ]
```

Since `registerPlugin` allows the case when other list entry is removed (when there is position collision), `unregisterPlugin` should allow the case when no entry is removed (because it could already be removed in `registerPlugin`).


