### PR TITLE
fix(react-grid): prevent collapse VirtualTable with horizontal scrolling

### DIFF
--- a/packages/dx-react-grid/src/components/table-layout/virtual-table-layout.test.tsx
+++ b/packages/dx-react-grid/src/components/table-layout/virtual-table-layout.test.tsx
@@ -253,7 +253,7 @@ describe('VirtualTableLayout', () => {
       ));
 
       expect(tree.find(defaultProps.containerComponent).props().style)
-        .toMatchObject({ height: tree.instance().containerHeight });
+        .not.toMatchObject({ height: `${defaultProps.height}px` });
     });
 
     it('should recalculate viewport on scroll', () => {

--- a/packages/dx-react-grid/src/components/table-layout/virtual-table-layout.tsx
+++ b/packages/dx-react-grid/src/components/table-layout/virtual-table-layout.tsx
@@ -313,7 +313,7 @@ export class VirtualTableLayout extends React.PureComponent<PropsType, VirtualTa
       blockRefsHandler: this.registerBlockRef,
       rowRefsHandler: this.registerRowRef,
     };
-    const sizerHeight = height === AUTO_HEIGHT ? containerHeight : height;
+    const sizerHeight = height === AUTO_HEIGHT ? null : height;
 
     return (
       <Sizer


### PR DESCRIPTION
Fixes #2863 

Fix regression after #2787

Issue #2749 resolves by correct filling container (see [docs](https://devexpress.github.io/devextreme-reactive/react/grid/docs/guides/virtual-scrolling/#fill-the-container)). [Example](https://codesandbox.io/s/sad-dawn-rqutn?file=/index.html).