### PR TITLE
fix(react-grid-material-ui): Make border for fixed cells nontransparent

### DIFF
--- a/packages/dx-react-grid-material-ui/src/templates/table-fixed-cell.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-fixed-cell.jsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import classNames from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
-import { getStickyCellStyle } from './utils';
+import { getStickyCellStyle, getBorder } from './utils';
 
 const styles = theme => ({
   dividerRight: {
-    borderRight: `1px solid ${theme.palette.divider}`,
+    borderRight: getBorder(theme),
   },
   dividerLeft: {
-    borderLeft: `1px solid ${theme.palette.divider}`,
+    borderLeft: getBorder(theme),
   },
   fixedCell: getStickyCellStyle(theme),
   selected: {


### PR DESCRIPTION
Fixes #2924