### PR TITLE
fix(react-grid): reset viewport position on search and group when data remote

### DIFF
--- a/packages/dx-react-grid/src/plugins/grouping-panel.test.tsx
+++ b/packages/dx-react-grid/src/plugins/grouping-panel.test.tsx
@@ -4,6 +4,7 @@ import { pluginDepsToComponents, setupConsole } from '@devexpress/dx-testing';
 import {
   groupingPanelItems,
   getColumnSortingDirection,
+  TOP_POSITION,
 } from '@devexpress/dx-grid-core';
 import { PluginHost } from '@devexpress/dx-react-core';
 import { GroupingPanel } from './grouping-panel';
@@ -26,6 +27,7 @@ const defaultDeps = {
     changeColumnSorting: jest.fn(),
     draftColumnGrouping: jest.fn(),
     cancelColumnGroupingDraft: jest.fn(),
+    scrollToRow: jest.fn(),
   },
   template: {
     toolbarContent: {},
@@ -124,5 +126,46 @@ describe('GroupingPanel', () => {
         sortingDirection: getColumnSortingDirection(),
         onGroup: expect.any(Function),
       });
+  });
+
+  it('should not call scroll up on group if data is not remote', () => {
+    const tree = mount((
+      <PluginHost>
+        {pluginDepsToComponents(defaultDeps)}
+        <GroupingPanel
+          {...defaultProps}
+        />
+      </PluginHost>
+    ));
+    tree.find(defaultProps.layoutComponent)
+      .prop('onGroup')('a');
+
+    expect(defaultDeps.action.scrollToRow)
+      .not.toHaveBeenCalled();
+  });
+
+  it('should scroll up on group if data is remote', () => {
+    const deps = {
+      ...defaultDeps,
+      getter: {
+        ...defaultDeps.getter,
+        isDataRemote: true,
+      },
+    };
+    const tree = mount((
+      <PluginHost>
+        {pluginDepsToComponents(deps)}
+        <GroupingPanel
+          {...defaultProps}
+        />
+      </PluginHost>
+    ));
+    tree.find(defaultProps.layoutComponent)
+      .prop('onGroup')('a');
+
+    expect(deps.action.scrollToRow)
+      .toHaveBeenCalledTimes(1);
+    expect(deps.action.scrollToRow.mock.calls[0][0])
+      .toBe(TOP_POSITION);
   });
 });

--- a/packages/dx-react-grid/src/plugins/grouping-panel.tsx
+++ b/packages/dx-react-grid/src/plugins/grouping-panel.tsx
@@ -7,6 +7,7 @@ import {
 import {
   groupingPanelItems,
   getColumnSortingDirection,
+  TOP_POSITION,
 } from '@devexpress/dx-grid-core';
 import { GroupPanelLayout as Layout } from '../components/group-panel-layout';
 import { GroupingPanelProps } from '../types';
@@ -93,22 +94,30 @@ class GroupingPanelRaw extends React.PureComponent<GroupingPanelProps & typeof d
         <Template name="toolbarContent">
           <TemplateConnector>
             {({
-              columns, grouping, draftGrouping, draggingEnabled, isColumnGroupingEnabled,
+              columns, grouping, draftGrouping,
+              draggingEnabled, isColumnGroupingEnabled, isDataRemote,
             }: Getters, {
-              changeColumnGrouping, draftColumnGrouping, cancelColumnGroupingDraft,
-            }: Actions) => (
-              <LayoutComponent
+              changeColumnGrouping, draftColumnGrouping, cancelColumnGroupingDraft, scrollToRow,
+            }: Actions) => {
+              const onGroup = (config) => {
+                if (isDataRemote) {
+                  scrollToRow(TOP_POSITION);
+                }
+                changeColumnGrouping(config);
+              };
+
+              return <LayoutComponent
                 items={groupingPanelItems(columns, grouping, draftGrouping)}
                 isColumnGroupingEnabled={isColumnGroupingEnabled}
                 draggingEnabled={draggingEnabled}
-                onGroup={changeColumnGrouping}
+                onGroup={onGroup}
                 onGroupDraft={draftColumnGrouping}
                 onGroupDraftCancel={cancelColumnGroupingDraft}
                 itemComponent={ItemPlaceholder}
                 emptyMessageComponent={EmptyMessagePlaceholder}
                 containerComponent={Container}
-              />
-            )}
+              />;
+            }}
           </TemplateConnector>
           <TemplatePlaceholder />
         </Template>

--- a/packages/dx-react-grid/src/plugins/search-panel.test.tsx
+++ b/packages/dx-react-grid/src/plugins/search-panel.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { PluginHost } from '@devexpress/dx-react-core';
+import { TOP_POSITION } from '@devexpress/dx-grid-core';
 import { pluginDepsToComponents } from '@devexpress/dx-testing';
 import { SearchPanel } from './search-panel';
 
