### PR TITLE
fix(react-grid-demos): correct displaying custom selector in Edge

### DIFF
--- a/packages/dx-react-grid-demos/src/demo-sources/grid-featured-data-editing/material-ui/demo.jsx
+++ b/packages/dx-react-grid-demos/src/demo-sources/grid-featured-data-editing/material-ui/demo.jsx
@@ -43,6 +43,9 @@ const styles = theme => ({
   inputRoot: {
     width: '100%',
   },
+  selectMenu: {
+    position: 'absolute !important',
+  },
 });
 
 const AddButton = ({ onExecute }) => (
@@ -121,11 +124,14 @@ const LookupEditCellBase = ({
     <Select
       value={value}
       onChange={event => onValueChange(event.target.value)}
+      MenuProps={{
+        className: classes.selectMenu,
+      }}
       input={(
         <Input
           classes={{ root: classes.inputRoot }}
         />
-)}
+      )}
     >
       {availableColumnValues.map(item => (
         <MenuItem key={item} value={item}>


### PR DESCRIPTION
Fixes #2421

Before:
![image](https://user-images.githubusercontent.com/43685423/66576978-45733f00-eb81-11e9-9ecd-db4d775b69b0.png)

After:
![image](https://user-images.githubusercontent.com/43685423/66576881-207ecc00-eb81-11e9-8346-1db20f14cc11.png)
