### PR TITLE
chore: support React DevTools for demo page

### DIFF
--- a/packages/dx-demo-shell/src/demo-viewer/demo-frame.jsx
+++ b/packages/dx-demo-shell/src/demo-viewer/demo-frame.jsx
@@ -78,6 +78,11 @@ class DemoFrameRenderer extends React.PureComponent {
         <div class="embedded-demo" data-options='{ "path": "${frameUrl}${mode}", "frame": true }'>
           <div style="min-height: 500px;">Loading...</div>
         </div>
+        <script>
+          if (window.parent !== window) {
+            window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+          }
+        </script>
         <script src="${demoScript}"></script>
       </body>
       </html>`;


### PR DESCRIPTION
Because a demo is in a iframe element, we can't select a component by React DevTools.
This change refer to https://github.com/facebook/react-devtools/issues/76.
