### PR TITLE
fix(scheduler-core): filter WeekView appointments correctly when excluded days contain an interval of three or more days in a row

### DIFF
--- a/packages/dx-scheduler-core/src/utils.test.ts
+++ b/packages/dx-scheduler-core/src/utils.test.ts
@@ -12,6 +12,7 @@ import {
   filterByViewBoundaries,
   getRRuleSetWithExDates,
   formatDateToString,
+  excludedIntervals,
 } from './utils';
 
 describe('Utils', () => {
@@ -91,6 +92,48 @@ describe('Utils', () => {
 
       expect(filtered)
         .toEqual(appointments.slice(0, 1));
+    });
+  });
+  describe('#excludedIntervals', () => {
+    const firstDayOfWeek = moment('2020-03-03');
+    it('should create an interval of excluded days', () => {
+      const excludedDays = [3];
+
+      expect(excludedIntervals(excludedDays, firstDayOfWeek))
+        .toEqual([[
+          moment(firstDayOfWeek.day(3)),
+          moment(firstDayOfWeek.day(3)).endOf('day'),
+        ]]);
+    });
+    it('should create several intervals of excluded days', () => {
+      const excludedDays = [2, 5];
+
+      expect(excludedIntervals(excludedDays, firstDayOfWeek))
+        .toEqual([[
+          moment(firstDayOfWeek.day(2)),
+          moment(firstDayOfWeek.day(2)).endOf('day'),
+        ], [
+          moment(firstDayOfWeek.day(5)),
+          moment(firstDayOfWeek.day(5)).endOf('day'),
+        ]]);
+    });
+    it('should create an interval for several excluded days in a row', () => {
+      const excludedDays = [2, 3, 4, 5];
+
+      expect(excludedIntervals(excludedDays, firstDayOfWeek))
+        .toEqual([[
+          moment(firstDayOfWeek.day(2)),
+          moment(firstDayOfWeek.day(5)).endOf('day'),
+        ]]);
+    });
+    it('should work correctly with sundays', () => {
+      const excludedDays = [0, 5, 6];
+
+      expect(excludedIntervals(excludedDays, firstDayOfWeek))
+        .toEqual([[
+          moment(firstDayOfWeek.day(5)),
+          moment(firstDayOfWeek.day(7)).endOf('day'),
+        ]]);
     });
   });
   describe('#sortAppointments', () => {

--- a/packages/dx-scheduler-core/src/utils.test.ts
+++ b/packages/dx-scheduler-core/src/utils.test.ts
@@ -95,44 +95,44 @@ describe('Utils', () => {
     });
   });
   describe('#excludedIntervals', () => {
-    const firstDayOfWeek = moment('2020-03-03');
+    const start = moment('2020-03-03');
     it('should create an interval of excluded days', () => {
       const excludedDays = [3];
 
-      expect(excludedIntervals(excludedDays, firstDayOfWeek))
+      expect(excludedIntervals(excludedDays, start))
         .toEqual([[
-          moment(firstDayOfWeek.day(3)),
-          moment(firstDayOfWeek.day(3)).endOf('day'),
+          moment(start.day(3)),
+          moment(start.day(3)).endOf('day'),
         ]]);
     });
     it('should create several intervals of excluded days', () => {
       const excludedDays = [2, 5];
 
-      expect(excludedIntervals(excludedDays, firstDayOfWeek))
+      expect(excludedIntervals(excludedDays, start))
         .toEqual([[
-          moment(firstDayOfWeek.day(2)),
-          moment(firstDayOfWeek.day(2)).endOf('day'),
+          moment(start.day(2)),
+          moment(start.day(2)).endOf('day'),
         ], [
-          moment(firstDayOfWeek.day(5)),
-          moment(firstDayOfWeek.day(5)).endOf('day'),
+          moment(start.day(5)),
+          moment(start.day(5)).endOf('day'),
         ]]);
     });
     it('should create an interval for several excluded days in a row', () => {
       const excludedDays = [2, 3, 4, 5];
 
-      expect(excludedIntervals(excludedDays, firstDayOfWeek))
+      expect(excludedIntervals(excludedDays, start))
         .toEqual([[
-          moment(firstDayOfWeek.day(2)),
-          moment(firstDayOfWeek.day(5)).endOf('day'),
+          moment(start.day(2)),
+          moment(start.day(5)).endOf('day'),
         ]]);
     });
     it('should work correctly with sundays', () => {
       const excludedDays = [0, 5, 6];
 
-      expect(excludedIntervals(excludedDays, firstDayOfWeek))
+      expect(excludedIntervals(excludedDays, start))
         .toEqual([[
-          moment(firstDayOfWeek.day(5)),
-          moment(firstDayOfWeek.day(7)).endOf('day'),
+          moment(start.day(5)),
+          moment(start.day(7)).endOf('day'),
         ]]);
     });
   });

--- a/packages/dx-scheduler-core/src/utils.test.ts
+++ b/packages/dx-scheduler-core/src/utils.test.ts
@@ -126,7 +126,7 @@ describe('Utils', () => {
           moment(start.day(5)).endOf('day'),
         ]]);
     });
-    it('should work correctly with sundays', () => {
+    it('should work with week boundarie', () => {
       const excludedDays = [0, 5, 6];
 
       expect(excludedIntervals(excludedDays, start))

--- a/packages/dx-scheduler-core/src/utils.ts
+++ b/packages/dx-scheduler-core/src/utils.ts
@@ -38,14 +38,14 @@ const createExcludedInterval: CustomFunction<
   ];
 };
 
-const excludedIntervals: PureComputed<
+export const excludedIntervals: PureComputed<
   [number[], moment.Moment], Interval[]
 > = (excludedDays, start) => excludedDays
   .map(day => (day === 0 ? 7 : day))
   .sort((a, b) => a - b)
   .reduce((acc, day, i, allDays) => {
     if (i && day === allDays[i - 1] + 1) {
-      acc[i - 1][1].day(day);
+      acc[acc.length - 1][1].day(day);
     } else {
       acc.push(createExcludedInterval(day, start));
     }


### PR DESCRIPTION
Fixes #2712 