### PR TITLE
fix(react-grid): fix typings of ValueEditorProps (#3124)

### DIFF
--- a/packages/dx-react-grid/api/dx-react-grid.api.md
+++ b/packages/dx-react-grid/api/dx-react-grid.api.md
@@ -144,10 +144,9 @@ export const DataTypeProvider: React.ComponentType<DataTypeProviderProps>;
 // @public (undocumented)
 export namespace DataTypeProvider {
   export interface ValueEditorProps {
-    column: Column;
-    disabled: boolean;
+    autoFocus: boolean;
+    onBlur: any;
     onValueChange: (newValue: any) => void;
-    row?: any;
     value: any;
   }
   export interface ValueFormatterProps {

--- a/packages/dx-react-grid/src/types/data-type-provider/data-type-provider.types.ts
+++ b/packages/dx-react-grid/src/types/data-type-provider/data-type-provider.types.ts
@@ -14,16 +14,15 @@ export namespace DataTypeProvider {
 
   /** Describes properties passed to a component that renders the value editor. */
   export interface ValueEditorProps {
-    /** A column object. */
-    column: Column;
-    /** A row. */
-    row?: any;
     /** Specifies the editor value. */
     value: any;
     /** Handles value changes. */
     onValueChange: (newValue: any) => void;
-    /** "true" if users should not be able to edit the value, "false" otherwise. */
-    disabled: boolean;
+	/** Specifies the editor value. */
+    onBlur: any;
+	/** Where the autoFocus was set to enabled */
+	autoFocus: boolean;
+
   }
 }
 

--- a/packages/dx-react-grid/src/types/data-type-provider/data-type-provider.types.ts
+++ b/packages/dx-react-grid/src/types/data-type-provider/data-type-provider.types.ts
@@ -18,11 +18,10 @@ export namespace DataTypeProvider {
     value: any;
     /** Handles value changes. */
     onValueChange: (newValue: any) => void;
-	/** Specifies the editor value. */
+    /** Specifies the editor value. */
     onBlur: any;
-	/** Where the autoFocus was set to enabled */
-	autoFocus: boolean;
-
+    /** Where the autoFocus was set to enabled */
+    autoFocus: boolean;
   }
 }
 


### PR DESCRIPTION
This PR corrects the typing issue described in #3124