### PR TITLE
docs(react-scheduler): add description to AppointmentForm Select's availableOptions

### DIFF
--- a/packages/dx-react-scheduler/api/dx-react-scheduler.api.md
+++ b/packages/dx-react-scheduler/api/dx-react-scheduler.api.md
@@ -227,7 +227,7 @@ export namespace AppointmentForm {
     resources: Array<ValidResource>;
   }
   export interface SelectProps {
-    availableOptions?: Array<object>;
+    availableOptions?: Array<SelectOption>;
     onValueChange: (nextValue: string | number) => void;
     readOnly?: boolean;
     type: 'outlinedSelect' | 'filledSelect';
@@ -987,6 +987,12 @@ export type ScrollingStrategy = {
   rightBoundary: number;
   changeVerticalScroll: (value: number) => void;
   changeHorizontalScroll: (value: number) => void;
+};
+
+// @public
+export type SelectOption = {
+  text: string;
+  id: number | string;
 };
 
 // @public (undocumented)

--- a/packages/dx-react-scheduler/docs/reference/appointment-form.md
+++ b/packages/dx-react-scheduler/docs/reference/appointment-form.md
@@ -211,6 +211,14 @@ availableOptions? | Array&lt;object&gt; | Specifies available menu options.
 type? | `outlinedSelect` &#124; `filledSelect` | The menu's type.
 readOnly | boolean | Specifies whether the menu is read-only.
 
+> availableOptions object must conform to this shape:  
+> ```
+> availableOptions: {  
+>    id: (string | number),  
+>    text: (string),  
+> }  
+> ```
+
 ### AppointmentForm.ResourceEditorProps
 
 Properties passed to a component that renders a resource editor on the appointment form.

--- a/packages/dx-react-scheduler/docs/reference/appointment-form.md
+++ b/packages/dx-react-scheduler/docs/reference/appointment-form.md
@@ -55,12 +55,12 @@ weeklyRecurrenceSelectorComponent | ComponentType&lt;[AppointmentForm.WeeklyRecu
 
 ### SelectOption
 
-Represents a Select Editor's value and its id.
+An option in the Select editor.
 
 Field | Type | Description
 ------|------|------------
 id | string &#124; number | The option's id.
-text | string | The option's text value.
+text | string | The option's text.
 
 ### AppointmentForm.OverlayProps
 

--- a/packages/dx-react-scheduler/docs/reference/appointment-form.md
+++ b/packages/dx-react-scheduler/docs/reference/appointment-form.md
@@ -53,6 +53,15 @@ weeklyRecurrenceSelectorComponent | ComponentType&lt;[AppointmentForm.WeeklyRecu
 
 ## Interfaces
 
+### SelectOption
+
+Represents a Select Editor's value and its id.
+
+Field | Type | Description
+------|------|------------
+id | string &#124; number | The option's id.
+text | string | The option's text value.
+
 ### AppointmentForm.OverlayProps
 
 Properties passed to a component that renders the appointment form's overlay.
@@ -207,17 +216,9 @@ Field | Type | Description
 ------|------|------------
 value? | string &#124; number | The selected option.
 onValueChange | (nextValue: string &#124; number) => void | Handles value changes.
-availableOptions? | Array&lt;object&gt; | Specifies available menu options.
+availableOptions? | Array&lt;[SelectOption](#selectoption)&gt; | Specifies available menu options.
 type? | `outlinedSelect` &#124; `filledSelect` | The menu's type.
 readOnly | boolean | Specifies whether the menu is read-only.
-
-> availableOptions object must conform to this shape:  
-> ```
-> availableOptions: {  
->    id: (string | number),  
->    text: (string),  
-> }  
-> ```
 
 ### AppointmentForm.ResourceEditorProps
 

--- a/packages/dx-react-scheduler/src/types/editing/appointment-form.types.ts
+++ b/packages/dx-react-scheduler/src/types/editing/appointment-form.types.ts
@@ -1,4 +1,6 @@
-import { AppointmentModel, FormatterFn, ValidResourceInstance, ValidResource } from '../index';
+import {
+  AppointmentModel, FormatterFn, ValidResourceInstance, ValidResource, SelectOption,
+} from '../index';
 
 /* tslint:disable no-namespace max-line-length */
 export namespace AppointmentForm {
@@ -166,7 +168,7 @@ export namespace AppointmentForm {
     /** Handles value changes. */
     onValueChange: (nextValue: string | number) => void;
     /** Specifies available menu options. */
-    availableOptions?: Array<object>;
+    availableOptions?: Array<SelectOption>;
     /** Specifies whether the menu is read-only. */
     readOnly?: boolean;
     /** The menu's type. */

--- a/packages/dx-react-scheduler/src/types/index.ts
+++ b/packages/dx-react-scheduler/src/types/index.ts
@@ -2,7 +2,7 @@ export {
   AppointmentModel, AppointmentMeta, ElementRect, ValidResource, Color,
   ScrollingStrategy, CellElementsMeta, FormatterFn, SchedulerView,
   PreCommitChangesFn, ChangeSet, ViewCell, Resource, ValidResourceInstance,
-  Grouping, GroupKey, GroupOrientation, Group,
+  Grouping, GroupKey, GroupOrientation, Group, SelectOption,
 } from '../../../dx-scheduler-core/src/index';
 
 /** @internal */

--- a/packages/dx-scheduler-core/src/plugins/appointment-form/utils.ts
+++ b/packages/dx-scheduler-core/src/plugins/appointment-form/utils.ts
@@ -3,7 +3,9 @@ import {
   LONG_MONTH_OPTIONS,
 } from '@devexpress/dx-scheduler-core';
 import { PureComputed } from '@devexpress/dx-core';
-import { Option, OptionsFormatterFn, DateFormatterFn, RecurrenceFrequency } from '../../types';
+import {
+  SelectOption, OptionsFormatterFn, DateFormatterFn, RecurrenceFrequency,
+} from '../../types';
 import {
   MONTHS_DATES, REPEAT_TYPES_ARRAY, WEEK_NUMBER_LABELS, DAYS_IN_WEEK, RRULE_REPEAT_TYPES,
   BASIC_YEALY_COUNT, BASIC_MONTHLY_COUNT, BASIC_WEEKLY_COUNT, BASIC_DAILY_COUNT,
@@ -17,7 +19,7 @@ export const getWeekNumberLabels: OptionsFormatterFn = getMessage =>
   }));
 
 export const getDaysOfWeek: PureComputed<
-  [(date: Date, formatOptions: object) => string, number], Array<Option>
+  [(date: Date, formatOptions: object) => string, number], Array<SelectOption>
 > = (formatDate, firstDayOfWeek) => {
   const daysOfWeekArray = getDaysOfWeekArray(firstDayOfWeek);
   const daysOfWeekDates = getDaysOfWeekDates(firstDayOfWeek);
@@ -36,7 +38,7 @@ export const getMonths: DateFormatterFn = formatDate => MONTHS_DATES.map((month,
 
 export const getMonthsWithOf: PureComputed<
   [(messageKey: string) => string, (date: Date, formatOptions: object) => string],
-    Array<Option>
+    Array<SelectOption>
 > = (getMessage, formatDate) => MONTHS_DATES.map((month, index) => ({
   text: getMonthWithOf(month, getMessage, formatDate),
   id: getMonthId(index),

--- a/packages/dx-scheduler-core/src/types/appointment-form.types.ts
+++ b/packages/dx-scheduler-core/src/types/appointment-form.types.ts
@@ -23,18 +23,20 @@ export type RadioGroupDisplayData = {
   dayOfWeek: number;
   radioGroupValue: string;
 };
-/** @internal */
-export type Option = {
+/** Represents a Select Editor's value and its id. */
+export type SelectOption = {
+  /** The option's text value. */
   text: string;
+  /** The option's id. */
   id: number | string;
 };
 /** @internal */
 export type OptionsFormatterFn = PureComputed<
-  [(messageKey: string) => string], Array<Option>
+  [(messageKey: string) => string], Array<SelectOption>
 >;
 /** @internal */
 export type DateFormatterFn = PureComputed<
-  [(date: Date, formatOptions: object) => string], Array<Option>
+  [(date: Date, formatOptions: object) => string], Array<SelectOption>
 >;
 /** @internal */
 export enum RecurrenceFrequency {

--- a/packages/dx-scheduler-core/src/types/appointment-form.types.ts
+++ b/packages/dx-scheduler-core/src/types/appointment-form.types.ts
@@ -23,9 +23,9 @@ export type RadioGroupDisplayData = {
   dayOfWeek: number;
   radioGroupValue: string;
 };
-/** Represents a Select Editor's value and its id. */
+/** An option in the Select editor. */
 export type SelectOption = {
-  /** The option's text value. */
+  /** The option's text. */
   text: string;
   /** The option's id. */
   id: number | string;


### PR DESCRIPTION
Updated `AppointmentForm` `selectProps` documentation to detail the required shape of the `availableOptions` object. 

I was looking around for forever for this and had to dig into the code to find it eventually. 

Go open-source :wink: :thumbsup: