### PR TITLE
fix(react-chart): make ArgumentScale factory type compatible with d3-scale

### DIFF
--- a/packages/dx-chart-core/src/plugins/zoom-and-pan/computeds.ts
+++ b/packages/dx-chart-core/src/plugins/zoom-and-pan/computeds.ts
@@ -104,7 +104,7 @@ export const getViewport = (
   rotated: boolean,
   [argInteraction, valInteraction]: Readonly<[Interaction, Interaction]>, type: Interaction,
   deltas: Readonly<[number, number]> | null,
-  anchors: Readonly<[number, number]> | null,
+  anchors: Readonly<number[]> | null,
   ranges: Readonly<[NumberArray, NumberArray]> | null,
   viewport?: Viewport, onViewportChange?: OnViewportChangeFn,
 ) => {

--- a/packages/dx-chart-core/src/types/chart-core.types.ts
+++ b/packages/dx-chart-core/src/types/chart-core.types.ts
@@ -3,7 +3,7 @@ export type DataItems = ReadonlyArray<DataItem>;
 
 export type DomainItems = ReadonlyArray<any>;
 
-export type NumberArray = [number, number];
+export type NumberArray = number[];
 
 // TODO: Find a way to use types from "d3-scale".
 export interface ScaleObject {

--- a/packages/dx-react-chart/api/dx-react-chart.api.md
+++ b/packages/dx-react-chart/api/dx-react-chart.api.md
@@ -248,7 +248,7 @@ export type ModifyDomainFn = (domain: DomainItems) => DomainItems;
 export type NotifyPointerMoveFn = (target: SeriesRef | null) => void;
 
 // @public (undocumented)
-export type NumberArray = [number, number];
+export type NumberArray = number[];
 
 // @public (undocumented)
 export type OffsetFn = (series: StackData, order: number[]) => void;


### PR DESCRIPTION
fixes #2746 