### PR TITLE
fix(react-grid-demos): fix object assign on Safari

### DIFF
--- a/packages/dx-react-grid-demos/src/demo-sources/grid-grouping/custom-grouping-static.jsxt
+++ b/packages/dx-react-grid-demos/src/demo-sources/grid-grouping/custom-grouping-static.jsxt
@@ -28,13 +28,13 @@ export default () => {
   const [data] = useState([{
     key: 'Male',
     items: generateRows({
-      columnValues: { ...defaultColumnValues, gender: ['Male'] },
+      columnValues: Object.assign(defaultColumnValues, { gender: ['Male'] }),
       length: 5,
     }),
   }, {
     key: 'Female',
     items: generateRows({
-      columnValues: { ...defaultColumnValues, gender: ['Female'] },
+      columnValues: Object.assign(defaultColumnValues, { gender: ['Female'] }),
       length: 5,
     }),
   }]);


### PR DESCRIPTION
Fixes #2488 