### PR TITLE
adds the date from each individual cell into appointment.dataItem

### DIFF
--- a/packages/dx-scheduler-core/src/plugins/horizontal-rect/helpers.ts
+++ b/packages/dx-scheduler-core/src/plugins/horizontal-rect/helpers.ts
@@ -8,6 +8,12 @@ const CELL_BOUND_OFFSET_PX = 1;
 const getCellRect: GetCellRectHorizontalFn = (
   date, appointment, viewCellsData, viewMetaData, cellElementsMeta, takePrev, multiline,
 ) => {
+  // Adds the date from each individual cell
+  // This is so I can get the date after selecting a cell
+  if((appointment as any).dataItem){
+    (appointment as any).dataItem = JSON.parse(JSON.stringify(appointment.dataItem)) as any;
+    (appointment as any).dataItem.cellRectDate = date;
+  }
   const cellIndex = multiline
     ? getMonthCellIndexByAppointmentData(
       viewCellsData, viewMetaData, date, appointment, takePrev,

--- a/packages/dx-scheduler-core/src/plugins/vertical-rect/helpers.ts
+++ b/packages/dx-scheduler-core/src/plugins/vertical-rect/helpers.ts
@@ -37,6 +37,12 @@ const getCellRect: GetCellRectVerticalFn = (
   date, appointment, viewCellsData, cellDuration,
   cellElementsMeta, takePrev, viewMetaData,
 ) => {
+  // Adds the date from each individual cell
+  // This is so I can get the date after selecting a cell
+  if((appointment as any).dataItem){
+    (appointment as any).dataItem = JSON.parse(JSON.stringify(appointment.dataItem)) as any;
+    (appointment as any).dataItem.cellRectDate = date;
+  }
   const {
     index: cellIndex,
     startDate: cellStartDate,


### PR DESCRIPTION
The main purpose of this change is to get the accurate date of the cell clicked by the user. 
In dx-scheduler-core/src/plugins/horizontal-rect & vertical-rect, date for individual cell is cloned into appointment.dataItem.cellRectDate so that when AppointmentTooltip is opened, both tooltip header and container have a prop showing the accurate date of the chosen cell. 

This function can be used for creating custom functions on the tooltip. With the accurate date, new features such as editing or deleting only one day from repeating appointments can be implemented as buttons on Appointment Tooltip.

I wasn't able to pass the automatic checks but the codes work when I am using the scheduler.
<img width="1111" alt="Screen Shot 2020-08-27 at 3 43 31 PM" src="https://user-images.githubusercontent.com/60558366/91492547-db8c8280-e883-11ea-96f0-0070a6f8ba54.png">
