### PR TITLE
fix(react-grid-material-ui): add padding for first edit cell in in-line cell editing mode

### DIFF
--- a/packages/dx-react-grid-material-ui/src/templates/table-edit-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-edit-cell.jsx
@@ -8,6 +8,9 @@ import { withStyles } from '@material-ui/core/styles';
 const styles = theme => ({
   cell: {
     padding: theme.spacing(1),
+    '&:first-child': {
+      paddingLeft: theme.spacing(3),
+    },
   },
   inputRoot: {
     width: '100%',


### PR DESCRIPTION
Fixes #2391