@@ -13,6 +14,7 @@ const defaultDeps = {
   },
   action: {
     changeSearchValue: () => {},
+    scrollToRow: jest.fn(),
   },
   template: {
     toolbarContent: {},
@@ -34,5 +36,46 @@ describe('SearchPanel', () => {
     expect(tree.find(Input).props().value).toBe('abc');
     expect(tree.find(Input).props().onValueChange).toEqual(expect.any(Function));
     expect(tree.find(Input).props().getMessage).toEqual(expect.any(Function));
+  });
+
+  it('should not call scroll up on search if data is not remote', () => {
+    const tree = mount((
+      <PluginHost>
+        {pluginDepsToComponents(defaultDeps)}
+        <SearchPanel
+          {...defaultProps}
+        />
+      </PluginHost>
+    ));
+    tree.find(defaultProps.inputComponent)
+      .prop('onValueChange')('a');
+
+    expect(defaultDeps.action.scrollToRow)
+      .not.toHaveBeenCalled();
+  });
+
+  it('should scroll up on search if data is remote', () => {
+    const deps = {
+      ...defaultDeps,
+      getter: {
+        ...defaultDeps.getter,
+        isDataRemote: true,
+      },
+    };
+    const tree = mount((
+      <PluginHost>
+        {pluginDepsToComponents(deps)}
+        <SearchPanel
+          {...defaultProps}
+        />
+      </PluginHost>
+    ));
+    tree.find(defaultProps.inputComponent)
+      .prop('onValueChange')('a');
+
+    expect(deps.action.scrollToRow)
+      .toHaveBeenCalledTimes(1);
+    expect(deps.action.scrollToRow.mock.calls[0][0])
+      .toBe(TOP_POSITION);
   });
 });

--- a/packages/dx-react-grid/src/plugins/search-panel.tsx
+++ b/packages/dx-react-grid/src/plugins/search-panel.tsx
@@ -6,6 +6,9 @@ import {
   Plugin,
   TemplateConnector,
 } from '@devexpress/dx-react-core';
+import {
+  TOP_POSITION,
+} from '@devexpress/dx-grid-core';
 import { SearchPanelProps } from '../types';
 
 const pluginDependencies = [
@@ -37,13 +40,20 @@ class SearchPanelBase extends React.PureComponent<SearchPanelProps> {
         <Template name="toolbarContent">
           <TemplatePlaceholder />
           <TemplateConnector>
-            {({ searchValue }, { changeSearchValue }) => (
-              <Input
+            {({ searchValue, isDataRemote }, { changeSearchValue, scrollToRow }) => {
+              const onValueChange = (value) => {
+                if (isDataRemote) {
+                  scrollToRow(TOP_POSITION);
+                }
+                changeSearchValue(value);
+              };
+
+              return <Input
                 value={searchValue}
-                onValueChange={changeSearchValue}
+                onValueChange={onValueChange}
                 getMessage={getMessage}
-              />
-            )}
+              />;
+            }}
           </TemplateConnector>
         </Template>
       </Plugin>

--- a/packages/dx-react-grid/src/plugins/virtual-table/virtual-table-state.test.tsx
+++ b/packages/dx-react-grid/src/plugins/virtual-table/virtual-table-state.test.tsx
@@ -290,6 +290,50 @@ describe('VirtualTableState', () => {
         expect(getRows)
           .toHaveBeenNthCalledWith(2, 0, 100); // both calls should have same args
       });
+
+      it('should reload rows when search value changed', () => {
+        const getRows = jest.fn();
+        const tree = mount((
+          <PluginHost>
+            {pluginDepsToComponents(defaultDeps)}
+            <VirtualTableState
+              {...defaultProps}
+              getRows={getRows}
+            />
+          </PluginHost>
+        ));
+
+        executeComputedAction(tree, actions => actions.changeSearchValue({}));
+        jest.runAllTimers();
+
+        expect(getRows).toHaveBeenCalledTimes(2);
+        expect(getRows)
+          .toHaveBeenNthCalledWith(1, 0, 100);
+        expect(getRows)
+          .toHaveBeenNthCalledWith(2, 0, 100);
+      });
+
+      it('should reload rows when grouping changed', () => {
+        const getRows = jest.fn();
+        const tree = mount((
+          <PluginHost>
+            {pluginDepsToComponents(defaultDeps)}
+            <VirtualTableState
+              {...defaultProps}
+              getRows={getRows}
+            />
+          </PluginHost>
+        ));
+
+        executeComputedAction(tree, actions => actions.changeColumnGrouping({}));
+        jest.runAllTimers();
+
+        expect(getRows).toHaveBeenCalledTimes(2);
+        expect(getRows)
+          .toHaveBeenNthCalledWith(1, 0, 100);
+        expect(getRows)
+          .toHaveBeenNthCalledWith(2, 0, 100);
+      });
     });
   });
 

--- a/packages/dx-react-grid/src/plugins/virtual-table/virtual-table-state.tsx
+++ b/packages/dx-react-grid/src/plugins/virtual-table/virtual-table-state.tsx
@@ -120,7 +120,7 @@ class VirtualTableStateBase extends React.PureComponent<VirtualTableStateProps, 
     requestNextPage({ forceReload: true });
   }
 
-  changeColumnFilterAction = () => this.requestFirstPage();
+  resetVirtualTablePosition = () => this.requestFirstPage();
 
   static getDerivedStateFromProps(nextProps, prevState) {
     const {
@@ -180,7 +180,9 @@ class VirtualTableStateBase extends React.PureComponent<VirtualTableStateProps, 
         <Action name="setViewport" action={this.setViewport} />
         <Action name="clearRowCache" action={this.clearRowsCacheAction} />
         <Action name="changeColumnSorting" action={this.clearRowsCacheAction} />
-        <Action name="changeColumnFilter" action={this.changeColumnFilterAction} />
+        <Action name="changeColumnFilter" action={this.resetVirtualTablePosition} />
+        <Action name="changeSearchValue" action={this.resetVirtualTablePosition} />
+        <Action name="changeColumnGrouping" action={this.resetVirtualTablePosition} />
       </Plugin>
     );
   }


### PR DESCRIPTION
Fixes #2932
Fixes #2933