### PR TITLE
fix(react-chart): fix tooltip customization

### DIFF
--- a/packages/dx-react-bootstrap4/components/popover.jsx
+++ b/packages/dx-react-bootstrap4/components/popover.jsx
@@ -6,7 +6,7 @@ import * as PropTypes from 'prop-types';
 import { Popper } from 'react-popper';
 
 const DefaultArrowComponent = ({ arrowProps }) => (
-  <div className="arrow" ref={arrowProps.ref} style={arrowProps.style} />
+  <div className="arrow" {...arrowProps} />
 );
 
 DefaultArrowComponent.propTypes = {

--- a/packages/dx-react-bootstrap4/components/popover.jsx
+++ b/packages/dx-react-bootstrap4/components/popover.jsx
@@ -78,9 +78,9 @@ export class Popover extends React.PureComponent {
   renderPopper() {
     const {
       children, target, renderInBody,
-      arrowComponent: ArrowComponent = DefaultArrowComponent, ...restProps
+      arrowComponent: ArrowComponent, ...restProps
     } = this.props;
-
+    const { placement: poperPlacement } = this.props;
     return (
       <Popper
         referenceElement={target}
@@ -93,7 +93,7 @@ export class Popover extends React.PureComponent {
             <div className="popover-inner" ref={this.contentRef}>
               {children}
             </div>
-            <ArrowComponent arrowProps={arrowProps} placement={placement} />
+            <ArrowComponent arrowProps={arrowProps} placement={poperPlacement} />
           </div>
         )}
       </Popper>
@@ -137,5 +137,5 @@ Popover.defaultProps = {
   isOpen: false,
   placement: 'auto',
   toggle: undefined,
-  arrowComponent: undefined,
+  arrowComponent: DefaultArrowComponent,
 };

--- a/packages/dx-react-bootstrap4/components/popover.jsx
+++ b/packages/dx-react-bootstrap4/components/popover.jsx
@@ -5,6 +5,14 @@ import * as ReactDOM from 'react-dom';
 import * as PropTypes from 'prop-types';
 import { Popper } from 'react-popper';
 
+const DefaultArrowComponent = ({ arrowProps }) => (
+  <div className="arrow" ref={arrowProps.ref} style={arrowProps.style} />
+);
+
+DefaultArrowComponent.propTypes = {
+  arrowProps: PropTypes.object.isRequired,
+};
+
 export class Popover extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -69,7 +77,8 @@ export class Popover extends React.PureComponent {
 
   renderPopper() {
     const {
-      children, target, renderInBody, ...restProps
+      children, target, renderInBody,
+      arrowComponent: ArrowComponent = DefaultArrowComponent, ...restProps
     } = this.props;
 
     return (
@@ -84,7 +93,7 @@ export class Popover extends React.PureComponent {
             <div className="popover-inner" ref={this.contentRef}>
               {children}
             </div>
-            <div className="arrow" ref={arrowProps.ref} style={arrowProps.style} />
+            <ArrowComponent arrowProps={arrowProps} placement={placement} />
           </div>
         )}
       </Popper>
@@ -119,6 +128,7 @@ Popover.propTypes = {
     PropTypes.object,
   ]),
   toggle: PropTypes.func,
+  arrowComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
 };
 
 Popover.defaultProps = {
@@ -127,4 +137,5 @@ Popover.defaultProps = {
   isOpen: false,
   placement: 'auto',
   toggle: undefined,
+  arrowComponent: undefined,
 };

--- a/packages/dx-react-bootstrap4/components/popover.jsx
+++ b/packages/dx-react-bootstrap4/components/popover.jsx
@@ -5,14 +5,14 @@ import * as ReactDOM from 'react-dom';
 import * as PropTypes from 'prop-types';
 import { Popper } from 'react-popper';
 
-const DefaultArrowComponent = ({ placement, refEl, ...restProps }) => (
-  <div className="arrow" ref={refEl} {...restProps} />
+const Arrow = ({ placement, ...restProps }, ref) => (
+  <div className="arrow" ref={ref} {...restProps} />
 );
 
-DefaultArrowComponent.propTypes = {
+Arrow.propTypes = {
   placement: PropTypes.string.isRequired,
-  refEl: PropTypes.func.isRequired,
 };
+const DefaultArrowComponent = React.forwardRef(Arrow);
 
 export class Popover extends React.PureComponent {
   constructor(props) {
@@ -94,8 +94,7 @@ export class Popover extends React.PureComponent {
               {children}
             </div>
             <ArrowComponent
-              refEl={arrowProps.ref}
-              style={arrowProps.style}
+              {...arrowProps}
               placement={restProps.placement}
             />
           </div>

--- a/packages/dx-react-bootstrap4/components/popover.jsx
+++ b/packages/dx-react-bootstrap4/components/popover.jsx
@@ -80,7 +80,6 @@ export class Popover extends React.PureComponent {
       children, target, renderInBody,
       arrowComponent: ArrowComponent, ...restProps
     } = this.props;
-    const { placement: poperPlacement } = this.props;
     return (
       <Popper
         referenceElement={target}
@@ -93,7 +92,7 @@ export class Popover extends React.PureComponent {
             <div className="popover-inner" ref={this.contentRef}>
               {children}
             </div>
-            <ArrowComponent arrowProps={arrowProps} placement={poperPlacement} />
+            <ArrowComponent arrowProps={arrowProps} placement={restProps.placement} />
           </div>
         )}
       </Popper>

--- a/packages/dx-react-bootstrap4/components/popover.jsx
+++ b/packages/dx-react-bootstrap4/components/popover.jsx
@@ -5,12 +5,13 @@ import * as ReactDOM from 'react-dom';
 import * as PropTypes from 'prop-types';
 import { Popper } from 'react-popper';
 
-const DefaultArrowComponent = ({ arrowProps }) => (
-  <div className="arrow" {...arrowProps} />
+const DefaultArrowComponent = ({ placement, refEl, ...restProps }) => (
+  <div className="arrow" ref={refEl} {...restProps} />
 );
 
 DefaultArrowComponent.propTypes = {
-  arrowProps: PropTypes.object.isRequired,
+  placement: PropTypes.string.isRequired,
+  refEl: PropTypes.func.isRequired,
 };
 
 export class Popover extends React.PureComponent {
@@ -92,7 +93,11 @@ export class Popover extends React.PureComponent {
             <div className="popover-inner" ref={this.contentRef}>
               {children}
             </div>
-            <ArrowComponent arrowProps={arrowProps} placement={restProps.placement} />
+            <ArrowComponent
+              refEl={arrowProps.ref}
+              style={arrowProps.style}
+              placement={restProps.placement}
+            />
           </div>
         )}
       </Popper>

--- a/packages/dx-react-bootstrap4/components/popover.test.jsx
+++ b/packages/dx-react-bootstrap4/components/popover.test.jsx
@@ -54,9 +54,19 @@ describe('BS4 Popover', () => {
 
       expect(tree.find('.popover.show.bs-popover-undefined').exists()).toBeTruthy();
       expect(tree.find('.popover').children()).toHaveLength(2);
-      expect(tree.find('.popover > .arrow').exists()).toBeTruthy();
+      expect(tree.find('.arrow').exists()).toBeTruthy();
       expect(tree.find('.popover > .popover-inner').exists()).toBeTruthy();
       expect(tree.find('.popover-inner').childAt(0).is(Content)).toBeTruthy();
+    });
+
+    it('should render custom arrow component', () => {
+      const ArrowComponent = () => null;
+      const tree = mount((
+        <Popover target={target} placement="bottom" isOpen arrowComponent={ArrowComponent}>
+          <Content />
+        </Popover>
+      ), { attachTo: container });
+      expect(tree.find(ArrowComponent).exists()).toBeTruthy();
     });
 
     it('should render outside a container if container is body', () => {

--- a/packages/dx-react-chart-bootstrap4/api/dx-react-chart-bootstrap4.api.md
+++ b/packages/dx-react-chart-bootstrap4/api/dx-react-chart-bootstrap4.api.md
@@ -289,18 +289,32 @@ export namespace Tooltip {
   export type ContentProps = Tooltip_2.ContentProps;
 }
 
+// @public (undocumented)
+export namespace Tooltip {
+  export type ArrowProps = Tooltip_2.ArrowProps;
+}
+
+// @public (undocumented)
+export namespace Tooltip {
+  export type SheetProps = Tooltip_2.SheetProps;
+}
+
 // @public
 export const Tooltip: React.ComponentType<TooltipProps> & {
   Overlay: React.ComponentType<Tooltip_2.OverlayProps & { className?: string; style?: React.CSSProperties; [x: string]: any }>;
   Content: React.ComponentType<Tooltip_2.ContentProps & { className?: string; style?: React.CSSProperties; [x: string]: any }>;
+  Arrow: React.ComponentType<Tooltip_2.ArrowProps & { className?: string; style?: React.CSSProperties; [x: string]: any }>;
+  Sheet: React.ComponentType<Tooltip_2.SheetProps & { className?: string; style?: React.CSSProperties; [x: string]: any }>;
 };
 
 // @public (undocumented)
 export interface TooltipProps {
+  arrowComponent?: React.ComponentType<Tooltip_2.ArrowProps>;
   contentComponent?: React.ComponentType<Tooltip_2.ContentProps>;
   defaultTargetItem?: SeriesRef;
   onTargetItemChange?: (target: SeriesRef) => void;
   overlayComponent?: React.ComponentType<Tooltip_2.OverlayProps>;
+  sheetComponent?: React.ComponentType<Tooltip_2.SheetProps>;
   targetItem?: SeriesRef;
 }
 

--- a/packages/dx-react-chart-bootstrap4/src/plugins/tooltip.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/plugins/tooltip.jsx
@@ -2,5 +2,9 @@ import { Tooltip as TooltipBase } from '@devexpress/dx-react-chart';
 import { withComponents } from '@devexpress/dx-react-core';
 import { Overlay } from '../templates/tooltip/overlay';
 import { Content } from '../templates/tooltip/content';
+import { Arrow } from '../templates/tooltip/arrow';
+import { Sheet } from '../templates/tooltip/sheet';
 
-export const Tooltip = withComponents({ Overlay, Content })(TooltipBase);
+export const Tooltip = withComponents({
+  Overlay, Content, Arrow, Sheet,
+})(TooltipBase);

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.jsx
@@ -3,12 +3,12 @@ import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 export const Arrow = ({
-  arrowProps, className, placement, ...restProps
+  className, placement, refEl, ...restProps
 }) => (
-  <div className={classNames('arrow', className)} {...arrowProps} {...restProps} />
+  <div className={classNames('arrow', className)} ref={refEl} {...restProps} />
 );
 Arrow.propTypes = {
-  arrowProps: PropTypes.object.isRequired,
+  refEl: PropTypes.func.isRequired,
   placement: PropTypes.string.isRequired,
   className: PropTypes.string,
 };

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.jsx
@@ -2,11 +2,14 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export const Arrow = ({ arrowProps, className }) => (
-  <div className={classNames('arrow', className)} {...arrowProps} />
+export const Arrow = ({
+  arrowProps, className, placement, ...restProps
+}) => (
+  <div className={classNames('arrow', className)} {...arrowProps} {...restProps} />
 );
 Arrow.propTypes = {
   arrowProps: PropTypes.object.isRequired,
+  placement: PropTypes.string.isRequired,
   className: PropTypes.string,
 };
 

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.jsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+
+export const Arrow = ({ arrowProps }) => (
+  <div className="arrow" {...arrowProps} />
+);
+
+Arrow.propTypes = {
+  arrowProps: PropTypes.any.isRequired,
+};

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.jsx
@@ -2,17 +2,18 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-export const Arrow = ({
-  className, placement, refEl, ...restProps
-}) => (
-  <div className={classNames('arrow', className)} ref={refEl} {...restProps} />
+const BaseArrow = ({
+  className, placement, ...restProps
+}, ref) => (
+  <div className={classNames('arrow', className)} ref={ref} {...restProps} />
 );
-Arrow.propTypes = {
-  refEl: PropTypes.func.isRequired,
+BaseArrow.propTypes = {
   placement: PropTypes.string.isRequired,
   className: PropTypes.string,
 };
 
-Arrow.defaultProps = {
+BaseArrow.defaultProps = {
   className: undefined,
 };
+
+export const Arrow = React.forwardRef(BaseArrow);

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.jsx
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-export const Arrow = ({ arrowProps }) => (
-  <div className="arrow" {...arrowProps} />
+export const Arrow = ({ arrowProps, className }) => (
+  <div className={classNames('arrow', className)} {...arrowProps} />
 );
-
 Arrow.propTypes = {
-  arrowProps: PropTypes.any.isRequired,
+  arrowProps: PropTypes.object.isRequired,
+  className: PropTypes.string,
+};
+
+Arrow.defaultProps = {
+  className: undefined,
 };

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.test.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.test.jsx
@@ -2,19 +2,12 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Arrow } from './arrow';
 
-describe('Content', () => {
-  const defaultProps = {
-    arrowProps: { style: 'style' },
-    className: 'custom_className',
-  };
-
+describe('Arrow', () => {
   it('should render content', () => {
     const tree = shallow((
-      <Arrow
-        {...defaultProps}
-      />
+      <Arrow />
     ));
 
-    expect(tree.find('div').props()).toEqual({ className: 'arrow custom_className', style: 'style' });
+    expect(tree.find('div').exists()).toBeTruthy();
   });
 });

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.test.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.test.jsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Arrow } from './arrow';
+
+describe('Content', () => {
+  const defaultProps = {
+    arrowProps: { style: 'style' },
+  };
+
+  it('should render content', () => {
+    const tree = shallow((
+      <Arrow
+        {...defaultProps}
+      />
+    ));
+
+    expect(tree.find('div').props()).toEqual({ className: 'arrow', style: 'style' });
+  });
+});

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.test.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/arrow.test.jsx
@@ -5,6 +5,7 @@ import { Arrow } from './arrow';
 describe('Content', () => {
   const defaultProps = {
     arrowProps: { style: 'style' },
+    className: 'custom_className',
   };
 
   it('should render content', () => {
@@ -14,6 +15,6 @@ describe('Content', () => {
       />
     ));
 
-    expect(tree.find('div').props()).toEqual({ className: 'arrow', style: 'style' });
+    expect(tree.find('div').props()).toEqual({ className: 'arrow custom_className', style: 'style' });
   });
 });

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/overlay.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/overlay.jsx
@@ -20,9 +20,7 @@ export class Overlay extends React.PureComponent {
         modifiers={popperModifiers}
         {...restProps}
       >
-        <div className="popover-body">
-          {children}
-        </div>
+        {children}
       </Popover>
     );
   }

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/overlay.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/overlay.jsx
@@ -30,4 +30,5 @@ Overlay.propTypes = {
   children: PropTypes.node.isRequired,
   target: PropTypes.any.isRequired,
   rotated: PropTypes.bool.isRequired,
+  arrowComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
 };

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/sheet.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/sheet.jsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+export const Sheet = ({ className, ...restProps }) => (
+  <div className={classNames('popover-body', className)} {...restProps} />
+);
+
+Sheet.propTypes = {
+  className: PropTypes.string,
+};
+
+Sheet.defaultProps = {
+  className: undefined,
+};

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/sheet.test.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/sheet.test.jsx
@@ -2,19 +2,12 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import { Sheet } from './sheet';
 
-describe('Content', () => {
-  const defaultProps = {
-    className: 'custom_class_name',
-    placement: 'placement',
-  };
-
+describe('Sheet', () => {
   it('should render content', () => {
     const tree = shallow((
-      <Sheet
-        {...defaultProps}
-      />
+      <Sheet />
     ));
 
-    expect(tree.find('div').props()).toEqual({ className: 'popover-body custom_class_name', placement: 'placement' });
+    expect(tree.find('div').exists()).toBeTruthy();
   });
 });

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/sheet.test.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/sheet.test.jsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Sheet } from './sheet';
+
+describe('Content', () => {
+  const defaultProps = {
+    className: 'custom_class_name',
+    placement: 'placement',
+  };
+
+  it('should render content', () => {
+    const tree = shallow((
+      <Sheet
+        {...defaultProps}
+      />
+    ));
+
+    expect(tree.find('div').props()).toEqual({ className: 'popover-body custom_class_name', placement: 'placement' });
+  });
+});

--- a/packages/dx-react-chart-demos/src/demo-sources/bar-chart/bootstrap4/side-by-side.jsx
+++ b/packages/dx-react-chart-demos/src/demo-sources/bar-chart/bootstrap4/side-by-side.jsx
@@ -6,8 +6,9 @@ import {
   BarSeries,
   Title,
   Legend,
+  Tooltip,
 } from '@devexpress/dx-react-chart-bootstrap4';
-import { Stack, Animation } from '@devexpress/dx-react-chart';
+import { Stack, Animation, EventTracker } from '@devexpress/dx-react-chart';
 
 import { olimpicMedals as data } from '../../../demo-data/data-vizualization';
 
@@ -15,6 +16,13 @@ const Root = props => (
   <Legend.Root
     {...props}
     className="m-auto flex-row"
+  />
+);
+
+const Sheet = props => (
+  <Tooltip.Sheet
+    {...props}
+    className="bg-primary"
   />
 );
 
@@ -59,6 +67,8 @@ export default class Demo extends React.PureComponent {
           <Animation />
           <Legend position="bottom" rootComponent={Root} />
           <Title text="Olimpic Medals in 2008" />
+          <EventTracker />
+          <Tooltip sheetComponent={Sheet} />
           <Stack />
         </Chart>
       </div>

--- a/packages/dx-react-chart-demos/src/demo-sources/bar-chart/material-ui/side-by-side.jsx
+++ b/packages/dx-react-chart-demos/src/demo-sources/bar-chart/material-ui/side-by-side.jsx
@@ -7,9 +7,10 @@ import {
   BarSeries,
   Title,
   Legend,
+  Tooltip,
 } from '@devexpress/dx-react-chart-material-ui';
 import { withStyles } from '@material-ui/core/styles';
-import { Stack, Animation } from '@devexpress/dx-react-chart';
+import { Stack, Animation, EventTracker } from '@devexpress/dx-react-chart';
 
 import { olimpicMedals as data } from '../../../demo-data/data-vizualization';
 
@@ -33,6 +34,28 @@ const legendLabelBase = ({ classes, ...restProps }) => (
   <Legend.Label className={classes.label} {...restProps} />
 );
 const Label = withStyles(legendLabelStyles, { name: 'LegendLabel' })(legendLabelBase);
+
+const sheetStyles = {
+  paper: {
+    background: 'red',
+  },
+};
+
+const arrowStyles = {
+  arrow: { '&::after': { backgroundColor: 'red' } },
+};
+
+const Arrow = withStyles(arrowStyles)(({ classes, ...restProps }) => (
+  <Tooltip.Arrow className={classes.arrow} {...restProps} />
+));
+
+const SheetBase = ({ classes, ...restProps }) => (
+  <Tooltip.Sheet
+    className={classes.paper}
+    {...restProps}
+  />
+);
+const Sheet = withStyles(sheetStyles)(SheetBase);
 
 export default class Demo extends React.PureComponent {
   constructor(props) {
@@ -76,6 +99,8 @@ export default class Demo extends React.PureComponent {
           <Legend position="bottom" rootComponent={Root} labelComponent={Label} />
           <Title text="Olimpic Medals in 2008" />
           <Stack />
+          <EventTracker />
+          <Tooltip sheetComponent={Sheet} arrowComponent={Arrow} />
         </Chart>
       </Paper>
     );

--- a/packages/dx-react-chart-material-ui/api/dx-react-chart-material-ui.api.md
+++ b/packages/dx-react-chart-material-ui/api/dx-react-chart-material-ui.api.md
@@ -289,18 +289,32 @@ export namespace Tooltip {
   export type ContentProps = Tooltip_2.ContentProps;
 }
 
+// @public (undocumented)
+export namespace Tooltip {
+  export type ArrowProps = Tooltip_2.ArrowProps;
+}
+
+// @public (undocumented)
+export namespace Tooltip {
+  export type SheetProps = Tooltip_2.SheetProps;
+}
+
 // @public
 export const Tooltip: React.ComponentType<TooltipProps> & {
   Overlay: React.ComponentType<Tooltip_2.OverlayProps & { className?: string; style?: React.CSSProperties; [x: string]: any }>;
   Content: React.ComponentType<Tooltip_2.ContentProps & { className?: string; style?: React.CSSProperties; [x: string]: any }>;
+  Arrow: React.ComponentType<Tooltip_2.ArrowProps & { className?: string; style?: React.CSSProperties; [x: string]: any }>;
+  Sheet: React.ComponentType<Tooltip_2.SheetProps & { className?: string; style?: React.CSSProperties; [x: string]: any }>;
 };
 
 // @public (undocumented)
 export interface TooltipProps {
+  arrowComponent?: React.ComponentType<Tooltip_2.ArrowProps>;
   contentComponent?: React.ComponentType<Tooltip_2.ContentProps>;
   defaultTargetItem?: SeriesRef;
   onTargetItemChange?: (target: SeriesRef) => void;
   overlayComponent?: React.ComponentType<Tooltip_2.OverlayProps>;
+  sheetComponent?: React.ComponentType<Tooltip_2.SheetProps>;
   targetItem?: SeriesRef;
 }
 

--- a/packages/dx-react-chart-material-ui/src/plugins/tooltip.jsx
+++ b/packages/dx-react-chart-material-ui/src/plugins/tooltip.jsx
@@ -2,5 +2,9 @@ import { Tooltip as TooltipBase } from '@devexpress/dx-react-chart';
 import { withComponents } from '@devexpress/dx-react-core';
 import { Overlay } from '../templates/tooltip/overlay';
 import { Content } from '../templates/tooltip/content';
+import { Arrow } from '../templates/tooltip/arrow';
+import { Sheet } from '../templates/tooltip/sheet';
 
-export const Tooltip = withComponents({ Overlay, Content })(TooltipBase);
+export const Tooltip = withComponents({
+  Overlay, Content, Sheet, Arrow,
+})(TooltipBase);

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/arrow.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/arrow.jsx
@@ -51,7 +51,7 @@ const styles = (theme) => {
 };
 
 export const Arrow = withStyles(styles)(({
-  classes, className, placement,
+  classes, className, placement, ...restProps
 }) => (
-  <div className={classNames(classes[`arrow-${placement}`], className)} />
+  <div className={classNames(classes[`arrow-${placement}`], className)} {...restProps} />
 ));

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/arrow.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/arrow.jsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import classNames from 'classnames';
+
+const styles = (theme) => {
+  const arrowSize = theme.spacing(1.2);
+  return {
+    'arrow-top': {
+      width: `${arrowSize * 5}px`,
+      height: `${arrowSize * 2.5}px`,
+      position: 'absolute',
+      top: '100%',
+      left: '50%',
+      transform: 'translateX(-50%)',
+      overflow: 'hidden',
+
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        width: `${arrowSize}px`,
+        height: `${arrowSize}px`,
+        background: theme.palette.background.paper,
+        transform: 'translateX(-50%) translateY(-50%) rotate(45deg)',
+        top: 0,
+        left: '50%',
+        boxShadow: theme.shadows[2],
+      },
+    },
+    'arrow-right': {
+      width: `${arrowSize * 2.5}px`,
+      height: `${arrowSize * 5}px`,
+      position: 'absolute',
+      top: '50%',
+      left: 0,
+      transform: 'translateX(-100%) translateY(-50%)',
+      overflow: 'hidden',
+
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        width: `${arrowSize}px`,
+        height: `${arrowSize}px`,
+        background: theme.palette.background.paper,
+        transform: 'translateX(-50%) translateY(-50%) rotate(45deg)',
+        top: '50%',
+        left: '100%',
+        boxShadow: theme.shadows[2],
+      },
+    },
+  };
+};
+
+export const Arrow = withStyles(styles)(({
+  classes, className, placement,
+}) => (
+  <div className={classNames(classes[`arrow-${placement}`], className)} />
+));

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/arrow.test.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/arrow.test.jsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { Arrow } from './arrow';
+
+describe('Arrow', () => {
+  const defaultProps = {
+    className: 'custom-className',
+    placement: 'top',
+  };
+  let mount;
+  const classes = getClasses(<Arrow {...defaultProps} />);
+
+  beforeEach(() => {
+    mount = createMount();
+  });
+
+  afterEach(() => {
+    mount.cleanUp();
+  });
+
+  it('should render Arrow', () => {
+    const tree = mount((
+      <Arrow
+        {...defaultProps}
+      />
+    ));
+    expect(tree.find('div').props()).toMatchObject({
+      className: `${classes['arrow-top']} custom-className`,
+    });
+  });
+
+  it('should render Arrow, placement right', () => {
+    const tree = mount((
+      <Arrow
+        {...defaultProps}
+        placement="right"
+      />
+    ));
+    expect(tree.find('div').props()).toMatchObject({
+      className: `${classes['arrow-right']} custom-className`,
+    });
+  });
+});

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.jsx
@@ -1,65 +1,19 @@
 import * as React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import Popper from '@material-ui/core/Popper';
-import Paper from '@material-ui/core/Paper';
 import { RIGHT, TOP } from '@devexpress/dx-chart-core';
 import classNames from 'classnames';
 
 const styles = (theme) => {
   const arrowSize = theme.spacing(1.2);
   return {
-    popper: {
+    'popper-top': {
       zIndex: 1,
       marginBottom: `${arrowSize}px`,
     },
-    popperRotated: {
+    'popper-right': {
       zIndex: 1,
       marginLeft: `${arrowSize}px`,
-    },
-    paper: {
-      padding: theme.spacing(0.5, 1),
-    },
-    arrow: {
-      width: `${arrowSize * 5}px`,
-      height: `${arrowSize * 2.5}px`,
-      position: 'absolute',
-      top: '100%',
-      left: '50%',
-      transform: 'translateX(-50%)',
-      overflow: 'hidden',
-
-      '&::after': {
-        content: '""',
-        position: 'absolute',
-        width: `${arrowSize}px`,
-        height: `${arrowSize}px`,
-        background: theme.palette.background.paper,
-        transform: 'translateX(-50%) translateY(-50%) rotate(45deg)',
-        top: 0,
-        left: '50%',
-        boxShadow: theme.shadows[2],
-      },
-    },
-    arrowRotated: {
-      width: `${arrowSize * 2.5}px`,
-      height: `${arrowSize * 5}px`,
-      position: 'absolute',
-      top: '50%',
-      left: 0,
-      transform: 'translateX(-100%) translateY(-50%)',
-      overflow: 'hidden',
-
-      '&::after': {
-        content: '""',
-        position: 'absolute',
-        width: `${arrowSize}px`,
-        height: `${arrowSize}px`,
-        background: theme.palette.background.paper,
-        transform: 'translateX(-50%) translateY(-50%) rotate(45deg)',
-        top: '50%',
-        left: '100%',
-        boxShadow: theme.shadows[2],
-      },
     },
   };
 };
@@ -69,19 +23,20 @@ const popperModifiers = {
 };
 
 export const Overlay = withStyles(styles)(({
-  classes, className, children, target, rotated, ...restProps
-}) => (
-  <Popper
-    open
-    anchorEl={target}
-    placement={rotated ? RIGHT : TOP}
-    className={classNames(rotated ? classes.popperRotated : classes.popper, className)}
-    modifiers={popperModifiers}
-    {...restProps}
-  >
-    <Paper className={classes.paper}>
+  classes, className, children, target, rotated, arrowComponent: ArrowComponent, ...restProps
+}) => {
+  const placement = rotated ? RIGHT : TOP;
+  return (
+    <Popper
+      open
+      anchorEl={target}
+      placement={placement}
+      className={classNames(classes[`popper-${placement}`], className)}
+      modifiers={popperModifiers}
+      {...restProps}
+    >
       {children}
-    </Paper>
-    <div className={rotated ? classes.arrowRotated : classes.arrow} />
-  </Popper>
-));
+      <ArrowComponent placement={placement} />
+    </Popper>
+  );
+});

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.test.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.test.jsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import Popper from '@material-ui/core/Popper';
-import Paper from '@material-ui/core/Paper';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import { Overlay } from './overlay';
 
 describe('Overlay', () => {
+  const ArrowComponent = () => null;
+
   const defaultProps = {
     target: {},
     rotated: false,
+    arrowComponent: ArrowComponent,
   };
   let mount;
   const classes = getClasses(<Overlay {...defaultProps}>Test</Overlay>);
@@ -33,18 +35,15 @@ describe('Overlay', () => {
       open: true,
       anchorEl: defaultProps.target,
       placement: 'top',
-      className: classes.popper,
+      className: classes['popper-top'],
     });
-    expect(tree.find(Paper).props()).toMatchObject({
-      className: classes.paper,
-    });
-    expect(tree.find('div').get(3).props).toMatchObject({
-      className: classes.arrow,
+    expect(tree.find(ArrowComponent).props()).toMatchObject({
+      placement: 'top',
     });
     expect(tree.find('.content').exists()).toBeTruthy();
   });
 
-  it('should pass custom class to the root element', () => {
+  it('should pass custom class to the element', () => {
     const tree = mount((
       <Overlay
         {...defaultProps}
@@ -55,7 +54,7 @@ describe('Overlay', () => {
     ));
 
     expect(tree.find(Popper).is('.custom-class')).toBeTruthy();
-    expect(tree.find(Popper).is(`.${classes.popper}`)).toBeTruthy();
+    expect(tree.find(Popper).is(`.${classes['popper-top']}`)).toBeTruthy();
   });
 
   it('should pass rest props to the root element', () => {
@@ -85,10 +84,10 @@ describe('Overlay', () => {
       open: true,
       anchorEl: defaultProps.target,
       placement: 'right',
-      className: classes.popperRotated,
+      className: classes['popper-right'],
     });
-    expect(tree.find('div').get(3).props).toMatchObject({
-      className: classes.arrowRotated,
+    expect(tree.find(ArrowComponent).props()).toMatchObject({
+      placement: 'right',
     });
     expect(tree.find('.content').exists()).toBeTruthy();
   });

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/sheet.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/sheet.jsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import Paper from '@material-ui/core/Paper';
+import { withClassName } from '../utils';
+
+const styles = theme => ({
+  root: {
+    padding: theme.spacing(0.5, 1),
+  },
+});
+
+export const Sheet = withClassName(styles)(props => (
+  <Paper {...props} />
+));

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/sheet.test.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/sheet.test.jsx
@@ -4,11 +4,8 @@ import Paper from '@material-ui/core/Paper';
 import { Sheet } from './sheet';
 
 describe('Sheet', () => {
-  const defaultProps = {
-    className: 'custom-className',
-  };
   let mount;
-  const classes = getClasses(<Sheet {...defaultProps} />);
+  const classes = getClasses(<Sheet />);
 
   beforeEach(() => {
     mount = createMount();
@@ -20,12 +17,10 @@ describe('Sheet', () => {
 
   it('should render Sheet', () => {
     const tree = mount((
-      <Sheet
-        {...defaultProps}
-      />
+      <Sheet />
     ));
     expect(tree.find(Paper).props()).toMatchObject({
-      className: `${classes.root} custom-className`,
+      className: `${classes.root}`,
     });
   });
 });

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/sheet.test.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/sheet.test.jsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { createMount, getClasses } from '@material-ui/core/test-utils';
+import Paper from '@material-ui/core/Paper';
+import { Sheet } from './sheet';
+
+describe('Sheet', () => {
+  const defaultProps = {
+    className: 'custom-className',
+  };
+  let mount;
+  const classes = getClasses(<Sheet {...defaultProps} />);
+
+  beforeEach(() => {
+    mount = createMount();
+  });
+
+  afterEach(() => {
+    mount.cleanUp();
+  });
+
+  it('should render Sheet', () => {
+    const tree = mount((
+      <Sheet
+        {...defaultProps}
+      />
+    ));
+    expect(tree.find(Paper).props()).toMatchObject({
+      className: `${classes.root} custom-className`,
+    });
+  });
+});

--- a/packages/dx-react-chart/api/dx-react-chart.api.md
+++ b/packages/dx-react-chart/api/dx-react-chart.api.md
@@ -537,23 +537,32 @@ export const Tooltip: React.ComponentType<TooltipProps>;
 
 // @public (undocumented)
 export namespace Tooltip {
+  export interface ArrowProps {
+    placement: 'right' | 'top';
+  }
   export interface ContentProps {
     targetItem: SeriesRef;
     text: string;
   }
   export interface OverlayProps {
+    arrowComponent: React.ComponentType<Tooltip.ArrowProps>;
     children: React.ReactNode;
     rotated: boolean;
     target: TooltipReference;
+  }
+  export interface SheetProps {
+    children: React.ReactNode;
   }
 }
 
 // @public (undocumented)
 export interface TooltipProps {
+  arrowComponent: React.ComponentType<Tooltip.ArrowProps>;
   contentComponent: React.ComponentType<Tooltip.ContentProps>;
   defaultTargetItem?: SeriesRef;
   onTargetItemChange?: NotifyPointerMoveFn;
   overlayComponent: React.ComponentType<Tooltip.OverlayProps>;
+  sheetComponent: React.ComponentType<Tooltip.SheetProps>;
   targetItem?: SeriesRef;
 }
 

--- a/packages/dx-react-chart/docs/reference/tooltip.md
+++ b/packages/dx-react-chart/docs/reference/tooltip.md
@@ -26,6 +26,8 @@ targetItem? | [SeriesRef](./event-tracker.md#seriesref) | | An item for which th
 onTargetItemChange? | (target: [SeriesRef](./event-tracker.md#seriesref)) => void | | A function that is executed when the target item changes.
 overlayComponent | ComponentType&lt;[Tooltip.OverlayProps](#tooltipoverlayprops)&gt; | | A component that renders the tooltip.
 contentComponent | ComponentType&lt;[Tooltip.ContentProps](#tooltipcontentprops)&gt; | | A component that renders the tooltip content.
+arrowComponent | ComponentType&lt;[Tooltip.ArrowProps](#tooltiparrowprops)&gt; | | A component that renders the tooltip arrow.
+sheetComponent | ComponentType&lt;[Tooltip.SheetProps](#tooltipsheetprops)&gt; | | A component that renders the tooltip sheet.
 
 ## Interfaces
 
@@ -47,9 +49,28 @@ Field | Type | Description
 text | string | The component's text.
 targetItem | [SeriesRef](./event-tracker.md#seriesref) | An item for which the tooltip is displayed.
 
+### Tooltip.ArrowProps
+
+Describes properties passed to a component that renders the tooltip's arrow.
+
+Field | Type | Description
+------|------|------------
+placement | 'top' &#124; 'right' | The tooltip's placement.
+
+### Tooltip.SheetProps
+
+Describes properties passed to a component that renders the tooltip's sheet.
+
+Field | Type | Description
+------|------|------------
+children | ReactNode | The sheet's children.
+
+
 ## Plugin Components
 
 Name | Properties | Description
 -----|------------|------------
 Tooltip.Overlay | [Tooltip.OverlayProps](#tooltipoverlayprops) | A component that renders the tooltip.
 Tooltip.Content | [Tooltip.ContentProps](#tooltipcontentprops) | A component that renders the tooltip's content.
+Tooltip.Arrow | [Tooltip.ArrowProps](#tooltiparrowprops) | A component that renders the tooltip arrow.
+Tooltip.Sheet | [Tooltip.SheetProps](#tooltipsheetprops) | A component that renders the tooltip sheet.

--- a/packages/dx-react-chart/docs/reference/tooltip.md
+++ b/packages/dx-react-chart/docs/reference/tooltip.md
@@ -39,6 +39,7 @@ Field | Type | Description
 ------|------|------------
 target | {getBoundingClientRect: () => ClientRect, clientHeight: number, clientWidth: number} | An [object](https://popper.js.org/popper-documentation.html#referenceObject) that provides an API to position the tooltip.
 children | ReactNode | A React node used to render the tooltip's content.
+arrowComponent | ComponentType&lt;[Tooltip.ArrowProps](#tooltiparrowprops)&gt; | | A component that renders the tooltip arrow.
 
 ### Tooltip.ContentProps
 

--- a/packages/dx-react-chart/src/plugins/tooltip.test.tsx
+++ b/packages/dx-react-chart/src/plugins/tooltip.test.tsx
@@ -18,6 +18,12 @@ const OverlayComponent = ({ children }) => (
   </div>
 );
 const ContentComponent = () => null;
+const ArrowComponent = () => null;
+const SheetComponent = ({ children }) => (
+  <div>
+    {children}
+  </div>
+);
 
 const defaultDeps = {
   getter: {
@@ -35,6 +41,8 @@ const defaultProps = {
   targetComponent: TargetComponent,
   overlayComponent: OverlayComponent,
   contentComponent: ContentComponent,
+  arrowComponent: ArrowComponent,
+  sheetComponent: SheetComponent,
 };
 
 describe('Tooltip', () => {
@@ -66,6 +74,10 @@ describe('Tooltip', () => {
       target: { tag: 'test-reference' },
       children: expect.anything(),
       rotated: true,
+      arrowComponent: ArrowComponent,
+    });
+    expect(tree.find(SheetComponent).props()).toEqual({
+      children: expect.anything(),
     });
     expect(tree.find(ContentComponent).props()).toEqual({
       text: 'tooltip-text',

--- a/packages/dx-react-chart/src/plugins/tooltip.tsx
+++ b/packages/dx-react-chart/src/plugins/tooltip.tsx
@@ -19,6 +19,8 @@ class RawTooltip extends React.PureComponent<TooltipProps, TooltipState> {
     overlayComponent: 'Overlay',
     targetComponent: 'Target',
     contentComponent: 'Content',
+    arrowComponent: 'Arrow',
+    sheetComponent: 'Sheet',
   };
   getPointerMoveHandlers: GetPointerMoveHandlersFn;
 
@@ -54,6 +56,8 @@ class RawTooltip extends React.PureComponent<TooltipProps, TooltipState> {
     const {
       overlayComponent: OverlayComponent,
       contentComponent: ContentComponent,
+      sheetComponent: SheetComponent,
+      arrowComponent,
     } = this.props;
     const { target } = this.state;
     return (
@@ -72,8 +76,11 @@ class RawTooltip extends React.PureComponent<TooltipProps, TooltipState> {
                   key={`${target.series}${target.point}`}
                   target={createReference(element, rootRef)}
                   rotated={rotated}
+                  arrowComponent={arrowComponent}
                 >
-                  <ContentComponent text={text} targetItem={target} />
+                  <SheetComponent>
+                    <ContentComponent text={text} targetItem={target} />
+                  </SheetComponent>
                 </OverlayComponent>
               );
             }}

--- a/packages/dx-react-chart/src/types/plugins.tooltip.types.ts
+++ b/packages/dx-react-chart/src/types/plugins.tooltip.types.ts
@@ -15,6 +15,10 @@ export interface TooltipProps {
   overlayComponent: React.ComponentType<Tooltip.OverlayProps>;
   /** A component that renders the tooltip content */
   contentComponent: React.ComponentType<Tooltip.ContentProps>;
+  /** A component that renders the tooltip arrow */
+  arrowComponent: React.ComponentType<Tooltip.ArrowProps>;
+  /** A component that renders the tooltip sheet */
+  sheetComponent: React.ComponentType<Tooltip.SheetProps>;
 }
 /** @internal */
 export type TooltipState = {
@@ -31,6 +35,8 @@ export namespace Tooltip {
     children: React.ReactNode;
     /** Set orientation for tooltip */
     rotated: boolean;
+    /** A component that renders the tooltip arrow */
+    arrowComponent: React.ComponentType<Tooltip.ArrowProps>;
   }
 
   /** Describes properties passed to a component that renders the tooltip’s content */
@@ -39,5 +45,16 @@ export namespace Tooltip {
     text: string;
     /** An item for which the tooltip is displayed */
     targetItem: SeriesRef;
+  }
+
+  /** Describes properties passed to a component that renders the tooltip’s arrow */
+  export interface ArrowProps {
+    /** the tooltip's placement */
+    placement: 'right' | 'top';
+  }
+  /** Describes properties passed to a component that renders the tooltip’s sheet */
+  export interface SheetProps {
+    /** The sheet's children */
+    children: React.ReactNode;
   }
 }


### PR DESCRIPTION
Fixes #2166 

Added `arrowComponent` and `sheetComponent` to customize background of the tooltip and its arrow. 