### PR TITLE
fix(react-grid): correct calculating start index of loading row for Infinite Scrolling

### DIFF
--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
@@ -169,7 +169,6 @@ describe('VirtualTableState helpers', () => {
         const loadedInterval = createInterval(200, 500);
         const newInterval = createInterval(100, 400);
         const virtualRows = createVirtualRows(loadedInterval);
-        const referenceIndex = 60;
 
         expect(calculateRequestedRange(virtualRows, newInterval, pageSize))
           .toEqual({ start: 100, end: 200 });
@@ -258,15 +257,33 @@ describe('VirtualTableState helpers', () => {
       });
 
       // tslint:disable-next-line: max-line-length
-      it('should caclulate correct if reference index more than the start of a new interval and less than half of page', () => {
+      describe('reference index more than the start of a new interval and less than half of page', () => {
         const loadedInterval = createInterval(100, 400);
         const newInterval = createInterval(200, 500);
         const virtualRows = createVirtualRows(loadedInterval);
         const referenceIndex = 320;
 
-        expect(calculateRequestedRange(virtualRows, newInterval, pageSize, referenceIndex))
+        it('should caclulate correct if infinite scrolling', () => {
+          expect(calculateRequestedRange(virtualRows, newInterval, pageSize, referenceIndex, true))
           .toEqual({ start: 300, end: 400 });
+        });
+
+        it('should caclulate correct if non-infinite scrolling', () => {
+          expect(calculateRequestedRange(virtualRows, newInterval, pageSize, referenceIndex, false))
+          .toEqual({ start: 400, end: 500 });
+        });
       });
+    });
+
+    // tslint:disable-next-line: max-line-length
+    it('should caclulate correct in non-infinite scrolling', () => {
+      const loadedInterval = createInterval(100, 400);
+      const newInterval = createInterval(200, 500);
+      const virtualRows = createVirtualRows(loadedInterval);
+      const referenceIndex = 320;
+
+      expect(calculateRequestedRange(virtualRows, newInterval, pageSize, referenceIndex))
+        .toEqual({ start: 400, end: 500 });
     });
   });
 

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.test.ts
@@ -161,7 +161,7 @@ describe('VirtualTableState helpers', () => {
         const newInterval = createInterval(200, 500);
         const virtualRows = createVirtualRows(loadedInterval);
 
-        expect(calculateRequestedRange(virtualRows, newInterval, 310, pageSize))
+        expect(calculateRequestedRange(virtualRows, newInterval, pageSize))
           .toEqual({ start: 400, end: 500 });
       });
 
@@ -169,8 +169,9 @@ describe('VirtualTableState helpers', () => {
         const loadedInterval = createInterval(200, 500);
         const newInterval = createInterval(100, 400);
         const virtualRows = createVirtualRows(loadedInterval);
+        const referenceIndex = 60;
 
-        expect(calculateRequestedRange(virtualRows, newInterval, 310, pageSize))
+        expect(calculateRequestedRange(virtualRows, newInterval, pageSize))
           .toEqual({ start: 100, end: 200 });
       });
 
@@ -179,7 +180,7 @@ describe('VirtualTableState helpers', () => {
         const newInterval = createInterval(400, 700);
         const virtualRows = createVirtualRows(loadedInterval);
 
-        expect(calculateRequestedRange(virtualRows, newInterval, 580, pageSize))
+        expect(calculateRequestedRange(virtualRows, newInterval, pageSize))
           .toEqual({ start: 400, end: 700 });
       });
 
@@ -188,8 +189,8 @@ describe('VirtualTableState helpers', () => {
         const newInterval = createInterval(100, 400);
         const virtualRows = createVirtualRows(loadedInterval);
 
-        expect(calculateRequestedRange(virtualRows, newInterval, 270, pageSize))
-          .toEqual({ start: 100, end: 300 });
+        expect(calculateRequestedRange(virtualRows, newInterval, pageSize))
+          .toEqual({ start: 100, end: 400 });
       });
     });
 
