### PR TITLE
fix(react-grid): make TableBandHeader work correctly with TableColumnVisibility

### DIFF
--- a/packages/dx-grid-core/src/plugins/table-band-header/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-band-header/helpers.test.ts
@@ -232,7 +232,7 @@ describe('TableBandHeader Plugin helpers', () => {
         });
     });
 
-    it('should return a null-typed band component for column without key', () => {
+    it('should return a an empty cell type for column without key', () => {
       const params = {
         tableColumn: {
           type: TABLE_DATA_TYPE,
@@ -250,7 +250,7 @@ describe('TableBandHeader Plugin helpers', () => {
           chains, columnVisibleBoundaries, levelsVisibility,
       ))
         .toEqual({
-          type: null,
+          type: 'bandEmptyCell',
           payload: null,
         });
     });

--- a/packages/dx-grid-core/src/plugins/table-band-header/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-band-header/helpers.test.ts
@@ -232,7 +232,7 @@ describe('TableBandHeader Plugin helpers', () => {
         });
     });
 
-    it('should return a an empty cell type for column without key', () => {
+    it('should return an empty cell type for column without key', () => {
       const params = {
         tableColumn: {
           type: TABLE_DATA_TYPE,

--- a/packages/dx-grid-core/src/plugins/table-band-header/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/table-band-header/helpers.ts
@@ -122,7 +122,7 @@ export const getBandComponent: GetBandComponentFn = (
     }
   }
 
-  if (!isColumnVisible) return { type: null, payload: null };
+  if (!isColumnVisible) return { type: BAND_EMPTY_CELL, payload: null };
 
   const currentColumnChain = findChainByColumnIndex(
     tableHeaderColumnChains[currentRowLevel],

--- a/packages/dx-react-grid/docs/reference/table-band-header.md
+++ b/packages/dx-react-grid/docs/reference/table-band-header.md
@@ -26,6 +26,7 @@ import { TableBandHeader } from '@devexpress/dx-react-grid';
 - [TableHeaderRow](table-header-row.md)
 - [TableEditColumn](table-edit-column.md) [Optional]
 - [TableSelection](table-selection.md) [Optional]
+- [TableColumnVisibility](table-column-visibility.md) [Optional]
 
 ### Properties
 

--- a/packages/dx-react-grid/src/plugins/table-band-header.tsx
+++ b/packages/dx-react-grid/src/plugins/table-band-header.tsx
@@ -67,6 +67,7 @@ class TableBandHeaderBase extends React.PureComponent<TableBandHeaderProps> {
           { name: 'TableHeaderRow' },
           { name: 'TableSelection', optional: true },
           { name: 'TableEditColumn', optional: true },
+          { name: 'TableColumnVisibility', optional: true },
         ]}
       >
         <Getter name="tableHeaderRows" computed={tableHeaderRowsComputed} />


### PR DESCRIPTION
Fixes #2963

BREAKING CHANGE:

The `TableColumnVisibility` plugin must now be declared **before** the `TableBandHeader` plugin. This is required to correctly calculate column spans and borders.

```diff
...
+<TableColumnVisibility
+  defaultHiddenColumnNames={...}
+/>
...
<TableBandHeader
  columnBands={columnBands}
/>
...
-<TableColumnVisibility
-  defaultHiddenColumnNames={...}
-/>
...
```