### PR TITLE
fix(react-core): prevent errors when mouse drags element outside the window

### DIFF
--- a/packages/dx-react-core/src/draggable/mouse-strategy.test.tsx
+++ b/packages/dx-react-core/src/draggable/mouse-strategy.test.tsx
@@ -1,0 +1,48 @@
+// import * as React from 'react';
+import { MouseStrategy } from './mouse-strategy';
+
+describe('MouseStrategy', () => {
+  const startPoint = { clientX: 0, clientY: 0 };
+  const defaultEvent = { clientX: 100, clientY: 100, preventDefault: jest.fn() };
+  const { elementFromPoint } = document;
+  const { getComputedStyle } = window;
+  let delegate;
+
+  beforeEach(() => {
+    delegate = {
+      onStart: jest.fn(),
+      onMove: jest.fn(),
+      onEnd: jest.fn(),
+    };
+  });
+  afterEach(() => {
+    document.elementFromPoint = elementFromPoint;
+    window.getComputedStyle = getComputedStyle;
+  });
+
+  it('"move" should work', () => {
+    document.elementFromPoint = jest.fn().mockImplementation(() => 'Element');
+    window.getComputedStyle = jest.fn().mockImplementation(() => ({ style: { cursor: '' } }));
+
+    const mouse = new MouseStrategy(delegate);
+    mouse.start(startPoint);
+
+    expect(() => mouse.move(defaultEvent))
+      .not.toThrow();
+    expect(document.elementFromPoint).toHaveBeenCalled();
+    expect(window.getComputedStyle).toHaveBeenCalled();
+  });
+
+  it('"move" should work if element is null', () => {
+    document.elementFromPoint = jest.fn().mockImplementation(() => null);
+    window.getComputedStyle = jest.fn().mockImplementation(getComputedStyle);
+
+    const mouse = new MouseStrategy(delegate);
+    mouse.start(startPoint);
+
+    expect(() => mouse.move(defaultEvent))
+      .not.toThrow();
+    expect(document.elementFromPoint).toHaveBeenCalled();
+    expect(window.getComputedStyle).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dx-react-core/src/draggable/mouse-strategy.ts
+++ b/packages/dx-react-core/src/draggable/mouse-strategy.ts
@@ -49,7 +49,8 @@ export class MouseStrategy {
       this.delegate.onMove({ x, y });
     }
     if (dragStarted) {
-      const { cursor } = window.getComputedStyle(document.elementFromPoint(x, y)!);
+      const element = document.elementFromPoint(x, y);
+      const cursor = element ? window.getComputedStyle(element).cursor : null;
       toggleGestureCover(true, cursor);
     }
   }


### PR DESCRIPTION
Fixes #2925 