### PR TITLE
fix(react-grid): allow to change "TableTreeColumn.for" property in runtime

### DIFF
--- a/packages/dx-react-grid/src/plugins/table-tree-column.test.tsx
+++ b/packages/dx-react-grid/src/plugins/table-tree-column.test.tsx
@@ -226,46 +226,48 @@ describe('TableTreeColumn', () => {
   });
 
   it('should change "for" property in runtime', () => {
-      class Test extends React.Component {
-        constructor(props) {
-          super(props);
-          this.state = {
-            columnName: props.columnName,
-          }
-        }
-
-        render() {
-          const { columnName } = this.state;
-          isTreeTableCell.mockImplementation(( _, tableColumn ) => tableColumn.column.name === columnName);
-
-          return(
-            <PluginHost>
-            {pluginDepsToComponents(defaultDeps)}
-              <TableTreeColumn
-                {...defaultProps}
-                for={columnName}
-              />
-            </PluginHost>
-          )
-        }
+    class Test extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          columnName: props.columnName,
+        };
       }
-      
-      const tree = mount((
-        <Test
-          columnName={'b'}
-        />
-      ))
 
-      expect(tree.find(defaultProps.cellComponent).exists())
-        .toBeFalsy();
+      render() {
+        const { columnName } = this.state;
+        isTreeTableCell.mockImplementation((_, tableColumn) => (
+          tableColumn.column.name === columnName
+        ));
 
-      tree.setState({
-        columnName: 'a',
-      })
+        return(
+          <PluginHost>
+          {pluginDepsToComponents(defaultDeps)}
+            <TableTreeColumn
+              {...defaultProps}
+              for={columnName}
+            />
+          </PluginHost>
+        );
+      }
+    }
 
-      expect(tree.find(defaultProps.cellComponent).exists())
-        .toBeTruthy();
-      expect(tree.find(defaultProps.cellComponent).props().column.name)
-        .toEqual('a');
+    const tree = mount((
+      <Test
+        columnName={'b'}
+      />
+    ));
+
+    expect(tree.find(defaultProps.cellComponent).exists())
+      .toBeFalsy();
+
+    tree.setState({
+      columnName: 'a',
+    });
+
+    expect(tree.find(defaultProps.cellComponent).exists())
+      .toBeTruthy();
+    expect(tree.find(defaultProps.cellComponent).props().column.name)
+      .toEqual('a');
   });
 });

--- a/packages/dx-react-grid/src/plugins/table-tree-column.test.tsx
+++ b/packages/dx-react-grid/src/plugins/table-tree-column.test.tsx
@@ -24,7 +24,7 @@ const defaultDeps = {
     tableCell: {
       tableRow: { type: 'undefined', rowId: 1, row: { value: 'value' } },
       tableColumn: { type: 'undefined', rowId: 1, column: { name: 'a' } },
-      style: {},  
+      style: {},
     },
   },
   plugins: ['TreeDataState', 'Table'],

--- a/packages/dx-react-grid/src/plugins/table-tree-column.test.tsx
+++ b/packages/dx-react-grid/src/plugins/table-tree-column.test.tsx
@@ -24,7 +24,7 @@ const defaultDeps = {
     tableCell: {
       tableRow: { type: 'undefined', rowId: 1, row: { value: 'value' } },
       tableColumn: { type: 'undefined', rowId: 1, column: { name: 'a' } },
-      style: {},
+      style: {},  
     },
   },
   plugins: ['TreeDataState', 'Table'],
@@ -223,5 +223,49 @@ describe('TableTreeColumn', () => {
         row: defaultDeps.template.tableCell.tableRow.row,
         value: defaultDeps.template.tableCell.tableRow.row.value,
       });
+  });
+
+  it('should change "for" property in runtime', () => {
+      class Test extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            columnName: props.columnName,
+          }
+        }
+
+        render() {
+          const { columnName } = this.state;
+          isTreeTableCell.mockImplementation(( _, tableColumn ) => tableColumn.column.name === columnName);
+
+          return(
+            <PluginHost>
+            {pluginDepsToComponents(defaultDeps)}
+              <TableTreeColumn
+                {...defaultProps}
+                for={columnName}
+              />
+            </PluginHost>
+          )
+        }
+      }
+      
+      const tree = mount((
+        <Test
+          columnName={'b'}
+        />
+      ))
+
+      expect(tree.find(defaultProps.cellComponent).exists())
+        .toBeFalsy();
+
+      tree.setState({
+        columnName: 'a',
+      })
+
+      expect(tree.find(defaultProps.cellComponent).exists())
+        .toBeTruthy();
+      expect(tree.find(defaultProps.cellComponent).props().column.name)
+        .toEqual('a');
   });
 });

--- a/packages/dx-react-grid/src/plugins/table-tree-column.tsx
+++ b/packages/dx-react-grid/src/plugins/table-tree-column.tsx
@@ -40,6 +40,7 @@ class TableTreeColumnBase extends React.PureComponent<TableTreeColumnProps> {
           { name: 'Table' },
           { name: 'TableHeaderRow', optional: true },
         ]}
+        key={forColumnName}
       >
         <Getter name="tableTreeColumnName" value={forColumnName} />
         <Template


### PR DESCRIPTION
Fixes #2649 