### PR TITLE
fix(react-grid): add summary rows only if summary items are specified

### DIFF
--- a/packages/dx-grid-core/src/plugins/table-summary-row/computeds.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-summary-row/computeds.test.ts
@@ -18,40 +18,88 @@ describe('TableSummaryRow', () => {
   });
 
   describe('#tableRowsWithSummaries', () => {
+    const groupSummaryItems = [];
+    const treeSummaryItems = [];
+    const tableRows = [
+      { row: { levelKey: 'a', compoundKey: 'a1', group: true } },
+      { row: { levelKey: 'a', compoundKey: 'a2', group: true, a: 'a2' } },
+      { row: { a: 1 } },
+      { row: { a: 2 } },
+      { row: { levelKey: 'a', compoundKey: 'a3', group: true, a: 'a3' } },
+      { row: { levelKey: 'b', a: 3 } },
+      { row: { a: 4 } },
+    ];
+    const getRowLevelKey = row => row.levelKey;
+    const isGroupRow = row => row.group;
+    const getRowId = row => row.a;
+
     it('should add summary rows in correct places', () => {
-      const tableRows = [
-        { row: { levelKey: 'a', compoundKey: 'a1', group: true } },
-        { row: { levelKey: 'a', compoundKey: 'a2', group: true } },
-        { row: { a: 1 } },
-        { row: { a: 2 } },
-        { row: { levelKey: 'a', compoundKey: 'a3', group: true } },
-        { row: { levelKey: 'b', a: 3 } },
-        { row: { a: 4 } },
-      ];
-      const getRowLevelKey = row => row.levelKey;
-      const isGroupRow = row => row.group;
-      const getRowId = row => row.a;
       /* tslint:disable: max-line-length */
       const result = [
         { row: { levelKey: 'a', compoundKey: 'a1', group: true } },
-        { row: { levelKey: 'a', compoundKey: 'a2', group: true } },
+        { row: { levelKey: 'a', compoundKey: 'a2', group: true, a: 'a2' } },
         { row: { a: 1 } },
         { row: { a: 2 } },
-        { key: `${TABLE_GROUP_SUMMARY_TYPE.toString()}_a2`, type: TABLE_GROUP_SUMMARY_TYPE, row: { levelKey: 'a', compoundKey: 'a2', group: true } },
-        { row: { levelKey: 'a', compoundKey: 'a3', group: true } },
+        { key: `${TABLE_GROUP_SUMMARY_TYPE.toString()}_a2`, type: TABLE_GROUP_SUMMARY_TYPE, row: { levelKey: 'a', compoundKey: 'a2', group: true, a: 'a2' } },
+        { row: { levelKey: 'a', compoundKey: 'a3', group: true, a: 'a3' } },
         { row: { levelKey: 'b', a: 3 } },
         { row: { a: 4 } },
         { key: `${TABLE_TREE_SUMMARY_TYPE.toString()}_3`, type: TABLE_TREE_SUMMARY_TYPE, row: { levelKey: 'b', a: 3 } },
-        { key: `${TABLE_GROUP_SUMMARY_TYPE.toString()}_a3`, type: TABLE_GROUP_SUMMARY_TYPE, row: { levelKey: 'a', compoundKey: 'a3', group: true } },
+        { key: `${TABLE_GROUP_SUMMARY_TYPE.toString()}_a3`, type: TABLE_GROUP_SUMMARY_TYPE, row: { levelKey: 'a', compoundKey: 'a3', group: true, a: 'a3' } },
       ];
       /* tslint:enable: max-line-length */
 
-      expect(tableRowsWithSummaries(tableRows, getRowLevelKey, isGroupRow, getRowId))
+      expect(tableRowsWithSummaries(
+        tableRows, groupSummaryItems, treeSummaryItems, getRowLevelKey, isGroupRow, getRowId,
+      ))
+        .toEqual(result);
+    });
+
+    it('should not add tree summary row if treeSummaryItems are not specified', () => {
+      /* tslint:disable: max-line-length */
+      const result = [
+        { row: { levelKey: 'a', compoundKey: 'a1', group: true } },
+        { row: { levelKey: 'a', compoundKey: 'a2', group: true, a: 'a2' } },
+        { row: { a: 1 } },
+        { row: { a: 2 } },
+        { key: `${TABLE_GROUP_SUMMARY_TYPE.toString()}_a2`, type: TABLE_GROUP_SUMMARY_TYPE, row: { levelKey: 'a', compoundKey: 'a2', group: true, a: 'a2' } },
+        { row: { levelKey: 'a', compoundKey: 'a3', group: true, a: 'a3' } },
+        { row: { levelKey: 'b', a: 3 } },
+        { row: { a: 4 } },
+        { key: `${TABLE_GROUP_SUMMARY_TYPE.toString()}_a3`, type: TABLE_GROUP_SUMMARY_TYPE, row: { levelKey: 'a', compoundKey: 'a3', group: true, a: 'a3' } },
+      ];
+      /* tslint:enable: max-line-length */
+
+      expect(tableRowsWithSummaries(
+        tableRows, groupSummaryItems, undefined, getRowLevelKey, isGroupRow, getRowId,
+      ))
+        .toEqual(result);
+    });
+
+    it('should not add group summary row if groupSummaryItems are not specified', () => {
+      /* tslint:disable: max-line-length */
+      const result = [
+        { row: { levelKey: 'a', compoundKey: 'a1', group: true } },
+        { row: { levelKey: 'a', compoundKey: 'a2', group: true, a: 'a2' } },
+        { row: { a: 1 } },
+        { row: { a: 2 } },
+        { key: `${TABLE_TREE_SUMMARY_TYPE.toString()}_a2`, type: TABLE_TREE_SUMMARY_TYPE, row: { levelKey: 'a', compoundKey: 'a2', group: true, a: 'a2' } },
+        { row: { levelKey: 'a', compoundKey: 'a3', group: true, a: 'a3' } },
+        { row: { levelKey: 'b', a: 3 } },
+        { row: { a: 4 } },
+        { key: `${TABLE_TREE_SUMMARY_TYPE.toString()}_3`, type: TABLE_TREE_SUMMARY_TYPE, row: { levelKey: 'b', a: 3 } },
+        { key: `${TABLE_TREE_SUMMARY_TYPE.toString()}_a3`, type: TABLE_TREE_SUMMARY_TYPE, row: { levelKey: 'a', compoundKey: 'a3', group: true, a: 'a3' } },
+      ];
+      /* tslint:enable: max-line-length */
+
+      expect(tableRowsWithSummaries(
+        tableRows, undefined, treeSummaryItems, getRowLevelKey, isGroupRow, getRowId,
+      ))
         .toEqual(result);
     });
 
     it('should sort group summary rows correctly', () => {
-      const tableRows = [
+      const testTableRows = [
         { row: { levelKey: 'a', compoundKey: 'a1', group: true } },
         { row: { levelKey: 'b', compoundKey: 'a1|b1', group: true } },
         { row: { levelKey: 'b', compoundKey: 'a1|b2', group: true } },
@@ -60,9 +108,6 @@ describe('TableSummaryRow', () => {
         { row: { a: 2 } },
         { row: { levelKey: 'a', compoundKey: 'a2', group: true } },
       ];
-      const getRowLevelKey = row => row.levelKey;
-      const isGroupRow = row => row.group;
-      const getRowId = row => row.a;
 
       /* tslint:disable: max-line-length */
       const expectedResult = [
@@ -79,7 +124,9 @@ describe('TableSummaryRow', () => {
       ];
       /* tslint:enable: max-line-length */
 
-      expect(tableRowsWithSummaries(tableRows, getRowLevelKey, isGroupRow, getRowId))
+      expect(tableRowsWithSummaries(
+        testTableRows, groupSummaryItems, treeSummaryItems, getRowLevelKey, isGroupRow, getRowId,
+      ))
         .toEqual(expectedResult);
     });
   });

--- a/packages/dx-grid-core/src/plugins/table-summary-row/computeds.ts
+++ b/packages/dx-grid-core/src/plugins/table-summary-row/computeds.ts
@@ -14,21 +14,21 @@ export const tableRowsWithTotalSummaries: PureComputed<[TableRow[]]> = footerRow
 ];
 
 export const tableRowsWithSummaries: TableRowsWithSummariesFn = (
-  tableRows, getRowLevelKey, isGroupRow, getRowId,
+  tableRows, groupSummaryItems, treeSummaryItems, getRowLevelKey, isGroupRow, getRowId,
 ) => {
-  if (!getRowLevelKey) return tableRows;
+  if (!getRowLevelKey || !(groupSummaryItems || treeSummaryItems)) return tableRows;
 
   const result: TableRow[] = [];
   const closeLevel = (level: RowLevel) => {
     if (!level.opened) return;
-    if (isGroupRow && isGroupRow(level.row)) {
+    if (groupSummaryItems && isGroupRow && isGroupRow(level.row)) {
       const { compoundKey } = level.row;
       result.push({
         key: `${TABLE_GROUP_SUMMARY_TYPE.toString()}_${compoundKey}`,
         type: TABLE_GROUP_SUMMARY_TYPE,
         row: level.row,
       });
-    } else {
+    } else if (treeSummaryItems) {
       const rowId = getRowId(level.row);
       result.push({
         key: `${TABLE_TREE_SUMMARY_TYPE.toString()}_${rowId}`,

--- a/packages/dx-grid-core/src/types/summary.types.ts
+++ b/packages/dx-grid-core/src/types/summary.types.ts
@@ -31,7 +31,7 @@ export type GetColumnSummariesFn = PureComputed<
 
 /** @internal */
 export type TableRowsWithSummariesFn = PureComputed<
-  [TableRow[], GetRowLevelKeyFn, IsSpecificRowFn, GetRowIdFn]
+  [TableRow[], SummaryItem[], SummaryItem[], GetRowLevelKeyFn, IsSpecificRowFn, GetRowIdFn]
 >;
 
 /** @internal */

--- a/packages/dx-react-grid/src/plugins/table-summary-row.test.tsx
+++ b/packages/dx-react-grid/src/plugins/table-summary-row.test.tsx
@@ -126,6 +126,8 @@ describe('TableSummaryRow', () => {
       expect(tableRowsWithSummaries)
         .toBeCalledWith(
           defaultDeps.getter.tableBodyRows,
+          defaultDeps.getter.groupSummaryItems,
+          defaultDeps.getter.treeSummaryItems,
           defaultDeps.getter.getRowLevelKey,
           defaultDeps.getter.isGroupRow,
           defaultDeps.getter.getRowId,

--- a/packages/dx-react-grid/src/plugins/table-summary-row.tsx
+++ b/packages/dx-react-grid/src/plugins/table-summary-row.tsx
@@ -47,7 +47,11 @@ const tableBodyRowsComputed = ({
   getRowLevelKey,
   isGroupRow,
   getRowId,
-}: Getters) => tableRowsWithSummaries(tableBodyRows, getRowLevelKey, isGroupRow, getRowId);
+  groupSummaryItems,
+  treeSummaryItems,
+}: Getters) => tableRowsWithSummaries(
+  tableBodyRows, groupSummaryItems, treeSummaryItems, getRowLevelKey, isGroupRow, getRowId,
+);
 const tableFooterRowsComputed = ({
   tableFooterRows,
 }: Getters) => tableRowsWithTotalSummaries(tableFooterRows);


### PR DESCRIPTION
fixes #2297 