### PR TITLE
fix(react-grid): correct getCellWidth property's default value

### DIFF
--- a/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.jsx
@@ -40,12 +40,12 @@ export class TableHeaderCell extends React.PureComponent {
   render() {
     const {
       style, column, tableColumn,
-      showGroupingControls, onGroup, groupingEnabled,
       draggingEnabled, resizingEnabled,
-      onWidthChange, onWidthDraft, onWidthDraftCancel,
+      onWidthChange, onWidthDraft, onWidthDraftCancel, getCellWidth,
       tableRow, children,
       // @deprecated
-      showSortingControls, sortingDirection, sortingEnabled, onSort, before, getCellWidth,
+      showGroupingControls, onGroup, groupingEnabled,
+      showSortingControls, sortingDirection, sortingEnabled, onSort, before,
       ...restProps
     } = this.props;
     const { dragging } = this.state;

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell.jsx
@@ -143,5 +143,5 @@ TableHeaderCell.defaultProps = {
   onWidthDraftCancel: undefined,
   children: undefined,
   before: undefined,
-  getCellWidth: undefined,
+  getCellWidth: () => {},
 };

--- a/packages/dx-react-grid-bootstrap4/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-bootstrap4/src/templates/table-header-cell.jsx
@@ -136,5 +136,5 @@ TableHeaderCell.defaultProps = {
   onWidthDraft: undefined,
   onWidthDraftCancel: undefined,
   children: undefined,
-  getCellWidth: undefined,
+  getCellWidth: () => {},
 };

--- a/packages/dx-react-grid-bootstrap4/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-bootstrap4/src/templates/table-header-cell.jsx
@@ -41,12 +41,12 @@ export class TableHeaderCell extends React.PureComponent {
   render() {
     const {
       className, column, tableColumn,
-      showGroupingControls, onGroup, groupingEnabled,
       draggingEnabled, onWidthDraftCancel,
-      resizingEnabled, onWidthChange, onWidthDraft,
+      resizingEnabled, onWidthChange, onWidthDraft, getCellWidth,
       tableRow, children,
       // @deprecated
-      showSortingControls, sortingDirection, sortingEnabled, onSort, before, getCellWidth,
+      showGroupingControls, onGroup, groupingEnabled,
+      showSortingControls, sortingDirection, sortingEnabled, onSort, before,
       ...restProps
     } = this.props;
     const { dragging } = this.state;

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell.jsx
@@ -226,7 +226,7 @@ TableHeaderCellBase.defaultProps = {
   className: undefined,
   children: undefined,
   before: undefined,
-  getCellWidth: undefined,
+  getCellWidth: () => {},
 };
 
 export const TableHeaderCell = withStyles(styles, { name: 'TableHeaderCell' })(TableHeaderCellBase);

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell.jsx
@@ -126,12 +126,12 @@ class TableHeaderCellBase extends React.PureComponent {
   render() {
     const {
       style, column, tableColumn,
-      showGroupingControls, onGroup, groupingEnabled,
-      draggingEnabled,
-      resizingEnabled, onWidthChange, onWidthDraft, onWidthDraftCancel,
+      draggingEnabled, resizingEnabled,
+      onWidthChange, onWidthDraft, onWidthDraftCancel, getCellWidth,
       classes, tableRow, className, children,
       // @deprecated
-      showSortingControls, sortingDirection, sortingEnabled, onSort, before, getCellWidth,
+      showGroupingControls, onGroup, groupingEnabled,
+      showSortingControls, sortingDirection, sortingEnabled, onSort, before,
       ...restProps
     } = this.props;
 

--- a/packages/dx-react-grid/docs/reference/table-header-row.md
+++ b/packages/dx-react-grid/docs/reference/table-header-row.md
@@ -68,7 +68,6 @@ showSortingControls | boolean | **@deprecated** <br/> Specifies whether to rende
 sortingEnabled | boolean | **@deprecated** <br/> Specifies whether sorting by the column is enabled.
 sortingDirection? | 'asc' &#124; 'desc' | **@deprecated** <br/> Specifies the column's sorting direction.
 onSort | (parameters: { direction?: 'asc' &#124; 'desc' &#124; null, keepOther?: boolean }) => void | **@deprecated** <br/> An event that invokes a sorting direction change. Keeps the current sorting state if `keepOther` is set to true. Cancels sorting by the current column if `direction` is set to null.
-getCellWidth | (() => number) => void | A function that provides cell's width getter function to the TableColumnResizing component.
 
 ### TableHeaderRow.SortLabelProps
 

--- a/packages/dx-react-grid/docs/reference/table-header-row.md
+++ b/packages/dx-react-grid/docs/reference/table-header-row.md
@@ -68,6 +68,7 @@ showSortingControls | boolean | **@deprecated** <br/> Specifies whether to rende
 sortingEnabled | boolean | **@deprecated** <br/> Specifies whether sorting by the column is enabled.
 sortingDirection? | 'asc' &#124; 'desc' | **@deprecated** <br/> Specifies the column's sorting direction.
 onSort | (parameters: { direction?: 'asc' &#124; 'desc' &#124; null, keepOther?: boolean }) => void | **@deprecated** <br/> An event that invokes a sorting direction change. Keeps the current sorting state if `keepOther` is set to true. Cancels sorting by the current column if `direction` is set to null.
+getCellWidth | (() => number) => void | A function that provides cell's width getter function to the TableColumnResizing component.
 
 ### TableHeaderRow.SortLabelProps
 


### PR DESCRIPTION
Fixes #2351