### PR TITLE
fix(grid-core): prevent values from being calculated twice in a group summary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
 
   Jest Tests & Linter:
     docker:
-      - image: circleci/node:13
+      - image: circleci/node:13.12
     working_directory: ~/circleci
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   Build Source:
     docker:
-      - image: circleci/node:13
+      - image: circleci/node:13.12
     working_directory: ~/circleci
     steps:
       - checkout

--- a/packages/dx-grid-core/src/plugins/integrated-summary/computeds.test.ts
+++ b/packages/dx-grid-core/src/plugins/integrated-summary/computeds.test.ts
@@ -271,6 +271,40 @@ describe('IntegratedSummary', () => {
       ))
         .toEqual(result);
     });
+
+    it('should not calculate collapsed rows twice when row level summary is specified', () => {
+      const rows = [
+        { levelKey: 'b', compoundKey: 'b|1', group: true, collapsedRows: [] },
+        { levelKey: 'c', compoundKey: 'b|c|1', group: true, collapsedRows: [] },
+        { a: 1 },
+        { a: 2 },
+        { levelKey: 'c', compoundKey: 'b|c|2', group: true, collapsedRows: [{ a: 3 }, { a: 4 }] },
+        { levelKey: 'b', compoundKey: 'b|2', group: true, collapsedRows: [{ a: 5 }, { a: 6 }] },
+      ];
+      const summaryItems = [
+        { columnName: 'a', type: 'sum', showInGroupFooter: true },
+        { columnName: 'a', type: 'sum', showInGroupFooter: false },
+      ];
+      const result = {
+        'b|1': [10, 10],
+        'b|2': [11, 11],
+        'b|c|1': [3, 3],
+        'b|c|2': [7, 7],
+      };
+      const getRowLevelKey = row => row.levelKey;
+      const isGroupRow = row => row.group;
+      const getCollapsedRows = row => row.collapsedRows;
+
+      expect(groupSummaryValues(
+        rows,
+        summaryItems,
+        getCellValue,
+        getRowLevelKey,
+        isGroupRow,
+        getCollapsedRows,
+      ))
+        .toEqual(result);
+    });
   });
 
   describe('treeSummaryValues', () => {

--- a/packages/dx-grid-core/src/plugins/integrated-summary/computeds.ts
+++ b/packages/dx-grid-core/src/plugins/integrated-summary/computeds.ts
@@ -121,7 +121,8 @@ export const groupSummaryValues: GroupSummaryValuesFn = (
       });
       levelIndex = getLevelIndex(levelKey);
     }
-    const isCollapsedNestedGroupRow = collapsedRows && levelIndex > 0;
+    // when row level summary exists, these rows had already been expanded earlier
+    const isCollapsedNestedGroupRow = collapsedRows && levelIndex > 0 && !anyRowLevelSummaryExist;
     const rowsToAppend = !levelKey ? [row] : collapsedRows;
     if (!levelKey || isCollapsedNestedGroupRow) {
       levels.forEach((level) => {


### PR DESCRIPTION
fixes #2811