### PR TITLE
fix(react-grid): define `ref` and `exportGrid` types in GridExporter

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -16,10 +16,12 @@ scopes:
   - react-grid-bootstrap3
   - react-grid-bootstrap4
   - react-grid-demos
+  - react-grid-export
   - react-grid-material-ui
   - react-scheduler
   - react-scheduler-demos
   - react-scheduler-material-ui
   - scheduler-core
+  - site
   - styles
   - testing

--- a/packages/dx-react-grid-export/api/dx-react-grid-export.api.md
+++ b/packages/dx-react-grid-export/api/dx-react-grid-export.api.md
@@ -60,7 +60,7 @@ export type GetCellValueFn = (row: any, columnName: string) => any;
 
 // @public (undocumented)
 export const GridExporter: React.ComponentType<ExporterProps> & {
-    exportGrid: (options?: any) => void;
+    exportGrid: (options?: object) => void;
 };
 
 // @public (undocumented)

--- a/packages/dx-react-grid-export/api/dx-react-grid-export.api.md
+++ b/packages/dx-react-grid-export/api/dx-react-grid-export.api.md
@@ -43,6 +43,7 @@ export type ExporterProps = Omit<GridProps, 'rootComponent'> & Pick<FilteringSta
     customizeSummaryCell?: CustomizeSummaryCellFn;
     customizeHeader?: (worksheet: Worksheet) => void;
     customizeFooter?: (worksheet: Worksheet) => void;
+    ref?: React.RefObject<any>;
 };
 
 // @public (undocumented)