@@ -199,7 +200,7 @@ describe('VirtualTableState helpers', () => {
         const newInterval = createInterval(200, 500);
         const virtualRows = createVirtualRows(loadedInterval);
 
-        expect(calculateRequestedRange(virtualRows, newInterval, 300, pageSize))
+        expect(calculateRequestedRange(virtualRows, newInterval, pageSize))
           .toEqual({ start: 200, end: 500 });
       });
 
@@ -208,7 +209,7 @@ describe('VirtualTableState helpers', () => {
         const newInterval = createInterval(200, 500);
         const virtualRows = createVirtualRows(loadedInterval);
 
-        expect(calculateRequestedRange(virtualRows, newInterval, 399, pageSize))
+        expect(calculateRequestedRange(virtualRows, newInterval, pageSize))
           .toEqual({ start: 200, end: 500 });
       });
 
@@ -217,7 +218,7 @@ describe('VirtualTableState helpers', () => {
         const newInterval = createInterval(1000, 1200);
         const virtualRows = createVirtualRows(loadedInterval);
 
-        expect(calculateRequestedRange(virtualRows, newInterval, 1180, pageSize))
+        expect(calculateRequestedRange(virtualRows, newInterval, pageSize))
           .toEqual({ start: 1000, end: 1200 });
       });
     });
