### PR TITLE
fix(react-grid): use 'calc' to calculate table min width

### DIFF
--- a/packages/dx-react-grid/src/components/table-layout.test.tsx
+++ b/packages/dx-react-grid/src/components/table-layout.test.tsx
@@ -45,7 +45,7 @@ describe('TableLayout', () => {
     it('should add flex column if all columns have fixed widths', () => {
       const columns = [
         { key: 'a', column: { name: 'a' }, width: 100 },
-        { key: 'b', column: { name: 'b' }, width: 100 },
+        { key: 'b', column: { name: 'b' }, width: '50' },
       ];
 
       const tree = shallow((
@@ -58,7 +58,7 @@ describe('TableLayout', () => {
 
       expect(tree.find(defaultProps.layoutComponent).props())
         .toMatchObject({
-          minWidth: 200,
+          minWidth: '100px + 50px',
           columns: [
             ...columns,
             { key: 'flex', type: 'flex' },

--- a/packages/dx-react-grid/src/components/table-layout.tsx
+++ b/packages/dx-react-grid/src/components/table-layout.tsx
@@ -10,6 +10,7 @@ import {
 } from '@devexpress/dx-grid-core';
 import { shallowEqual } from '@devexpress/dx-core';
 import { TableLayoutCoreProps, TableLayoutCoreState } from '../types';
+import { isNumber } from '../utils/helpers';
 
 class TableLayoutBase extends React.PureComponent<TableLayoutCoreProps, TableLayoutCoreState> {
   animations: ColumnAnimationMap;
@@ -122,14 +123,16 @@ class TableLayoutBase extends React.PureComponent<TableLayoutCoreProps, TableLay
     const columns = this.getColumns();
     const minWidth = columns
       .map(column => column.width || (column.type === TABLE_FLEX_TYPE ? 0 : minColumnWidth))
-      .reduce((acc, width) => (acc as number) + (width as number), 0);
+      .filter(value => value !== 'auto' && value !== 0)
+      .map(value => isNumber(value) ? `${value}px` : value)
+      .join(' + ');
 
     return (
       <Layout
         {...restProps}
         tableRef={this.tableRef}
         columns={columns}
-        minWidth={minWidth as number}
+        minWidth={minWidth}
         minColumnWidth={minColumnWidth}
       />
     );

--- a/packages/dx-react-grid/src/components/table-layout/static-table-layout.test.tsx
+++ b/packages/dx-react-grid/src/components/table-layout/static-table-layout.test.tsx
@@ -10,7 +10,7 @@ const defaultProps = {
     { key: 'c', column: { name: 'c' } },
     { key: 'd', column: { name: 'd' } },
   ],
-  minWidth: 400,
+  minWidth: '400px',
   bodyRows: [
     { key: 1, rowId: 1 },
     { key: 2, rowId: 2 },
@@ -100,7 +100,7 @@ describe('StaticTableLayout', () => {
     expect(tree.find(defaultProps.tableComponent).props())
       .toMatchObject(expect.objectContaining({
         style: {
-          minWidth: '400px',
+          minWidth: 'calc(400px)',
         },
       }));
   });

--- a/packages/dx-react-grid/src/components/table-layout/static-table-layout.tsx
+++ b/packages/dx-react-grid/src/components/table-layout/static-table-layout.tsx
@@ -43,7 +43,7 @@ export class StaticTableLayout extends React.PureComponent<TableLayoutProps & ty
       <Container>
         <Table
           tableRef={tableRef}
-          style={{ minWidth: `${minWidth}px` }}
+          style={{ minWidth: `calc(${minWidth})` }}
         >
           <ColumnGroup columns={columns} />
           {!!headerRows.length && (

--- a/packages/dx-react-grid/src/types/layout/table-layout.types.ts
+++ b/packages/dx-react-grid/src/types/layout/table-layout.types.ts
@@ -18,7 +18,7 @@ export type TableLayoutProps =
     bodyRows: TableRow[],
     footerRows: TableRow[],
     columns: TableColumn[],
-    minWidth?: number,
+    minWidth?: string,
     minColumnWidth?: number,
     getCellColSpan?: GetCellColSpanFn,
     tableRef?: React.RefObject<HTMLTableElement>,

--- a/packages/dx-react-grid/src/utils/helpers.ts
+++ b/packages/dx-react-grid/src/utils/helpers.ts
@@ -1,3 +1,6 @@
 export const getRowStyle = ({ row }) => (row.height !== undefined
   ? ({ height: `${row.height}px` })
   : undefined);
+
+export const isNumber = (value: string | number) =>
+  typeof value === 'number' || !Number.isNaN(Number(value));


### PR DESCRIPTION
Fixes #3047 