### PR TITLE
fix(scheduler-core): get rid of different `new Date` behavior in Safari

### DIFF
--- a/packages/dx-scheduler-core/src/plugins/drag-drop-provider/helpers.ts
+++ b/packages/dx-scheduler-core/src/plugins/drag-drop-provider/helpers.ts
@@ -82,19 +82,19 @@ export const timeBoundariesByResize: TimeBoundariesByResize = (
     const insideTopOffset = calculateInsideOffset(targetType, insidePart, cellDurationMinutes);
     appointmentStartTime = moment(targetData.startDate as Date)
       .add(insideTopOffset, SECONDS).toDate();
-    appointmentEndTime = new Date(payload.endDate as Date);
+    appointmentEndTime = moment(payload.endDate as Date).toDate();
   }
   if (sourceType === RESIZE_BOTTOM) {
     const insideBottomOffset = insidePart === 0 && targetType === VERTICAL_TYPE
       ? cellDurationMinutes * 60 / 2 : 0;
     appointmentEndTime = moment(targetData.endDate as Date)
       .add(-insideBottomOffset, SECONDS).toDate();
-    appointmentStartTime = new Date(payload.startDate as Date);
+    appointmentStartTime = moment(payload.startDate as Date).toDate();
   }
   // keep origin appointment duration if coordinates are wrong
   if (moment(appointmentEndTime).diff(appointmentStartTime, MINUTES) < 1) {
-    appointmentStartTime = new Date(payload.startDate as Date);
-    appointmentEndTime = new Date(payload.endDate as Date);
+    appointmentStartTime = moment(payload.startDate as Date).toDate();
+    appointmentEndTime = moment(payload.endDate as Date).toDate();
   }
   return { appointmentStartTime, appointmentEndTime };
 };

--- a/packages/dx-scheduler-core/src/plugins/editing-state/helpers.ts
+++ b/packages/dx-scheduler-core/src/plugins/editing-state/helpers.ts
@@ -44,21 +44,22 @@ const configureDateSequence: MakeDateSequenceFn = (rRule, exDate, prevStartDate,
 
   const currentOptions = RRule.parseString(rRule as string);
   const correctedOptions = currentOptions.until
-    ? { ...currentOptions, until: new Date(getUTCDate(currentOptions.until)) }
+    ? { ...currentOptions, until: moment(getUTCDate(currentOptions.until)).toDate() }
     : currentOptions;
-  const prevStartDateUTC = new Date(getUTCDate(prevStartDate!));
+  const prevStartDateUTC = moment(getUTCDate(prevStartDate!)).toDate();
   rruleSet.rrule(new RRule({
     ...correctedOptions,
     dtstart: prevStartDateUTC,
   }));
   if (currentOptions.count || currentOptions.until) {
     return rruleSet.all()
-      .map(nextDate => new Date(formatDateToString(nextDate)));
+      // we shouldn't use `new Date(string)` because this function has different results in Safari
+      .map(nextDate => moment(formatDateToString(nextDate)).toDate());
   }
   const leftBound = prevStartDateUTC;
-  const rightBound = new Date(getUTCDate(nextStartDate!));
+  const rightBound = moment(getUTCDate(nextStartDate!)).toDate();
   return rruleSet.between(leftBound, rightBound, true)
-    .map(nextDate => new Date(formatDateToString(nextDate)));
+    .map(nextDate => moment(formatDateToString(nextDate)).toDate());
 };
 
 const configureICalendarRules = (rRule: string | undefined, options: object) => {

--- a/packages/dx-scheduler-core/src/plugins/scheduler-core/computeds.ts
+++ b/packages/dx-scheduler-core/src/plugins/scheduler-core/computeds.ts
@@ -1,5 +1,4 @@
 import { PureComputed } from '@devexpress/dx-core';
-import moment from 'moment';
 import { AppointmentModel, Appointment, FormatDateTimeGetterFn, FormatterFn } from '../../types';
 import { dateTimeFormatInstance } from './helpers';
 
@@ -25,7 +24,7 @@ export const formatDateTimeGetter: FormatDateTimeGetterFn = (locale) => {
 
   const formatter: FormatterFn = (nextDate, nextOptions) => {
     if (nextDate === undefined) return '';
-    const date = moment(nextDate).toDate();
+    const date = new Date(nextDate);
     let formatInstance = cache.get(nextOptions);
 
     if (!formatInstance) {

--- a/packages/dx-scheduler-core/src/plugins/scheduler-core/computeds.ts
+++ b/packages/dx-scheduler-core/src/plugins/scheduler-core/computeds.ts
@@ -1,4 +1,5 @@
 import { PureComputed } from '@devexpress/dx-core';
+import moment from 'moment';
 import { AppointmentModel, Appointment, FormatDateTimeGetterFn, FormatterFn } from '../../types';
 import { dateTimeFormatInstance } from './helpers';
 
@@ -24,7 +25,7 @@ export const formatDateTimeGetter: FormatDateTimeGetterFn = (locale) => {
 
   const formatter: FormatterFn = (nextDate, nextOptions) => {
     if (nextDate === undefined) return '';
-    const date = new Date(nextDate);
+    const date = moment(nextDate).toDate();
     let formatInstance = cache.get(nextOptions);
 
     if (!formatInstance) {

--- a/packages/dx-scheduler-core/src/utils.ts
+++ b/packages/dx-scheduler-core/src/utils.ts
@@ -307,15 +307,15 @@ export const calculateRectByDateIntervals: CalculateRectByDateIntervalsFn = (
 const expandRecurrenceAppointment = (
   appointment: AppointmentMoment, leftBound: Date, rightBound: Date,
 ) => {
-  const rightBoundUTC = new Date(getUTCDate(rightBound));
-  const leftBoundUTC = new Date(getUTCDate(leftBound));
+  const rightBoundUTC = moment(getUTCDate(rightBound)).toDate();
+  const leftBoundUTC = moment(getUTCDate(leftBound)).toDate();
   const appointmentStartDate = moment(appointment.start).toDate();
   const options = {
     ...RRule.parseString(appointment.rRule),
-    dtstart: new Date(getUTCDate(appointmentStartDate)),
+    dtstart: moment(getUTCDate(appointmentStartDate)).toDate(),
   };
   const correctedOptions = options.until
-    ? { ...options, until: new Date(getUTCDate(options.until)) }
+    ? { ...options, until: moment(getUTCDate(options.until)).toDate() }
     : options;
 
   const rruleSet = getRRuleSetWithExDates(appointment.exDate);
@@ -374,7 +374,7 @@ export const getRRuleSetWithExDates: PureComputed<
   if (exDate) {
     exDate.split(',').map((date: string) => {
       const currentExDate = moment(date).toDate();
-      rruleSet.exdate(new Date(getUTCDate(currentExDate)));
+      rruleSet.exdate(moment(getUTCDate(currentExDate)).toDate());
     });
   }
   return rruleSet;


### PR DESCRIPTION
Fixes #2369