@@ -58,7 +59,9 @@ export type ExportSummary = {
 export type GetCellValueFn = (row: any, columnName: string) => any;
 
 // @public (undocumented)
-export const GridExporter: React.ComponentType<ExporterProps>;
+export const GridExporter: React.ComponentType<ExporterProps> & {
+    exportGrid: (options?: any) => void;
+};
 
 // @public (undocumented)
 export type SummaryType = string;

--- a/packages/dx-react-grid-export/src/types/export/exporter.types.ts
+++ b/packages/dx-react-grid-export/src/types/export/exporter.types.ts
@@ -52,6 +52,6 @@ export type ExporterState = {
 };
 
 export declare const GridExporter: React.ComponentType<ExporterProps> & {
-  /** Initiates data export. */
+  /** A method that exports data. */
   exportGrid: (options?: any) => void;
 };

--- a/packages/dx-react-grid-export/src/types/export/exporter.types.ts
+++ b/packages/dx-react-grid-export/src/types/export/exporter.types.ts
@@ -21,26 +21,28 @@ export type ExporterProps =
   Pick<TableProps, 'columnExtensions'> &
   Pick<TableColumnVisibilityProps, 'hiddenColumnNames'> &
 {
-  /* The column order. */
+  /** The column order. */
   columnOrder?: string[],
-  /* Specifies additional properties for the columns used in grouping. */
+  /** Specifies additional properties for the columns used in grouping. */
   groupColumnExtensions?: TableGroupRow.ColumnExtension[],
-  /* Total summary items. */
+  /** Total summary items. */
   totalSummaryItems?: SummaryItem[],
-  /* Group summary items. */
+  /** Group summary items. */
   groupSummaryItems?: GroupSummaryItem[],
-  /* A function that should save the Excel document. */
+  /** A function that should save the Excel document. */
   onSave: (workbook: Workbook) => void;
-  /* Customizes Excel cells. */
+  /** Customizes Excel cells. */
   customizeCell?: (cell: ExcelCell, row: ExcelRow, column: Column) => void;
-  /* Customizes Excel cells that display summaries. */
+  /** Customizes Excel cells that display summaries. */
   customizeSummaryCell?: CustomizeSummaryCellFn;
-  /* Customizes the document's header. */
+  /** Customizes the document's header. */
   customizeHeader?: (worksheet: Worksheet) => void;
-  /* Customizes the document's footer. */
+  /** Customizes the document's footer. */
   customizeFooter?: (worksheet: Worksheet) => void;
   /** @internal */
   exportSelected: boolean;
+  /** A reference to the GridExporter instance */
+  ref?: React.RefObject<any>;
 };
 
 /** @internal */
@@ -49,4 +51,7 @@ export type ExporterState = {
   selectedOnly: boolean;
 };
 
-export declare const GridExporter: React.ComponentType<ExporterProps>;
+export declare const GridExporter: React.ComponentType<ExporterProps> & {
+  /** Initiates data export. */
+  exportGrid: (options?: any) => void;
+};

--- a/packages/dx-react-grid-export/src/types/export/exporter.types.ts
+++ b/packages/dx-react-grid-export/src/types/export/exporter.types.ts
@@ -53,5 +53,5 @@ export type ExporterState = {
 
 export declare const GridExporter: React.ComponentType<ExporterProps> & {
   /** A method that exports data. */
-  exportGrid: (options?: any) => void;
+  exportGrid: (options?: object) => void;
 };

--- a/packages/dx-react-grid/docs/reference/export-panel.md
+++ b/packages/dx-react-grid/docs/reference/export-panel.md
@@ -32,7 +32,7 @@ Name | Type | Default | Description
 toggleButtonComponent | ComponentType&lt;[ExportPanel.ToggleButtonProps](#exportpaneltogglebuttonprops)&gt; | | A component that renders a button that opens the export menu.
 menuComponent | ComponentType&lt;[ExportPanel.MenuProps](#exportpanelmenuprops)&gt; | | A component that renders the export menu.
 menuItemComponent | ComponentType&lt;[ExportPanel.MenuItemProps](#exportpanelmenuitemprops)&gt; | | A component that renders a menu item.
-startExport | (options: object) => void | A function that initiates the export.
+startExport | (options: object) => void | | A function that initiates the export.
 messages? | [ExportPanel.LocalizationMessages](#localization-messages) | | Localization messages.
 
 ## Interfaces

--- a/packages/dx-react-grid/docs/reference/grid-exporter.md
+++ b/packages/dx-react-grid/docs/reference/grid-exporter.md
@@ -40,3 +40,9 @@ customizeCell? | (cell: Excel.Cell, row: any, column: [Grid.Column](grid.md#colu
 customizeSummaryCell? | (cell: [ExcelJS.Cell](https://github.com/exceljs/exceljs#handling-individual-cells), row: any, summary: { type: string, ranges: number[][] }) => void | | Customizes Excel cells that display summaries.
 customizeHeader? | (worksheet: [ExcelJS.Worksheet](https://github.com/exceljs/exceljs#worksheet-properties)) => void | | Customizes the document's header.
 customizeFooter? | (worksheet: [ExcelJS.Worksheet](https://github.com/exceljs/exceljs#worksheet-properties)) => void | | Customizes the document's footer.
+
+## Methods
+
+Name | Type | Description
+-----|------|------------
+exportGrid | (options?: any) => void | Initiates data export.

--- a/packages/dx-react-grid/docs/reference/grid-exporter.md
+++ b/packages/dx-react-grid/docs/reference/grid-exporter.md
@@ -45,4 +45,4 @@ customizeFooter? | (worksheet: [ExcelJS.Worksheet](https://github.com/exceljs/ex
 
 Name | Type | Description
 -----|------|------------
-exportGrid | (options?: any) => void | A method that exports data.
+exportGrid | (options?: object) => void | A method that exports data.

--- a/packages/dx-react-grid/docs/reference/grid-exporter.md
+++ b/packages/dx-react-grid/docs/reference/grid-exporter.md
@@ -45,4 +45,4 @@ customizeFooter? | (worksheet: [ExcelJS.Worksheet](https://github.com/exceljs/ex
 
 Name | Type | Description
 -----|------|------------
-exportGrid | (options?: any) => void | Initiates data export.
+exportGrid | (options?: any) => void | A method that exports data.


### PR DESCRIPTION
Fixes #2751