@@ -228,8 +229,43 @@ describe('VirtualTableState helpers', () => {
       const virtualRows = createVirtualRows(loadedInterval);
 
       it('should return prev, current and next pages', () => {
-        expect(calculateRequestedRange(virtualRows, newInterval, 1170, pageSize))
+        expect(calculateRequestedRange(virtualRows, newInterval, pageSize))
           .toEqual({ start: 1000, end: 1300 });
+      });
+    });
+
+    describe('reference index', () => {
+      // tslint:disable-next-line: max-line-length
+      it('should caclulate correct if reference index less than the start of a new interval', () => {
+        const loadedInterval = createInterval(100, 400);
+        const newInterval = createInterval(200, 500);
+        const virtualRows = createVirtualRows(loadedInterval);
+        const referenceIndex = 440;
+
+        expect(calculateRequestedRange(virtualRows, newInterval, pageSize, referenceIndex))
+          .toEqual({ start: 400, end: 500 });
+      });
+
+      // tslint:disable-next-line: max-line-length
+      it('should caclulate correct if reference index more than the start of a new interval and less than half of page', () => {
+        const loadedInterval = createInterval(100, 400);
+        const newInterval = createInterval(200, 500);
+        const virtualRows = createVirtualRows(loadedInterval);
+        const referenceIndex = 360;
+
+        expect(calculateRequestedRange(virtualRows, newInterval, pageSize, referenceIndex))
+          .toEqual({ start: 400, end: 500 });
+      });
+
+      // tslint:disable-next-line: max-line-length
+      it('should caclulate correct if reference index more than the start of a new interval and less than half of page', () => {
+        const loadedInterval = createInterval(100, 400);
+        const newInterval = createInterval(200, 500);
+        const virtualRows = createVirtualRows(loadedInterval);
+        const referenceIndex = 320;
+
+        expect(calculateRequestedRange(virtualRows, newInterval, pageSize, referenceIndex))
+          .toEqual({ start: 300, end: 400 });
       });
     });
   });

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
@@ -43,13 +43,13 @@ export const mergeRows: MergeRowsFn = (
 };
 
 export const calculateRequestedRange: CalculateRequestedRangeFn = (
-  virtualRows, newRange, pageSize, referenceIndex,
+  virtualRows, newRange, pageSize, referenceIndex, isInfiniteScroll,
 ) => {
   const loadedInterval = intervalUtil.getRowsInterval(virtualRows);
   const isAdjacentPage = Math.abs(loadedInterval.start - newRange.start) < 2 * pageSize;
   const calculatedRange = intervalUtil.difference(newRange, loadedInterval);
   if (isAdjacentPage && calculatedRange !== intervalUtil.empty) {
-    if (calculatedRange.start - referenceIndex > pageSize / 2) {
+    if (calculatedRange.start - referenceIndex > pageSize / 2 && isInfiniteScroll) {
       calculatedRange.start -= pageSize;
       calculatedRange.end -= pageSize;
     }
@@ -125,14 +125,16 @@ export const getForceReloadInterval: PureComputed<[VirtualRows, number, number],
 };
 
 export const getRequestMeta: GetRequestMeta = (
-  referenceIndex, virtualRows, pageSize, totalRowCount, forceReload,
+  referenceIndex, virtualRows, pageSize, totalRowCount, forceReload, isInfiniteScroll,
 ) => {
   const actualBounds = forceReload
     ? getForceReloadInterval(virtualRows, pageSize!, totalRowCount)
     : recalculateBounds(referenceIndex, pageSize!, totalRowCount);
   const requestedRange = forceReload
     ? actualBounds
-    : calculateRequestedRange(virtualRows, actualBounds, pageSize!, referenceIndex);
+    : calculateRequestedRange(
+        virtualRows, actualBounds, pageSize!, referenceIndex, isInfiniteScroll,
+      );
 
   return { requestedRange, actualBounds };
 };

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
@@ -49,8 +49,7 @@ export const calculateRequestedRange: CalculateRequestedRangeFn = (
   const isAdjacentPage = Math.abs(loadedInterval.start - newRange.start) < 2 * pageSize;
   if (isAdjacentPage) {
     const calculatedRange = intervalUtil.difference(newRange, loadedInterval);
-    const firstHalfOfPage = calculatedRange.start - referenceIndex > pageSize / 2;
-    if (calculatedRange.start > referenceIndex && firstHalfOfPage) {
+    if (calculatedRange.start - referenceIndex > pageSize / 2) {
       calculatedRange.start -= pageSize;
       calculatedRange.end -= pageSize;
     }

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
@@ -43,7 +43,7 @@ export const mergeRows: MergeRowsFn = (
   };
 };
 
-const correctCalculateRange: CorrectRangeFn = (calculatedRange, referenceIndex, pageSize) => {
+const correctRequestedRange: CorrectRangeFn = (calculatedRange, referenceIndex, pageSize) => {
   const { start, end } = calculatedRange;
 
   if (start - referenceIndex > pageSize / 2) {
@@ -60,7 +60,7 @@ export const calculateRequestedRange: CalculateRequestedRangeFn = (
   const calculatedRange = intervalUtil.difference(newRange, loadedInterval);
   if (isAdjacentPage && calculatedRange !== intervalUtil.empty) {
     if (isInfiniteScroll) {
-      return correctCalculateRange(calculatedRange, referenceIndex, pageSize);
+      return correctRequestedRange(calculatedRange, referenceIndex, pageSize);
     }
     return calculatedRange;
   }

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
@@ -47,8 +47,8 @@ export const calculateRequestedRange: CalculateRequestedRangeFn = (
 ) => {
   const loadedInterval = intervalUtil.getRowsInterval(virtualRows);
   const isAdjacentPage = Math.abs(loadedInterval.start - newRange.start) < 2 * pageSize;
-  if (isAdjacentPage) {
-    const calculatedRange = intervalUtil.difference(newRange, loadedInterval);
+  const calculatedRange = intervalUtil.difference(newRange, loadedInterval);
+  if (isAdjacentPage && calculatedRange !== intervalUtil.empty) {
     if (calculatedRange.start - referenceIndex > pageSize / 2) {
       calculatedRange.start -= pageSize;
       calculatedRange.end -= pageSize;
@@ -143,7 +143,7 @@ export const needFetchMorePages: PureComputed<[VirtualRows, number, number], boo
   const { start, end } = intervalUtil.getRowsInterval(virtualRows);
   const loadCount = end - start;
   const topTriggerIndex = start > 0 ? start + pageSize! : 0;
-  const bottomTriggerIndex = end - pageSize!;
+  const bottomTriggerIndex = Math.max(topTriggerIndex + pageSize, end - pageSize! * 1.5);
 
   if (loadCount <= 0) {
     return false;

--- a/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/virtual-table-state/helpers.ts
@@ -57,9 +57,9 @@ export const calculateRequestedRange: CalculateRequestedRangeFn = (
 ) => {
   const loadedInterval = intervalUtil.getRowsInterval(virtualRows);
   const isAdjacentPage = Math.abs(loadedInterval.start - newRange.start) < 2 * pageSize;
-  const calculatedRange = intervalUtil.difference(newRange, loadedInterval);
-  if (isAdjacentPage && calculatedRange !== intervalUtil.empty) {
-    if (isInfiniteScroll) {
+  if (isAdjacentPage) {
+    const calculatedRange = intervalUtil.difference(newRange, loadedInterval);
+    if (isInfiniteScroll && calculatedRange !== intervalUtil.empty) {
       return correctRequestedRange(calculatedRange, referenceIndex, pageSize);
     }
     return calculatedRange;

--- a/packages/dx-grid-core/src/types/virtual-table-state.types.ts
+++ b/packages/dx-grid-core/src/types/virtual-table-state.types.ts
@@ -33,6 +33,10 @@ export type CalculateRequestedRangeFn = PureComputed<
   [VirtualRows, Interval, number, number, boolean], Interval
 >;
 /** @internal */
+export type CorrectRangeFn = PureComputed<
+  [Interval, number, number]
+>;
+/** @internal */
 export type GetRequestMeta = PureComputed<
   [number, VirtualRows, number, number, boolean, boolean],
   { requestedRange: Interval, actualBounds: Interval }

--- a/packages/dx-grid-core/src/types/virtual-table-state.types.ts
+++ b/packages/dx-grid-core/src/types/virtual-table-state.types.ts
@@ -29,7 +29,9 @@ export type MergeRowsFn = PureComputed<
 >;
 
 /** @internal */
-export type CalculateRequestedRangeFn = PureComputed<[VirtualRows, Interval, number], Interval>;
+export type CalculateRequestedRangeFn = PureComputed<
+  [VirtualRows, Interval, number, number], Interval
+>;
 /** @internal */
 export type GetRequestMeta = PureComputed<
   [number, VirtualRows, number, number, boolean],

--- a/packages/dx-grid-core/src/types/virtual-table-state.types.ts
+++ b/packages/dx-grid-core/src/types/virtual-table-state.types.ts
@@ -30,10 +30,10 @@ export type MergeRowsFn = PureComputed<
 
 /** @internal */
 export type CalculateRequestedRangeFn = PureComputed<
-  [VirtualRows, Interval, number, number], Interval
+  [VirtualRows, Interval, number, number, boolean], Interval
 >;
 /** @internal */
 export type GetRequestMeta = PureComputed<
-  [number, VirtualRows, number, number, boolean],
+  [number, VirtualRows, number, number, boolean, boolean],
   { requestedRange: Interval, actualBounds: Interval }
 >;

--- a/packages/dx-react-grid/api/dx-react-grid.api.md
+++ b/packages/dx-react-grid/api/dx-react-grid.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { CellWidthGetter } from '@devexpress/dx-grid-core';
 import * as React from 'react';
 
 // @public
@@ -75,12 +74,6 @@ export interface ColumnChooserProps {
     messages?: ColumnChooser.LocalizationMessages;
     overlayComponent: React.ComponentType<ColumnChooser.OverlayProps>;
     toggleButtonComponent: React.ComponentType<ColumnChooser.ToggleButtonProps>;
-}
-
-// @public (undocumented)
-export interface ColumnSizes {
-  size: number;
-  width: number;
 }
 
 // @public (undocumented)
@@ -278,7 +271,7 @@ export namespace Grid {
 // @public (undocumented)
 export type GridColumnExtension = {
     columnName: string;
-    width?: number | string;
+    width?: number;
     align?: 'left' | 'right' | 'center';
     wordWrapEnabled?: boolean;
 } & IntegratedFiltering.ColumnExtension;
@@ -504,12 +497,6 @@ export interface PagingStateProps {
 }
 
 // @public (undocumented)
-export interface ResizingSizes {
-  nextSize?: number;
-  size: number;
-}
-
-// @public (undocumented)
 export type Row = any;
 
 // @public
@@ -704,7 +691,7 @@ export interface TableColumn {
     fixed?: 'left' | 'right';
     key: string;
     type: symbol;
-    width?: number | string;
+    width?: number;
 }
 
 // @public
@@ -732,7 +719,6 @@ export namespace TableColumnResizing {
 // @public (undocumented)
 export interface TableColumnResizingProps {
   columnExtensions?: Array<TableColumnResizing.ColumnExtension>;
-  columnResizingMode?: string;
   columnWidths?: Array<TableColumnWidthInfo>;
   defaultColumnWidths?: Array<TableColumnWidthInfo>;
   maxColumnWidth?: number;
@@ -772,7 +758,7 @@ export interface TableColumnVisibilityProps {
 // @public
 export interface TableColumnWidthInfo {
   columnName: string;
-  width: number | string;
+  width: number;
 }
 
 // @public
@@ -997,7 +983,6 @@ export namespace TableHeaderRow {
     children: React.ReactNode;
     column: Column;
     draggingEnabled: boolean;
-    getCellWidth: (getter: CellWidthGetter) => void;
     groupingEnabled: boolean;
     onGroup(): void;
     onSort: (parameters: {
@@ -1285,16 +1270,6 @@ export type TreeDataStateState = {
   expandedRowIds: Array<number | string>;
 };
 
-// @public (undocumented)
-export namespace VirtualTable {
-    export interface ColumnExtension {
-        align?: 'left' | 'right' | 'center';
-        columnName: string;
-        width?: number;
-        wordWrapEnabled?: boolean;
-    }
-}
-
 // @public
 export const VirtualTable: React.ComponentType<VirtualTableProps> & {
     COLUMN_TYPE: symbol;
@@ -1306,7 +1281,7 @@ export const VirtualTable: React.ComponentType<VirtualTableProps> & {
 export interface VirtualTableProps {
     bodyComponent: React.ComponentType<object>;
     cellComponent: React.ComponentType<Table.DataCellProps>;
-    columnExtensions?: Array<VirtualTable.ColumnExtension>;
+    columnExtensions?: Array<Table.ColumnExtension>;
     containerComponent: React.ComponentType<object>;
     estimatedRowHeight: number;
     footerComponent: React.ComponentType<object>;

--- a/packages/dx-react-grid/api/dx-react-grid.api.md
+++ b/packages/dx-react-grid/api/dx-react-grid.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { CellWidthGetter } from '@devexpress/dx-grid-core';
 import * as React from 'react';
 
 // @public
@@ -271,7 +272,7 @@ export namespace Grid {
 // @public (undocumented)
 export type GridColumnExtension = {
     columnName: string;
-    width?: number;
+    width?: number | string;
     align?: 'left' | 'right' | 'center';
     wordWrapEnabled?: boolean;
 } & IntegratedFiltering.ColumnExtension;
@@ -497,6 +498,12 @@ export interface PagingStateProps {
 }
 
 // @public (undocumented)
+export interface ResizingSizes {
+  nextSize?: number;
+  size: number;
+}
+
+// @public (undocumented)
 export type Row = any;
 
 // @public
@@ -691,7 +698,7 @@ export interface TableColumn {
     fixed?: 'left' | 'right';
     key: string;
     type: symbol;
-    width?: number;
+    width?: number | string;
 }
 
 // @public
@@ -723,6 +730,7 @@ export interface TableColumnResizingProps {
   defaultColumnWidths?: Array<TableColumnWidthInfo>;
   maxColumnWidth?: number;
   minColumnWidth?: number;
+  nextColumnResizing?: boolean;
   onColumnWidthsChange?: (nextColumnWidths: Array<TableColumnWidthInfo>) => void;
 }
 
@@ -758,7 +766,7 @@ export interface TableColumnVisibilityProps {
 // @public
 export interface TableColumnWidthInfo {
   columnName: string;
-  width: number;
+  width: number | string;
 }
 
 // @public
@@ -983,6 +991,7 @@ export namespace TableHeaderRow {
     children: React.ReactNode;
     column: Column;
     draggingEnabled: boolean;
+    getCellWidth: (getter: CellWidthGetter) => void;
     groupingEnabled: boolean;
     onGroup(): void;
     onSort: (parameters: {
@@ -1270,6 +1279,16 @@ export type TreeDataStateState = {
   expandedRowIds: Array<number | string>;
 };
 
+// @public (undocumented)
+export namespace VirtualTable {
+    export interface ColumnExtension {
+        align?: 'left' | 'right' | 'center';
+        columnName: string;
+        width?: number;
+        wordWrapEnabled?: boolean;
+    }
+}
+
 // @public
 export const VirtualTable: React.ComponentType<VirtualTableProps> & {
     COLUMN_TYPE: symbol;
@@ -1281,7 +1300,7 @@ export const VirtualTable: React.ComponentType<VirtualTableProps> & {
 export interface VirtualTableProps {
     bodyComponent: React.ComponentType<object>;
     cellComponent: React.ComponentType<Table.DataCellProps>;
-    columnExtensions?: Array<Table.ColumnExtension>;
+    columnExtensions?: Array<VirtualTable.ColumnExtension>;
     containerComponent: React.ComponentType<object>;
     estimatedRowHeight: number;
     footerComponent: React.ComponentType<object>;

--- a/packages/dx-react-grid/api/dx-react-grid.api.md
+++ b/packages/dx-react-grid/api/dx-react-grid.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { CellWidthGetter } from '@devexpress/dx-grid-core';
 import * as React from 'react';
 
 // @public
@@ -74,6 +75,12 @@ export interface ColumnChooserProps {
     messages?: ColumnChooser.LocalizationMessages;
     overlayComponent: React.ComponentType<ColumnChooser.OverlayProps>;
     toggleButtonComponent: React.ComponentType<ColumnChooser.ToggleButtonProps>;
+}
+
+// @public (undocumented)
+export interface ColumnSizes {
+  size: number;
+  width: number;
 }
 
 // @public (undocumented)
@@ -271,7 +278,7 @@ export namespace Grid {
 // @public (undocumented)
 export type GridColumnExtension = {
     columnName: string;
-    width?: number;
+    width?: number | string;
     align?: 'left' | 'right' | 'center';
     wordWrapEnabled?: boolean;
 } & IntegratedFiltering.ColumnExtension;
@@ -497,6 +504,12 @@ export interface PagingStateProps {
 }
 
 // @public (undocumented)
+export interface ResizingSizes {
+  nextSize?: number;
+  size: number;
+}
+
+// @public (undocumented)
 export type Row = any;
 
 // @public
@@ -691,7 +704,7 @@ export interface TableColumn {
     fixed?: 'left' | 'right';
     key: string;
     type: symbol;
-    width?: number;
+    width?: number | string;
 }
 
 // @public
@@ -719,6 +732,7 @@ export namespace TableColumnResizing {
 // @public (undocumented)
 export interface TableColumnResizingProps {
   columnExtensions?: Array<TableColumnResizing.ColumnExtension>;
+  columnResizingMode?: string;
   columnWidths?: Array<TableColumnWidthInfo>;
   defaultColumnWidths?: Array<TableColumnWidthInfo>;
   maxColumnWidth?: number;
@@ -758,7 +772,7 @@ export interface TableColumnVisibilityProps {
 // @public
 export interface TableColumnWidthInfo {
   columnName: string;
-  width: number;
+  width: number | string;
 }
 
 // @public
@@ -983,6 +997,7 @@ export namespace TableHeaderRow {
     children: React.ReactNode;
     column: Column;
     draggingEnabled: boolean;
+    getCellWidth: (getter: CellWidthGetter) => void;
     groupingEnabled: boolean;
     onGroup(): void;
     onSort: (parameters: {
@@ -1270,6 +1285,16 @@ export type TreeDataStateState = {
   expandedRowIds: Array<number | string>;
 };
 
+// @public (undocumented)
+export namespace VirtualTable {
+    export interface ColumnExtension {
+        align?: 'left' | 'right' | 'center';
+        columnName: string;
+        width?: number;
+        wordWrapEnabled?: boolean;
+    }
+}
+
 // @public
 export const VirtualTable: React.ComponentType<VirtualTableProps> & {
     COLUMN_TYPE: symbol;
@@ -1281,7 +1306,7 @@ export const VirtualTable: React.ComponentType<VirtualTableProps> & {
 export interface VirtualTableProps {
     bodyComponent: React.ComponentType<object>;
     cellComponent: React.ComponentType<Table.DataCellProps>;
-    columnExtensions?: Array<Table.ColumnExtension>;
+    columnExtensions?: Array<VirtualTable.ColumnExtension>;
     containerComponent: React.ComponentType<object>;
     estimatedRowHeight: number;
     footerComponent: React.ComponentType<object>;

--- a/packages/dx-react-grid/api/dx-react-grid.api.md
+++ b/packages/dx-react-grid/api/dx-react-grid.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { CellWidthGetter } from '@devexpress/dx-grid-core';
 import * as React from 'react';
 
 // @public
@@ -272,7 +271,7 @@ export namespace Grid {
 // @public (undocumented)
 export type GridColumnExtension = {
     columnName: string;
-    width?: number | string;
+    width?: number;
     align?: 'left' | 'right' | 'center';
     wordWrapEnabled?: boolean;
 } & IntegratedFiltering.ColumnExtension;
@@ -498,12 +497,6 @@ export interface PagingStateProps {
 }
 
 // @public (undocumented)
-export interface ResizingSizes {
-  nextSize?: number;
-  size: number;
-}
-
-// @public (undocumented)
 export type Row = any;
 
 // @public
@@ -698,7 +691,7 @@ export interface TableColumn {
     fixed?: 'left' | 'right';
     key: string;
     type: symbol;
-    width?: number | string;
+    width?: number;
 }
 
 // @public
@@ -730,7 +723,6 @@ export interface TableColumnResizingProps {
   defaultColumnWidths?: Array<TableColumnWidthInfo>;
   maxColumnWidth?: number;
   minColumnWidth?: number;
-  nextColumnResizing?: boolean;
   onColumnWidthsChange?: (nextColumnWidths: Array<TableColumnWidthInfo>) => void;
 }
 
@@ -766,7 +758,7 @@ export interface TableColumnVisibilityProps {
 // @public
 export interface TableColumnWidthInfo {
   columnName: string;
-  width: number | string;
+  width: number;
 }
 
 // @public
@@ -991,7 +983,6 @@ export namespace TableHeaderRow {
     children: React.ReactNode;
     column: Column;
     draggingEnabled: boolean;
-    getCellWidth: (getter: CellWidthGetter) => void;
     groupingEnabled: boolean;
     onGroup(): void;
     onSort: (parameters: {
@@ -1279,16 +1270,6 @@ export type TreeDataStateState = {
   expandedRowIds: Array<number | string>;
 };
 
-// @public (undocumented)
-export namespace VirtualTable {
-    export interface ColumnExtension {
-        align?: 'left' | 'right' | 'center';
-        columnName: string;
-        width?: number;
-        wordWrapEnabled?: boolean;
-    }
-}
-
 // @public
 export const VirtualTable: React.ComponentType<VirtualTableProps> & {
     COLUMN_TYPE: symbol;
@@ -1300,7 +1281,7 @@ export const VirtualTable: React.ComponentType<VirtualTableProps> & {
 export interface VirtualTableProps {
     bodyComponent: React.ComponentType<object>;
     cellComponent: React.ComponentType<Table.DataCellProps>;
-    columnExtensions?: Array<VirtualTable.ColumnExtension>;
+    columnExtensions?: Array<Table.ColumnExtension>;
     containerComponent: React.ComponentType<object>;
     estimatedRowHeight: number;
     footerComponent: React.ComponentType<object>;

--- a/packages/dx-react-grid/src/plugins/virtual-table/virtual-table-state.tsx
+++ b/packages/dx-react-grid/src/plugins/virtual-table/virtual-table-state.tsx
@@ -49,11 +49,11 @@ class VirtualTableStateBase extends React.PureComponent<VirtualTableStateProps, 
     { referenceIndex, forceReload },
     { virtualRows }: Getters,
   ) => {
-    const { pageSize, totalRowCount } = this.props;
+    const { pageSize, totalRowCount, infiniteScrolling } = this.props;
     const { requestedStartIndex } = this.state;
     const actualVirtualRows = forceReload ? emptyVirtualRows : virtualRows;
     const { requestedRange, actualBounds } = getRequestMeta(
-      referenceIndex, virtualRows, pageSize!, totalRowCount, forceReload,
+      referenceIndex, virtualRows, pageSize!, totalRowCount, forceReload, infiniteScrolling,
     );
 
     if (forceReload || shouldSendRequest(requestedRange, requestedStartIndex)) {

--- a/packages/dx-react-grid/src/plugins/virtual-table/virtual-table-state.tsx
+++ b/packages/dx-react-grid/src/plugins/virtual-table/virtual-table-state.tsx
@@ -50,13 +50,14 @@ class VirtualTableStateBase extends React.PureComponent<VirtualTableStateProps, 
     { virtualRows }: Getters,
   ) => {
     const { pageSize, totalRowCount } = this.props;
-    const { requestedStartIndex } = this.state;
+    const { requestedStartIndex, availableRowCount } = this.state;
     const actualVirtualRows = forceReload ? emptyVirtualRows : virtualRows;
     const { requestedRange, actualBounds } = getRequestMeta(
       referenceIndex, virtualRows, pageSize!, totalRowCount, forceReload,
     );
+    const needCheckLimit = requestedStartIndex < availableRowCount;
 
-    if (forceReload || shouldSendRequest(requestedRange, requestedStartIndex)) {
+    if (forceReload || needCheckLimit || shouldSendRequest(requestedRange, requestedStartIndex)) {
       this.requestNextPage(requestedRange, actualVirtualRows, actualBounds);
     }
   }

--- a/packages/dx-react-grid/src/plugins/virtual-table/virtual-table-state.tsx
+++ b/packages/dx-react-grid/src/plugins/virtual-table/virtual-table-state.tsx
@@ -50,14 +50,13 @@ class VirtualTableStateBase extends React.PureComponent<VirtualTableStateProps, 
     { virtualRows }: Getters,
   ) => {
     const { pageSize, totalRowCount } = this.props;
-    const { requestedStartIndex, availableRowCount } = this.state;
+    const { requestedStartIndex } = this.state;
     const actualVirtualRows = forceReload ? emptyVirtualRows : virtualRows;
     const { requestedRange, actualBounds } = getRequestMeta(
       referenceIndex, virtualRows, pageSize!, totalRowCount, forceReload,
     );
-    const needCheckLimit = requestedStartIndex < availableRowCount;
 
-    if (forceReload || needCheckLimit || shouldSendRequest(requestedRange, requestedStartIndex)) {
+    if (forceReload || shouldSendRequest(requestedRange, requestedStartIndex)) {
       this.requestNextPage(requestedRange, actualVirtualRows, actualBounds);
     }
   }


### PR DESCRIPTION
Fixes #2139 