### PR TITLE
fix(react-grid): correct calculation of available row count in infninite scrolling mode

### DIFF
--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
@@ -328,11 +328,12 @@ describe('VirtualTableState helpers', () => {
   });
 
   describe('#getAvailableRowCount', () => {
-    it('should return totalCount when not infiniteScroll', () => {
+    const nextRowCount = 200;
+    const lastRowCount = 100;
+    const totalRowCount = 1000;
+
+    it('should return totalCount when not infinite scrolling', () => {
       const isInfniniteScroll = false;
-      const nextRowCount = 200;
-      const lastRowCount = 100;
-      const totalRowCount = 1000;
 
       expect(getAvailableRowCount(
         isInfniniteScroll,
@@ -342,11 +343,8 @@ describe('VirtualTableState helpers', () => {
       )).toEqual(totalRowCount);
     });
 
-    it('should return max of nextRowCount or lastRowCount when infiniteScroll', () => {
+    it('should return max of nextRowCount or lastRowCount when infinite scrolling', () => {
       const isInfniniteScroll = true;
-      const nextRowCount = 200;
-      const lastRowCount = 100;
-      const totalRowCount = 1000;
 
       expect(getAvailableRowCount(
         isInfniniteScroll,

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
@@ -368,6 +368,8 @@ describe('VirtualTableState helpers', () => {
         lastRowCount,
         totalRowCount,
       )).toEqual(lastRowCount);
+    });
+  });
 
   describe('#getForceReloadInterval', () => {
     it('should return 2 pages if loaded interval is less than 2 pages', () => {

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
@@ -328,7 +328,7 @@ describe('VirtualTableState helpers', () => {
   });
 
   describe('#getAvailableRowCount', () => {
-    const nextRowCount = 200;
+    const newRowCount = 200;
     const lastRowCount = 100;
     const totalRowCount = 1000;
 
@@ -337,21 +337,21 @@ describe('VirtualTableState helpers', () => {
 
       expect(getAvailableRowCount(
         isInfniniteScroll,
-        nextRowCount,
+        newRowCount,
         lastRowCount,
         totalRowCount,
       )).toEqual(totalRowCount);
     });
 
-    it('should return max of nextRowCount or lastRowCount when infinite scrolling', () => {
+    it('should return max of newRowCount or lastRowCount when infinite scrolling', () => {
       const isInfniniteScroll = true;
 
       expect(getAvailableRowCount(
         isInfniniteScroll,
-        nextRowCount,
+        newRowCount,
         lastRowCount,
         totalRowCount,
-      )).toEqual(Math.max(nextRowCount, lastRowCount));
+      )).toEqual(Math.max(newRowCount, lastRowCount));
     });
 
   });

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
@@ -368,7 +368,7 @@ describe('VirtualTableState helpers', () => {
         lastRowCount,
         totalRowCount,
       )).toEqual(lastRowCount);
-      
+
   describe('#getForceReloadInterval', () => {
     it('should return 2 pages if loaded interval is less than 2 pages', () => {
       expect(getForceReloadInterval({ start: 100, end: 200 }, 100, 1000)).toEqual({

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
@@ -1,6 +1,6 @@
 import {
   mergeRows, calculateRequestedRange, rowToPageIndex,
-  recalculateBounds, trimRowsToInterval,
+  recalculateBounds, trimRowsToInterval, getAvailableRowCount,
 } from './helpers';
 import { intervalUtil } from './utils';
 import { createInterval, generateRows, createVirtualRows } from './test-utils';
@@ -325,5 +325,36 @@ describe('VirtualTableState helpers', () => {
         rows: [],
       });
     });
+  });
+
+  describe('#getAvailableRowCount', () => {
+    it('should return totalCount when not infiniteScroll', () => {
+      const isInfniniteScroll = false;
+      const nextRowCount = 200;
+      const lastRowCount = 100;
+      const totalRowCount = 1000;
+
+      expect(getAvailableRowCount(
+        isInfniniteScroll,
+        nextRowCount,
+        lastRowCount,
+        totalRowCount,
+      )).toEqual(totalRowCount);
+    });
+
+    it('should return max of nextRowCount or lastRowCount when infiniteScroll', () => {
+      const isInfniniteScroll = true;
+      const nextRowCount = 200;
+      const lastRowCount = 100;
+      const totalRowCount = 1000;
+
+      expect(getAvailableRowCount(
+        isInfniniteScroll,
+        nextRowCount,
+        lastRowCount,
+        totalRowCount,
+      )).toEqual(Math.max(nextRowCount, lastRowCount));
+    });
+
   });
 });

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
@@ -344,30 +344,32 @@ describe('VirtualTableState helpers', () => {
       )).toEqual(totalRowCount);
     });
 
-    it('should return newRowCount if it more than lastRowCount in infinite scrolling', () => {
+    describe('infinite scrolling mode', () => {
       const isInfniniteScroll = true;
       const newRowCount = 200;
-      const lastRowCount = 100;
 
-      expect(getAvailableRowCount(
-        isInfniniteScroll,
-        newRowCount,
-        lastRowCount,
-        totalRowCount,
-      )).toEqual(newRowCount);
-    });
+      it('should return newRowCount if it more than lastRowCount in infinite scrolling', () => {
+        const lastRowCount = 100;
 
-    it('should return lastRowCount if it more than newRowCount in infinite scrolling', () => {
-      const isInfniniteScroll = true;
-      const newRowCount = 200;
-      const lastRowCount = 300;
+        expect(getAvailableRowCount(
+          isInfniniteScroll,
+          newRowCount,
+          lastRowCount,
+          totalRowCount,
+        )).toEqual(newRowCount);
+      });
 
-      expect(getAvailableRowCount(
-        isInfniniteScroll,
-        newRowCount,
-        lastRowCount,
-        totalRowCount,
-      )).toEqual(lastRowCount);
+      it('should return lastRowCount if it more than newRowCount in infinite scrolling', () => {
+        const lastRowCount = 300;
+
+        expect(getAvailableRowCount(
+          isInfniniteScroll,
+          newRowCount,
+          lastRowCount,
+          totalRowCount,
+        )).toEqual(lastRowCount);
+      });
+
     });
   });
 

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
@@ -328,12 +328,12 @@ describe('VirtualTableState helpers', () => {
   });
 
   describe('#getAvailableRowCount', () => {
-    const newRowCount = 200;
-    const lastRowCount = 100;
     const totalRowCount = 1000;
 
     it('should return totalCount when not infinite scrolling', () => {
       const isInfniniteScroll = false;
+      const newRowCount = 200;
+      const lastRowCount = 100;
 
       expect(getAvailableRowCount(
         isInfniniteScroll,
@@ -343,16 +343,30 @@ describe('VirtualTableState helpers', () => {
       )).toEqual(totalRowCount);
     });
 
-    it('should return max of newRowCount or lastRowCount when infinite scrolling', () => {
+    it('should return newRowCount if it more than lastRowCount in infinite scrolling', () => {
       const isInfniniteScroll = true;
+      const newRowCount = 200;
+      const lastRowCount = 100;
 
       expect(getAvailableRowCount(
         isInfniniteScroll,
         newRowCount,
         lastRowCount,
         totalRowCount,
-      )).toEqual(Math.max(newRowCount, lastRowCount));
+      )).toEqual(newRowCount);
     });
 
+    it('should return lastRowCount if it more than newRowCount in infinite scrolling', () => {
+      const isInfniniteScroll = true;
+      const newRowCount = 200;
+      const lastRowCount = 300;
+
+      expect(getAvailableRowCount(
+        isInfniniteScroll,
+        newRowCount,
+        lastRowCount,
+        totalRowCount,
+      )).toEqual(lastRowCount);
+    });
   });
 });

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
@@ -107,8 +107,9 @@ export const getAvailableRowCount: PureComputed<[boolean, number, number, number
         Math.max(newRowCount, lastRowCount),
         totalRowCount)
     : totalRowCount
+  );
 };
-                                  
+
 export const getForceReloadInterval: PureComputed<[Interval, number, number], Interval> = (
   { start, end: intervalEnd }, pageSize, totalRowCount,
 ) => {

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
@@ -100,13 +100,12 @@ export const trimRowsToInterval: PureComputed<[VirtualRows, Interval]> = (
 };
 
 export const getAvailableRowCount: PureComputed<[boolean, number, number, number], number> = (
-  infiniteScroll, newCount, lastCount, totalRowCount,
+  infiniteScroll, nextRowCount, lastRowCount, totalRowCount,
 ) => {
-  const maxWhenInfiniteScrolling = Math.min(
-    Math.max(newCount, lastCount),
-    totalRowCount);
   return (infiniteScroll
-    ? maxWhenInfiniteScrolling
+    ? Math.min(
+        Math.max(nextRowCount, lastRowCount),
+        totalRowCount)
     : totalRowCount
   );
 };

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
@@ -101,8 +101,12 @@ export const trimRowsToInterval: PureComputed<[VirtualRows, Interval]> = (
 
 export const getAvailableRowCount: PureComputed<[boolean, number, number, number], number> = (
   infiniteScroll, newCount, lastCount, totalRowCount,
-) => (
-  infiniteScroll
-    ? Math.max(newCount, lastCount)
+) => {
+  const maxWhenInfiniteScrolling = Math.min(
+    Math.max(newCount, lastCount),
+    totalRowCount);
+  return (infiniteScroll
+    ? maxWhenInfiniteScrolling
     : totalRowCount
-);
+  );
+};

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
@@ -100,11 +100,11 @@ export const trimRowsToInterval: PureComputed<[VirtualRows, Interval]> = (
 };
 
 export const getAvailableRowCount: PureComputed<[boolean, number, number, number], number> = (
-  infiniteScroll, nextRowCount, lastRowCount, totalRowCount,
+  infiniteScroll, newRowCount, lastRowCount, totalRowCount,
 ) => {
   return (infiniteScroll
     ? Math.min(
-        Math.max(nextRowCount, lastRowCount),
+        Math.max(newRowCount, lastRowCount),
         totalRowCount)
     : totalRowCount
   );

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
@@ -100,9 +100,9 @@ export const trimRowsToInterval: PureComputed<[VirtualRows, Interval]> = (
 };
 
 export const getAvailableRowCount: PureComputed<[boolean, number, number, number], number> = (
-  infiniteScroll, newRowCount, lastRowCount, totalRowCount,
+  isInfiniteScroll, newRowCount, lastRowCount, totalRowCount,
 ) => {
-  return (infiniteScroll
+  return (isInfiniteScroll
     ? Math.min(
         Math.max(newRowCount, lastRowCount),
         totalRowCount)

--- a/packages/dx-react-grid/src/plugins/virtual-table/virtual-table-state.tsx
+++ b/packages/dx-react-grid/src/plugins/virtual-table/virtual-table-state.tsx
@@ -3,7 +3,7 @@ import { Getter, Action, Plugin, Getters, Actions } from '@devexpress/dx-react-c
 import {
   recalculateBounds, calculateRequestedRange, virtualRowsWithCache,
   trimRowsToInterval, intervalUtil, emptyVirtualRows, plainRows, loadedRowsStart,
-  VirtualRows, Interval,
+  VirtualRows, Interval, getAvailableRowCount,
 } from '@devexpress/dx-grid-core';
 import { VirtualTableStateProps, VirtualTableStateState } from '../../types';
 
@@ -75,9 +75,12 @@ class VirtualTableStateBase extends React.PureComponent<VirtualTableStateProps, 
       getRows(newPageIndex, loadCount);
 
       const virtualRowsCache = trimRowsToInterval(virtualRows, newBounds);
-      const newRowCount = infiniteScrolling
-        ? Math.max(newBounds.end + loadCount, stateAvailableCount)
-        : totalRowCount;
+      const newRowCount = getAvailableRowCount(
+        infiniteScrolling,
+        newBounds.end + loadCount,
+        stateAvailableCount,
+        totalRowCount,
+      );
 
       this.setState({
         virtualRowsCache,


### PR DESCRIPTION
Fix #2197