### PR TITLE
fix(react-grid): add ref to VirtualTable props definition

### DIFF
--- a/packages/dx-react-grid-bootstrap3/api/dx-react-grid-bootstrap3.api.md
+++ b/packages/dx-react-grid-bootstrap3/api/dx-react-grid-bootstrap3.api.md
@@ -829,6 +829,7 @@ export interface VirtualTableProps {
   noDataCellComponent?: React.ComponentType<Table_2.NoDataCellProps>;
   noDataRowComponent?: React.ComponentType<Table_2.RowProps>;
   onTopRowChange?: (rowId: number | string) => void;
+  ref?: React.RefObject<typeof VirtualTable>;
   rowComponent?: React.ComponentType<Table_2.DataRowProps>;
   stubCellComponent?: React.ComponentType<Table_2.CellProps>;
   stubHeaderCellComponent?: React.ComponentType<Table_2.CellProps>;

--- a/packages/dx-react-grid-bootstrap4/api/dx-react-grid-bootstrap4.api.md
+++ b/packages/dx-react-grid-bootstrap4/api/dx-react-grid-bootstrap4.api.md
@@ -829,6 +829,7 @@ export interface VirtualTableProps {
   noDataCellComponent?: React.ComponentType<Table_2.NoDataCellProps>;
   noDataRowComponent?: React.ComponentType<Table_2.RowProps>;
   onTopRowChange?: (rowId: number | string) => void;
+  ref?: React.RefObject<typeof VirtualTable>;
   rowComponent?: React.ComponentType<Table_2.DataRowProps>;
   stubCellComponent?: React.ComponentType<Table_2.CellProps>;
   stubHeaderCellComponent?: React.ComponentType<Table_2.CellProps>;

--- a/packages/dx-react-grid-material-ui/api/dx-react-grid-material-ui.api.md
+++ b/packages/dx-react-grid-material-ui/api/dx-react-grid-material-ui.api.md
@@ -829,6 +829,7 @@ export interface VirtualTableProps {
   noDataCellComponent?: React.ComponentType<Table_2.NoDataCellProps>;
   noDataRowComponent?: React.ComponentType<Table_2.RowProps>;
   onTopRowChange?: (rowId: number | string) => void;
+  ref?: React.RefObject<typeof VirtualTable>;
   rowComponent?: React.ComponentType<Table_2.DataRowProps>;
   stubCellComponent?: React.ComponentType<Table_2.CellProps>;
   stubHeaderCellComponent?: React.ComponentType<Table_2.CellProps>;

--- a/packages/dx-react-grid/api/dx-react-grid.api.md
+++ b/packages/dx-react-grid/api/dx-react-grid.api.md
@@ -1469,6 +1469,7 @@ export interface VirtualTableProps {
     noDataCellComponent: React.ComponentType<Table.NoDataCellProps>;
     noDataRowComponent: React.ComponentType<Table.RowProps>;
     onTopRowChange: (rowId: number | string | symbol) => void;
+    ref?: React.RefObject<typeof VirtualTable>;
     rowComponent: React.ComponentType<Table.DataRowProps>;
     // (undocumented)
     skeletonCellComponent: React.ComponentType<Table.CellProps>;

--- a/packages/dx-react-grid/docs/reference/virtual-table.md
+++ b/packages/dx-react-grid/docs/reference/virtual-table.md
@@ -39,7 +39,7 @@ stubCellComponent | ComponentType&lt;[Table.CellProps](table.md#tablecellprops)&
 stubHeaderCellComponent | ComponentType&lt;[Table.CellProps](table.md#tablecellprops)&gt; | | A component that renders a stub header cell if the cell value is not provided.
 messages? | [Table.LocalizationMessages](table.md#localization-messages) | | An object that specifies the localization messages.
 onTopRowChange? | (rowId: number &#124; string) => void | | Handles a change of the top row.
-ref? | React.RefObject&lt;typeof VirtualTable&gt; | | A reference to the VirtualTable instance
+ref? | React.RefObject&lt;typeof VirtualTable&gt; | | A reference to the `VirtualTable` instance
 
 ## Methods
 

--- a/packages/dx-react-grid/docs/reference/virtual-table.md
+++ b/packages/dx-react-grid/docs/reference/virtual-table.md
@@ -39,6 +39,7 @@ stubCellComponent | ComponentType&lt;[Table.CellProps](table.md#tablecellprops)&
 stubHeaderCellComponent | ComponentType&lt;[Table.CellProps](table.md#tablecellprops)&gt; | | A component that renders a stub header cell if the cell value is not provided.
 messages? | [Table.LocalizationMessages](table.md#localization-messages) | | An object that specifies the localization messages.
 onTopRowChange? | (rowId: number &#124; string) => void | | Handles a change of the top row.
+ref? | React.RefObject&lt;typeof VirtualTable&gt; | | A reference to the VirtualTable instance
 
 ## Methods
 

--- a/packages/dx-react-grid/src/types/tables/virtual-table.types.ts
+++ b/packages/dx-react-grid/src/types/tables/virtual-table.types.ts
@@ -59,6 +59,8 @@ export interface VirtualTableProps {
   skeletonCellComponent: React.ComponentType<Table.CellProps>;
   /** Handles top row changes. */
   onTopRowChange: (rowId: number | string | symbol) => void;
+  /** A reference to the VirtualTable instance */
+  ref?: React.RefObject<typeof VirtualTable>;
 }
 
 /** @internal */


### PR DESCRIPTION
fixes #2659 

It is type-safe now to assign a ref to the VirtualTable plugin:

```typescript
const vtRef = useRef<typeof VirtualTable>(null);
```
