### PR TITLE
fix(react-grid): split band columns with the same name but different parents

### DIFF
--- a/packages/dx-grid-core/src/plugins/table-band-header/computeds.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-band-header/computeds.test.ts
@@ -158,9 +158,9 @@ describe('TableBandHeader Plugin computeds', () => {
               children: [
                 { columnName: 'a' },
                 { columnName: 'b' },
-              ]
-            }
-          ]
+              ],
+            },
+          ],
         },
         {
           title: 'parent2',
@@ -170,9 +170,9 @@ describe('TableBandHeader Plugin computeds', () => {
               children: [
                 { columnName: 'c' },
                 { columnName: 'd' },
-              ]
-            }
-          ]
+              ],
+            },
+          ],
         },
       ];
       const rows = [

--- a/packages/dx-grid-core/src/plugins/table-band-header/computeds.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-band-header/computeds.test.ts
@@ -63,46 +63,6 @@ describe('TableBandHeader Plugin computeds', () => {
     const columns = [
       'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
     ].map(name => ({ column: { name }, key: name, type: TABLE_DATA_TYPE }));
-    const bands = [
-      {
-        title: 'band A-0',
-        children: [
-          { columnName: 'a' },
-          { columnName: 'b' },
-          { columnName: 'c' },
-          {
-            title: 'Band B-0',
-            children: [
-              { columnName: 'c' },
-              { columnName: 'd' },
-            ],
-          },
-          {
-            title: 'Band B-1',
-            children: [
-              { columnName: 'e' },
-              { columnName: 'f' },
-              {
-                title: 'Band C-0',
-                children: [
-                  { columnName: 'f' },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      {
-        title: 'band A-1',
-        children: [{ columnName: 'h' }],
-      },
-    ];
-    const rows = [
-      { key: 'band_0', type: TABLE_BAND_TYPE, level: 0 },
-      { key: 'band_1', type: TABLE_BAND_TYPE, level: 1 },
-      { key: 'band_2', type: TABLE_BAND_TYPE, level: 2 },
-      { key: 'heading', type: 'heading' },
-    ];
     const expandChains = rowChains => rowChains && expandChainsCore(
       rowChains,
       col => ({
@@ -119,12 +79,14 @@ describe('TableBandHeader Plugin computeds', () => {
       ))
     );
     const assertChainsSplit = (
+      rows,
+      columnBands,
       expectedCompressedChains,
     ) => {
       const expectedChains = expandChains(expectedCompressedChains);
 
       const result = tableHeaderColumnChainsWithBands(
-        rows, columns, bands,
+        rows, columns, columnBands,
       );
       const collapsedChains = compressChains(result);
 
@@ -133,11 +95,98 @@ describe('TableBandHeader Plugin computeds', () => {
     };
 
     it('should split columns to band chains', () => {
+      const bands = [
+        {
+          title: 'band A-0',
+          children: [
+            { columnName: 'a' },
+            { columnName: 'b' },
+            { columnName: 'c' },
+            {
+              title: 'Band B-0',
+              children: [
+                { columnName: 'c' },
+                { columnName: 'd' },
+              ],
+            },
+            {
+              title: 'Band B-1',
+              children: [
+                { columnName: 'e' },
+                { columnName: 'f' },
+                {
+                  title: 'Band C-0',
+                  children: [
+                    { columnName: 'f' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          title: 'band A-1',
+          children: [{ columnName: 'h' }],
+        },
+      ];
+      const rows = [
+        { key: 'band_0', type: TABLE_BAND_TYPE, level: 0 },
+        { key: 'band_1', type: TABLE_BAND_TYPE, level: 1 },
+        { key: 'band_2', type: TABLE_BAND_TYPE, level: 2 },
+        { key: 'heading', type: 'heading' },
+      ];
+
       assertChainsSplit(
+        rows,
+        bands,
         [
           [['a', 'b', 'c', 'd', 'e', 'f'], ['g'], ['h'], ['i']],
           [['a', 'b'], ['c', 'd'], ['e', 'f'], ['g'], ['h'], ['i']],
           [['a', 'b'], ['c', 'd'], ['e'], ['f'], ['g'], ['h'], ['i']],
+          [['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']],
+        ],
+      );
+    });
+
+    it('should split columns if adjust bands have the same title but different parents', () => {
+      const adjacentBands = [
+        {
+          title: 'parent1',
+          children: [
+            {
+              title: 'sharedName',
+              children: [
+                { columnName: 'a' },
+                { columnName: 'b' },
+              ]
+            }
+          ]
+        },
+        {
+          title: 'parent2',
+          children: [
+            {
+              title: 'sharedName',
+              children: [
+                { columnName: 'c' },
+                { columnName: 'd' },
+              ]
+            }
+          ]
+        },
+      ];
+      const rows = [
+        { key: 'band_0', type: TABLE_BAND_TYPE, level: 0 },
+        { key: 'band_1', type: TABLE_BAND_TYPE, level: 1 },
+        { key: 'heading', type: 'heading' },
+      ];
+
+      assertChainsSplit(
+        rows,
+        adjacentBands,
+        [
+          [['a', 'b'], ['c', 'd'], ['e', 'f', 'g', 'h', 'i']],
+          [['a', 'b'], ['c', 'd'], ['e', 'f', 'g', 'h', 'i']],
           [['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']],
         ],
       );

--- a/packages/dx-grid-core/src/plugins/table-band-header/computeds.ts
+++ b/packages/dx-grid-core/src/plugins/table-band-header/computeds.ts
@@ -60,10 +60,11 @@ export const tableHeaderColumnChainsWithBands: GetHeaderColumnChainsFn<
     const columnName = column.column && column.column.name || '';
     currentBand = getColumnMeta(columnName, bands, rowIndex);
     return !chain
-      || (chain as any).bandTitle !== currentBand.title;
+      || (chain as any).key !== currentBand.key;
   };
   const extendChainProps = () => ({
-    bandTitle: (currentBand || {}).title,
+    bandTitle: currentBand?.title,
+    key: currentBand?.key,
   });
 
   const bandChains = splitHeaderColumnChains(

--- a/packages/dx-grid-core/src/plugins/table-band-header/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-band-header/helpers.test.ts
@@ -98,12 +98,12 @@ describe('TableBandHeader Plugin helpers', () => {
   describe('#getColumnMeta', () => {
     it('should return correct column meta for the first level children', () => {
       expect(getColumnMeta('d', columnBands, 1))
-        .toEqual({ title: 'Band A', level: 1 });
+        .toEqual({ title: 'Band A', level: 1, key: '_Band A' });
     });
 
     it('should return correct column meta for the deeper children levels', () => {
       expect(getColumnMeta('a', columnBands, 2))
-        .toEqual({ title: 'Band B', level: 2 });
+        .toEqual({ title: 'Band B', level: 2, key: '_Band A_Band B' });
     });
 
     it('should work with immutable properties', () => {
@@ -202,7 +202,7 @@ describe('TableBandHeader Plugin helpers', () => {
           payload: {
             colSpan: 4,
             value: 'Band A',
-            column: { title: 'Band A', level: 2 },
+            column: { title: 'Band A', level: 2, key: '_Band A' },
           },
         });
     });
@@ -255,7 +255,7 @@ describe('TableBandHeader Plugin helpers', () => {
             payload: {
               colSpan: 1,
               value: 'Band A',
-              column: { title: 'Band A', level: 2 },
+              column: { title: 'Band A', level: 2, key: '_Band A' },
             },
           });
 
@@ -271,7 +271,7 @@ describe('TableBandHeader Plugin helpers', () => {
             payload: {
               colSpan: 1,
               value: 'Band B',
-              column: { title: 'Band B', level: 2 },
+              column: { title: 'Band B', level: 2, key: '_Band A_Band B' },
             },
           });
 
@@ -316,7 +316,7 @@ describe('TableBandHeader Plugin helpers', () => {
             payload: {
               colSpan: 3,
               value: 'Band A',
-              column: { title: 'Band A', level: 2 },
+              column: { title: 'Band A', level: 2, key: '_Band A' },
             },
           });
       });
@@ -344,7 +344,7 @@ describe('TableBandHeader Plugin helpers', () => {
             payload: {
               colSpan: 2,
               value: 'Band A',
-              column: { title: 'Band A', level: 2 },
+              column: { title: 'Band A', level: 2, key: '_Band A' },
             },
           });
       });
@@ -389,7 +389,7 @@ describe('TableBandHeader Plugin helpers', () => {
             payload: {
               colSpan: 2,
               value: 'Band A',
-              column: { title: 'Band A', level: 1 },
+              column: { title: 'Band A', level: 1, key: '_Band A' },
               beforeBorder: true,
             },
           });
@@ -454,7 +454,7 @@ describe('TableBandHeader Plugin helpers', () => {
           payload: {
             colSpan,
             value: 'Band0',
-            column: { title: 'Band0', level: 1 },
+            column: { title: 'Band0', level: 1, key: '_Band0' },
           },
         });
 

--- a/packages/dx-grid-core/src/plugins/table-band-header/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/table-band-header/helpers.ts
@@ -16,24 +16,27 @@ export const isBandedOrHeaderRow: IsSpecificRowFn = tableRow => isBandedTableRow
 export const isNoDataColumn = (columnType: symbol) => columnType !== TABLE_DATA_TYPE;
 
 export const getColumnMeta: GetColumnBandMetaFn = (
-  columnName, bands, tableRowLevel,
+  columnName, bands, tableRowLevel, key = '',
   level = 0, title = null, result = null,
 ) => bands.reduce((acc, column) => {
   if (column.columnName === columnName) {
-    return { ...acc, title, level };
+    return { ...acc, title, level, key };
   }
   if (column.children !== undefined) {
+    const bandTitle = level > tableRowLevel ? title : column.title;
+    const bandKey = level > tableRowLevel ? key : `${key}_${bandTitle}`;
     return getColumnMeta(
       columnName,
       column.children,
       tableRowLevel,
+      bandKey,
       level + 1,
-      level > tableRowLevel ? title : column.title,
+      bandTitle,
       acc,
     );
   }
   return acc;
-}, result || { level, title });
+}, result || { level, title, key: title });
 
 // TODO: refactor
 export const getBandComponent: GetBandComponentFn = (

--- a/packages/dx-grid-core/src/plugins/table-band-header/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/table-band-header/helpers.ts
@@ -18,16 +18,18 @@ export const isNoDataColumn = (columnType: symbol) => columnType !== TABLE_DATA_
 export const getColumnMeta: GetColumnBandMetaFn = (
   columnName, bands, tableRowLevel, key = '',
   level = 0, title = null, result = null,
-) => bands.reduce((acc, column) => {
-  if (column.columnName === columnName) {
+) => bands.reduce((acc, band) => {
+  if (band.columnName === columnName) {
     return { ...acc, title, level, key };
   }
-  if (column.children !== undefined) {
-    const bandTitle = level > tableRowLevel ? title : column.title;
-    const bandKey = level > tableRowLevel ? key : `${key}_${bandTitle}`;
+  if (band.children !== undefined) {
+    const rowLevelPassed = level > tableRowLevel;
+    const bandTitle = rowLevelPassed ? title : band.title;
+    const bandKey = rowLevelPassed ? key : `${key}_${bandTitle}`;
+
     return getColumnMeta(
       columnName,
-      column.children,
+      band.children,
       tableRowLevel,
       bandKey,
       level + 1,

--- a/packages/dx-grid-core/src/types/band-header.types.ts
+++ b/packages/dx-grid-core/src/types/band-header.types.ts
@@ -36,6 +36,7 @@ export type GetColumnBandMetaFn = (
   columnName: string,
   bands: ReadonlyArray<ColumnBands>,
   tableRowLevel: number,
+  key?: string,
   level?: number,
   title?: string | null | undefined,
   result?: ColumnBandMeta | null,


### PR DESCRIPTION
fixes #2617 