### PR TITLE
fix(react-grid-demos): show nodata message after scrolling and filtering

### DIFF
--- a/packages/dx-react-grid-demos/src/demo-sources/grid-lazy-loading/remote-data.jsxt
+++ b/packages/dx-react-grid-demos/src/demo-sources/grid-lazy-loading/remote-data.jsxt
@@ -130,7 +130,7 @@ export default () => {
     dispatch({
       type: 'UPDATE_ROWS',
       payload: {
-        skip,
+        skip: Math.min(skip, newTotalCount),
         rows: cache.getRows(skip, count),
         totalCount: newTotalCount < MAX_ROWS ? newTotalCount : MAX_ROWS,
       },


### PR DESCRIPTION
fixes #2584 