### PR TITLE
fix(react-grid): avoid rendering group summary row if no footer summary exists

### DIFF
--- a/packages/dx-grid-core/src/plugins/table-summary-row/computeds.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-summary-row/computeds.test.ts
@@ -18,7 +18,7 @@ describe('TableSummaryRow', () => {
   });
 
   describe('#tableRowsWithSummaries', () => {
-    const groupSummaryItems = [];
+    const groupSummaryItems = [{ showInGroupFooter: true }];
     const treeSummaryItems = [];
     const tableRows = [
       { row: { levelKey: 'a', compoundKey: 'a1', group: true } },
@@ -94,6 +94,31 @@ describe('TableSummaryRow', () => {
 
       expect(tableRowsWithSummaries(
         tableRows, undefined, treeSummaryItems, getRowLevelKey, isGroupRow, getRowId,
+      ))
+        .toEqual(result);
+    });
+
+    it('should not add group summary row if no footer summaries are specified', () => {
+      const groupItems = [{
+        showInGroupFooter: false,
+      }];
+      /* tslint:disable: max-line-length */
+      const result = [
+        { row: { levelKey: 'a', compoundKey: 'a1', group: true } },
+        { row: { levelKey: 'a', compoundKey: 'a2', group: true, a: 'a2' } },
+        { row: { a: 1 } },
+        { row: { a: 2 } },
+        { key: `${TABLE_TREE_SUMMARY_TYPE.toString()}_a2`, type: TABLE_TREE_SUMMARY_TYPE, row: { levelKey: 'a', compoundKey: 'a2', group: true, a: 'a2' } },
+        { row: { levelKey: 'a', compoundKey: 'a3', group: true, a: 'a3' } },
+        { row: { levelKey: 'b', a: 3 } },
+        { row: { a: 4 } },
+        { key: `${TABLE_TREE_SUMMARY_TYPE.toString()}_3`, type: TABLE_TREE_SUMMARY_TYPE, row: { levelKey: 'b', a: 3 } },
+        { key: `${TABLE_TREE_SUMMARY_TYPE.toString()}_a3`, type: TABLE_TREE_SUMMARY_TYPE, row: { levelKey: 'a', compoundKey: 'a3', group: true, a: 'a3' } },
+      ];
+      /* tslint:enable: max-line-length */
+
+      expect(tableRowsWithSummaries(
+        tableRows, groupItems, treeSummaryItems, getRowLevelKey, isGroupRow, getRowId,
       ))
         .toEqual(result);
     });

--- a/packages/dx-grid-core/src/plugins/table-summary-row/computeds.ts
+++ b/packages/dx-grid-core/src/plugins/table-summary-row/computeds.ts
@@ -7,6 +7,7 @@ import {
 import {
   TableRow, RowLevel, TableRowsWithSummariesFn,
 } from '../../types';
+import { groupFooterSummaryExists } from './helpers';
 
 export const tableRowsWithTotalSummaries: PureComputed<[TableRow[]]> = footerRows => [
   { key: TABLE_TOTAL_SUMMARY_TYPE.toString(), type: TABLE_TOTAL_SUMMARY_TYPE },
@@ -18,10 +19,11 @@ export const tableRowsWithSummaries: TableRowsWithSummariesFn = (
 ) => {
   if (!getRowLevelKey || !(groupSummaryItems || treeSummaryItems)) return tableRows;
 
+  const hasGroupFooterSummary = groupFooterSummaryExists(groupSummaryItems);
   const result: TableRow[] = [];
   const closeLevel = (level: RowLevel) => {
     if (!level.opened) return;
-    if (groupSummaryItems && isGroupRow && isGroupRow(level.row)) {
+    if (hasGroupFooterSummary && isGroupRow && isGroupRow(level.row)) {
       const { compoundKey } = level.row;
       result.push({
         key: `${TABLE_GROUP_SUMMARY_TYPE.toString()}_${compoundKey}`,

--- a/packages/dx-grid-core/src/plugins/table-summary-row/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/table-summary-row/helpers.ts
@@ -44,6 +44,8 @@ export const isInlineGroupCaptionSummary: PureComputed<[SummaryItem], boolean> =
   !((summaryItem as GroupSummaryItem).showInGroupFooter ||
   (summaryItem as GroupSummaryItem).alignByColumn)
 );
+export const groupFooterSummaryExists: PureComputed<[GroupSummaryItem[]], boolean> =
+  groupSummaryItems => groupSummaryItems?.filter(isFooterSummary).length > 0;
 
 export const getGroupInlineSummaries: GetGroupInlineSummariesFn = (
   summaryItems, columns, summaryValues,

--- a/packages/dx-grid-core/src/plugins/table-summary-row/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/table-summary-row/helpers.ts
@@ -45,7 +45,7 @@ export const isInlineGroupCaptionSummary: PureComputed<[SummaryItem], boolean> =
   (summaryItem as GroupSummaryItem).alignByColumn)
 );
 export const groupFooterSummaryExists: PureComputed<[GroupSummaryItem[]], boolean> =
-  groupSummaryItems => groupSummaryItems?.filter(isFooterSummary).length > 0;
+  groupSummaryItems => groupSummaryItems?.some(isFooterSummary);
 
 export const getGroupInlineSummaries: GetGroupInlineSummariesFn = (
   summaryItems, columns, summaryValues,


### PR DESCRIPTION
fixes #2741 