### PR TITLE
feat(react-scheduler-material-ui): change DayView and WeekView DayScale's today cell appearance

### DIFF
--- a/packages/dx-react-scheduler-material-ui/src/templates/views/vertical/day-scale/cell.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/views/vertical/day-scale/cell.jsx
@@ -42,25 +42,9 @@ const styles = theme => ({
     fontSize: '1.8rem',
     paddingBottom: theme.spacing(0.625),
   },
-  today: {
-    width: '1.2em',
-    height: '1.2em',
-    lineHeight: 1.2,
-    textAlign: 'center',
-    borderRadius: '50%',
-    background: theme.palette.primary.main,
-    color: theme.palette.primary.contrastText,
-    cursor: 'default',
-    paddingBottom: 0,
-    marginRight: 'auto',
-    marginLeft: 'auto',
-    'td:only-child &': {
-      marginRight: 0,
-      marginLeft: 0,
-    },
-  },
-  highlight: {
+  highlightedText: {
     color: theme.palette.primary.main,
+    fontWeight: 'bold',
   },
   dayView: {
     'td:only-child &': {
@@ -101,7 +85,7 @@ const CellBase = React.memo(({
       <p
         className={classNames({
           [classes.dayOfWeek]: true,
-          [classes.highlight]: today,
+          [classes.highlightedText]: today,
         })}
       >
         {formatDate(startDate, WEEK_DAY_OPTIONS)}
@@ -109,7 +93,7 @@ const CellBase = React.memo(({
       <div
         className={classNames({
           [classes.dayOfMonth]: true,
-          [classes.today]: today,
+          [classes.highlightedText]: today,
         })}
       >
         {formatDate(startDate, DAY_OPTIONS)}

--- a/packages/dx-react-scheduler-material-ui/src/templates/views/vertical/day-scale/cell.test.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/views/vertical/day-scale/cell.test.jsx
@@ -50,7 +50,6 @@ describe('Vertical view DayScale', () => {
 
       expect(tree.find(`.${classes.highlightedText}`))
         .toHaveLength(2);
-
     });
     it('should call formatDate function', () => {
       const formatDate = jest.fn();

--- a/packages/dx-react-scheduler-material-ui/src/templates/views/vertical/day-scale/cell.test.jsx
+++ b/packages/dx-react-scheduler-material-ui/src/templates/views/vertical/day-scale/cell.test.jsx
@@ -38,13 +38,19 @@ describe('Vertical view DayScale', () => {
     });
     it('should highlight today cell', () => {
       const tree = shallow((
-        <Cell {...defaultProps} today />
+        <Cell {...defaultProps} today={false} />
       ));
 
-      expect(tree.find(`p.${classes.highlight}`).exists())
-        .toBeTruthy();
-      expect(tree.find(`div.${classes.today}`).exists())
-        .toBeTruthy();
+      expect(tree.find(`.${classes.highlightedText}`).exists())
+        .toBeFalsy();
+
+      tree.setProps({
+        today: true,
+      });
+
+      expect(tree.find(`.${classes.highlightedText}`))
+        .toHaveLength(2);
+
     });
     it('should call formatDate function', () => {
       const formatDate = jest.fn();


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/51905811/74214961-7fc82680-4cb0-11ea-8ac8-44b1ef292b0c.png)

After:

![image](https://user-images.githubusercontent.com/51905811/74214976-8eaed900-4cb0-11ea-8030-426c032cfe77.png)
