### PR TITLE
fix(react-grid): allow to use SummaryState without "*Items" properties

### DIFF
--- a/packages/dx-grid-core/src/plugins/table-summary-row/computeds.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-summary-row/computeds.test.ts
@@ -19,7 +19,7 @@ describe('TableSummaryRow', () => {
 
   describe('#tableRowsWithSummaries', () => {
     const groupSummaryItems = [{ showInGroupFooter: true }];
-    const treeSummaryItems = [];
+    const treeSummaryItems = [{}];
     const tableRows = [
       { row: { levelKey: 'a', compoundKey: 'a1', group: true } },
       { row: { levelKey: 'a', compoundKey: 'a2', group: true, a: 'a2' } },
@@ -32,6 +32,25 @@ describe('TableSummaryRow', () => {
     const getRowLevelKey = row => row.levelKey;
     const isGroupRow = row => row.group;
     const getRowId = row => row.a;
+
+    /* tslint:disable: max-line-length */
+    it('should not add summary rows if "groupSummaryItems" and "treeSummaryItems" are empty arrays', () => {
+      const result = [
+        { row: { levelKey: 'a', compoundKey: 'a1', group: true } },
+        { row: { levelKey: 'a', compoundKey: 'a2', group: true, a: 'a2' } },
+        { row: { a: 1 } },
+        { row: { a: 2 } },
+        { row: { levelKey: 'a', compoundKey: 'a3', group: true, a: 'a3' } },
+        { row: { levelKey: 'b', a: 3 } },
+        { row: { a: 4 } },
+      ];
+      /* tslint:enable: max-line-length */
+
+      expect(tableRowsWithSummaries(
+        tableRows, [], [], getRowLevelKey, isGroupRow, getRowId,
+      ))
+        .toEqual(result);
+    });
 
     it('should add summary rows in correct places', () => {
       /* tslint:disable: max-line-length */
@@ -55,7 +74,7 @@ describe('TableSummaryRow', () => {
         .toEqual(result);
     });
 
-    it('should not add tree summary row if treeSummaryItems are not specified', () => {
+    it('should not add tree summary row if "treeSummaryItems" is empty array', () => {
       /* tslint:disable: max-line-length */
       const result = [
         { row: { levelKey: 'a', compoundKey: 'a1', group: true } },
@@ -71,12 +90,12 @@ describe('TableSummaryRow', () => {
       /* tslint:enable: max-line-length */
 
       expect(tableRowsWithSummaries(
-        tableRows, groupSummaryItems, undefined, getRowLevelKey, isGroupRow, getRowId,
+        tableRows, groupSummaryItems, [], getRowLevelKey, isGroupRow, getRowId,
       ))
         .toEqual(result);
     });
 
-    it('should not add group summary row if groupSummaryItems are not specified', () => {
+    it('should not add group summary row if "groupSummaryItems" is empty array', () => {
       /* tslint:disable: max-line-length */
       const result = [
         { row: { levelKey: 'a', compoundKey: 'a1', group: true } },
@@ -93,7 +112,7 @@ describe('TableSummaryRow', () => {
       /* tslint:enable: max-line-length */
 
       expect(tableRowsWithSummaries(
-        tableRows, undefined, treeSummaryItems, getRowLevelKey, isGroupRow, getRowId,
+        tableRows, [], treeSummaryItems, getRowLevelKey, isGroupRow, getRowId,
       ))
         .toEqual(result);
     });

--- a/packages/dx-grid-core/src/plugins/table-summary-row/computeds.ts
+++ b/packages/dx-grid-core/src/plugins/table-summary-row/computeds.ts
@@ -17,9 +17,9 @@ export const tableRowsWithTotalSummaries: PureComputed<[TableRow[]]> = footerRow
 export const tableRowsWithSummaries: TableRowsWithSummariesFn = (
   tableRows, groupSummaryItems, treeSummaryItems, getRowLevelKey, isGroupRow, getRowId,
 ) => {
-  if (!getRowLevelKey || !(groupSummaryItems || treeSummaryItems)) return tableRows;
-
   const hasGroupFooterSummary = groupFooterSummaryExists(groupSummaryItems);
+  if (!getRowLevelKey || !(hasGroupFooterSummary || treeSummaryItems.length)) return tableRows;
+
   const result: TableRow[] = [];
   const closeLevel = (level: RowLevel) => {
     if (!level.opened) return;
@@ -30,7 +30,7 @@ export const tableRowsWithSummaries: TableRowsWithSummariesFn = (
         type: TABLE_GROUP_SUMMARY_TYPE,
         row: level.row,
       });
-    } else if (treeSummaryItems) {
+    } else if (treeSummaryItems.length) {
       const rowId = getRowId(level.row);
       result.push({
         key: `${TABLE_TREE_SUMMARY_TYPE.toString()}_${rowId}`,

--- a/packages/dx-grid-core/src/types/summary.types.ts
+++ b/packages/dx-grid-core/src/types/summary.types.ts
@@ -35,7 +35,7 @@ export type GetColumnSummariesFn = PureComputed<
 
 /** @internal */
 export type TableRowsWithSummariesFn = PureComputed<
-  [TableRow[], SummaryItem[], SummaryItem[], GetRowLevelKeyFn, IsSpecificRowFn, GetRowIdFn]
+  [TableRow[], GroupSummaryItem[], SummaryItem[], GetRowLevelKeyFn, IsSpecificRowFn, GetRowIdFn]
 >;
 
 /** @internal */

--- a/packages/dx-react-grid/docs/reference/summary-state.md
+++ b/packages/dx-react-grid/docs/reference/summary-state.md
@@ -20,9 +20,9 @@ none
 
 Name | Type | Default | Description
 -----|------|---------|------------
-totalItems? | Array&lt;[SummaryItem](#summaryitem)&gt; | | The total summary items.
-groupItems? | Array&lt;[GroupSummaryItem](#groupsummaryitem)&gt; | | The group summary items.
-treeItems? | Array&lt;[SummaryItem](#summaryitem)&gt; | | The tree summary items.
+totalItems? | Array&lt;[SummaryItem](#summaryitem)&gt; | [] | The total summary items.
+groupItems? | Array&lt;[GroupSummaryItem](#groupsummaryitem)&gt; | [] | The group summary items.
+treeItems? | Array&lt;[SummaryItem](#summaryitem)&gt; | [] | The tree summary items.
 
 ## Interfaces
 

--- a/packages/dx-react-grid/src/plugins/summary-state.test.tsx
+++ b/packages/dx-react-grid/src/plugins/summary-state.test.tsx
@@ -60,4 +60,21 @@ describe('SummaryState', () => {
     expect(getComputedState(tree).treeSummaryItems)
       .toBe(treeSummaryItems);
   });
+
+  it('should provide empty array as default value for each items', () => {
+    const tree = mount((
+      <PluginHost>
+        {pluginDepsToComponents(defaultDeps)}
+        <SummaryState />
+      </PluginHost>
+    ));
+
+    expect(getComputedState(tree).treeSummaryItems)
+      .toEqual([]);
+    expect(prepareGroupSummaryItems).toBeCalledWith([]);
+    expect(getComputedState(tree).groupSummaryItems)
+      .toBe('prepareGroupSummaryItems');
+    expect(getComputedState(tree).totalSummaryItems)
+      .toEqual([]);
+  });
 });

--- a/packages/dx-react-grid/src/plugins/summary-state.tsx
+++ b/packages/dx-react-grid/src/plugins/summary-state.tsx
@@ -8,6 +8,12 @@ const groupSummaryItemsComputed = (
 ) => prepareGroupSummaryItems(groupSummaryItems);
 
 class SummaryStateBase extends React.PureComponent<SummaryStateProps> {
+  static defaultProps = {
+    totalItems: [],
+    groupItems: [],
+    treeItems: [],
+  };
+
   render() {
     const { totalItems, groupItems, treeItems } = this.props;
 

--- a/packages/dx-react-grid/src/plugins/table-summary-row.test.tsx
+++ b/packages/dx-react-grid/src/plugins/table-summary-row.test.tsx
@@ -152,6 +152,20 @@ describe('TableSummaryRow', () => {
           defaultDeps.getter.tableFooterRows,
         );
     });
+
+    it('should not extend tableFooterRows if "totalSummaryItems" is empty array', () => {
+      const deps = { ...defaultDeps, getter: { ...defaultDeps.getter, totalSummaryItems: [] } };
+      const tree = mount((
+        <PluginHost>
+          {pluginDepsToComponents(deps)}
+          <TableSummaryRow
+            {...defaultProps}
+          />
+        </PluginHost>
+      ));
+
+      expect(tableRowsWithTotalSummaries).not.toHaveBeenCalled();
+    });
   });
 
   it('should render total summary row', () => {

--- a/packages/dx-react-grid/src/plugins/table-summary-row.tsx
+++ b/packages/dx-react-grid/src/plugins/table-summary-row.tsx
@@ -44,8 +44,10 @@ const tableBodyRowsComputed = ({
   tableBodyRows, groupSummaryItems, treeSummaryItems, getRowLevelKey, isGroupRow, getRowId,
 );
 const tableFooterRowsComputed = ({
-  tableFooterRows,
-}: Getters) => tableRowsWithTotalSummaries(tableFooterRows);
+  tableFooterRows, totalSummaryItems,
+}: Getters) => totalSummaryItems.length
+  ? tableRowsWithTotalSummaries(tableFooterRows)
+  : tableFooterRows;
 
 export class TableSummaryRowBase extends React.PureComponent<TableSummaryRowProps> {
   static TREE_ROW_TYPE = TABLE_TREE_SUMMARY_TYPE;


### PR DESCRIPTION
Fixes #2975