### PR TITLE
chore: correct scroll-to-row demo

### DIFF
--- a/packages/dx-react-grid-demos/src/demo-sources/grid-virtual-scrolling/scroll-to-row.jsxt
+++ b/packages/dx-react-grid-demos/src/demo-sources/grid-virtual-scrolling/scroll-to-row.jsxt
@@ -19,6 +19,10 @@ import {
 
 const getRowId = row => row.id;
 
+const defaultSorting = [
+  { columnName: 'name', direction: 'asc' },
+];
+
 export default () => {
   const [columns] = useState([
     { name: 'name', title: 'Name' },
@@ -34,9 +38,6 @@ export default () => {
     { columnName: 'id', width: 75 },
   ]);
   const vtRef = useRef();
-  const [defaultSorting] = useState([
-    { columnName: 'name', direction: 'asc' },
-  ]);
   const [sortingStateColumnExtensions] = useState([
     { columnName: 'gender', sortingEnabled: false },
     { columnName: 'city', sortingEnabled: false },

--- a/packages/dx-react-grid-demos/src/demo-sources/grid-virtual-scrolling/scroll-to-row.jsxt
+++ b/packages/dx-react-grid-demos/src/demo-sources/grid-virtual-scrolling/scroll-to-row.jsxt
@@ -34,6 +34,14 @@ export default () => {
     { columnName: 'id', width: 75 },
   ]);
   const vtRef = useRef();
+  const [defaultSorting] = useState([
+    { columnName: 'name', direction: 'asc' },
+  ]);
+  const [sortingStateColumnExtensions] = useState([
+    { columnName: 'gender', sortingEnabled: false },
+    { columnName: 'city', sortingEnabled: false },
+    { columnName: 'car', sortingEnabled: false },
+  ]);
 
   const scrollToRow = useCallback((rowId) => {
     vtRef.current.scrollToRow(rowId);
@@ -92,7 +100,8 @@ export default () => {
           onCommitChanges={commitChanges}
         />
         <SortingState
-          sorting={[{ columnName: 'name', direction: 'asc' }]}
+          defaultSorting={defaultSorting}
+          columnExtensions={sortingStateColumnExtensions}
         />
         <IntegratedSorting />
         <VirtualTable


### PR DESCRIPTION
Allow sorting only by the `name` column.
Get rid of sorting lables for other column (using `SortingState.columnExtensions`)