### PR TITLE
fix(scheduler-core): display recurrent appointments in the lower right corner of WeekView correctly

### DIFF
--- a/packages/dx-scheduler-core/src/utils.test.ts
+++ b/packages/dx-scheduler-core/src/utils.test.ts
@@ -610,19 +610,15 @@ describe('Utils', () => {
       expect(result[1].end.toString())
         .toBe(moment(new Date('2019-04-26T13:00:00+0600')).toString());
     });
-    fit('should work correctly with near-boundary appointments', () => {
+    it('should work correctly with near-left-boundary appointments', () => {
       const leftBoundary = new Date('2019-04-25 00:00:00+0300');
       const rightBoundary = new Date('2019-04-26 23:59:00+0300');
-      const appointments = [{
+      const appointment = {
         start: moment(new Date('2019-04-25T00:00:00+0300')),
         end: moment(new Date('2019-04-25T13:00:00+0300')),
         rRule: 'FREQ=DAILY;COUNT=2',
-      }, {
-        start: moment(new Date('2019-04-25T12:11:00+0300')),
-        end: moment(new Date('2019-04-25T23:00:00+0300')),
-        rRule: 'FREQ=DAILY;COUNT=2',
-      }];
-      let result = filterByViewBoundaries(appointments[0], leftBoundary, rightBoundary);
+      };
+      const result = filterByViewBoundaries(appointment, leftBoundary, rightBoundary);
 
       expect(result).toHaveLength(2);
 
@@ -635,8 +631,17 @@ describe('Utils', () => {
         .toBe(moment(new Date('2019-04-26T00:00:00+0300')).toString());
       expect(result[1].end.toString())
         .toBe(moment(new Date('2019-04-26T13:00:00+0300')).toString());
+    });
+    it('should work correctly with near-right-boundary appointments', () => {
+      const leftBoundary = new Date('2019-04-25 00:00:00+0300');
+      const rightBoundary = new Date('2019-04-26 23:59:00+0300');
+      const appointment = {
+        start: moment(new Date('2019-04-25T12:11:00+0300')),
+        end: moment(new Date('2019-04-25T23:00:00+0300')),
+        rRule: 'FREQ=DAILY;COUNT=2',
+      };
 
-      result = filterByViewBoundaries(appointments[1], leftBoundary, rightBoundary);
+      const result = filterByViewBoundaries(appointment, leftBoundary, rightBoundary);
 
       expect(result).toHaveLength(2);
 

--- a/packages/dx-scheduler-core/src/utils.test.ts
+++ b/packages/dx-scheduler-core/src/utils.test.ts
@@ -610,5 +610,45 @@ describe('Utils', () => {
       expect(result[1].end.toString())
         .toBe(moment(new Date('2019-04-26T13:00:00+0600')).toString());
     });
+    fit('should work correctly with near-boundary appointments', () => {
+      const leftBoundary = new Date('2019-04-25 00:00:00+0300');
+      const rightBoundary = new Date('2019-04-26 23:59:00+0300');
+      const appointments = [{
+        start: moment(new Date('2019-04-25T00:00:00+0300')),
+        end: moment(new Date('2019-04-25T13:00:00+0300')),
+        rRule: 'FREQ=DAILY;COUNT=2',
+      }, {
+        start: moment(new Date('2019-04-25T12:11:00+0300')),
+        end: moment(new Date('2019-04-25T23:00:00+0300')),
+        rRule: 'FREQ=DAILY;COUNT=2',
+      }];
+      let result = filterByViewBoundaries(appointments[0], leftBoundary, rightBoundary);
+
+      expect(result).toHaveLength(2);
+
+      expect(result[0].start.toString())
+        .toBe(moment(new Date('2019-04-25T00:00:00+0300')).toString());
+      expect(result[0].end.toString())
+        .toBe(moment(new Date('2019-04-25T13:00:00+0300')).toString());
+
+      expect(result[1].start.toString())
+        .toBe(moment(new Date('2019-04-26T00:00:00+0300')).toString());
+      expect(result[1].end.toString())
+        .toBe(moment(new Date('2019-04-26T13:00:00+0300')).toString());
+
+      result = filterByViewBoundaries(appointments[1], leftBoundary, rightBoundary);
+
+      expect(result).toHaveLength(2);
+
+      expect(result[0].start.toString())
+        .toBe(moment(new Date('2019-04-25T12:11:00+0300')).toString());
+      expect(result[0].end.toString())
+        .toBe(moment(new Date('2019-04-25T23:00:00+0300')).toString());
+
+      expect(result[1].start.toString())
+        .toBe(moment(new Date('2019-04-26T12:11:00+0300')).toString());
+      expect(result[1].end.toString())
+        .toBe(moment(new Date('2019-04-26T23:00:00+0300')).toString());
+    });
   });
 });

--- a/packages/dx-scheduler-core/src/utils.ts
+++ b/packages/dx-scheduler-core/src/utils.ts
@@ -308,7 +308,7 @@ const expandRecurrenceAppointment = (
   appointment: AppointmentMoment, leftBound: Date, rightBound: Date,
 ) => {
   const rightBoundUTC = new Date(getUTCDate(rightBound));
-  const leftBoundUTC = new Date(getUTCDate(leftBound) - 1);
+  const leftBoundUTC = new Date(getUTCDate(leftBound));
   const appointmentStartDate = moment(appointment.start).toDate();
   const options = {
     ...RRule.parseString(appointment.rRule),
@@ -328,7 +328,7 @@ const expandRecurrenceAppointment = (
 
   // According to https://github.com/jakubroztocil/rrule#important-use-utc-dates
   // we have to format the dates we get from RRuleSet to get local dates
-  const datesInBoundaries = rruleSet.between(leftBoundUTC as Date, rightBoundUTC as Date)
+  const datesInBoundaries = rruleSet.between(leftBoundUTC as Date, rightBoundUTC as Date, true)
     .map(date => moment.utc(date).format('YYYY-MM-DD HH:mm'));
   if (datesInBoundaries.length === 0) return [];
 

--- a/packages/dx-scheduler-core/src/utils.ts
+++ b/packages/dx-scheduler-core/src/utils.ts
@@ -307,6 +307,8 @@ export const calculateRectByDateIntervals: CalculateRectByDateIntervalsFn = (
 const expandRecurrenceAppointment = (
   appointment: AppointmentMoment, leftBound: Date, rightBound: Date,
 ) => {
+  const rightBoundUTC = new Date(getUTCDate(rightBound));
+  const leftBoundUTC = new Date(getUTCDate(leftBound) - 1);
   const appointmentStartDate = moment(appointment.start).toDate();
   const options = {
     ...RRule.parseString(appointment.rRule),
@@ -326,8 +328,8 @@ const expandRecurrenceAppointment = (
 
   // According to https://github.com/jakubroztocil/rrule#important-use-utc-dates
   // we have to format the dates we get from RRuleSet to get local dates
-  const datesInBoundaries = rruleSet.between(leftBound as Date, rightBound as Date).map(date =>
-    moment.utc(date).format('YYYY-MM-DD HH:mm'));
+  const datesInBoundaries = rruleSet.between(leftBoundUTC as Date, rightBoundUTC as Date)
+    .map(date => moment.utc(date).format('YYYY-MM-DD HH:mm'));
   if (datesInBoundaries.length === 0) return [];
 
   const appointmentDuration = moment(appointment.end)


### PR DESCRIPTION
Fixes #2287 