### PR TITLE
fix(react-grid): correct colspan calculating for group row when used with certain plugins

### DIFF
--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.ts
@@ -196,19 +196,19 @@ describe('TableGroupRow Plugin computeds', () => {
     });
 
     describe('Virtual Table', () => {
-      [0, 1, 2].map((firstVisibleColumn) => {
+      [0, 1, 2].map((firstVisibleColumnIndex) => {
         const tableColumn = { type: TABLE_GROUP_TYPE, column: { name: 'a' } };
         const getCellColSpanGetter = tableGroupCellColSpanGetter(
-          parentGetCellColSpan, [], firstVisibleColumn,
+          parentGetCellColSpan, [], firstVisibleColumnIndex,
         );
         const getExpectedColSpan = (tableColumns) => {
           const firstGroupColumnIndex = tableColumns
             .findIndex(col => col.type === TABLE_GROUP_TYPE);
-          return tableColumns.length - Math.min(firstVisibleColumn, firstGroupColumnIndex);
+          return tableColumns.length - Math.min(firstVisibleColumnIndex, firstGroupColumnIndex);
         };
 
         // tslint:disable-next-line: max-line-length
-        it(`should return correct colspan if the "firstVisibleColumn" is ${firstVisibleColumn}`, () => {
+        it(`should return correct ColSpan if the "firstVisibleColumnIndex" is ${firstVisibleColumnIndex}`, () => {
           let tableColumns = [tableColumn, {}, {}];
           expect(getCellColSpanGetter({
             tableColumn,

--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.test.ts
@@ -171,21 +171,21 @@ describe('TableGroupRow Plugin computeds', () => {
         tableRow: { type: TABLE_GROUP_TYPE, row: { groupedBy: 'a' } },
         tableColumns: [{}, tableColumn, {}],
       }))
-        .toBe(2);
+        .toBe(3);
 
       expect(getCellColSpanGetter({
         tableColumn,
         tableRow: { type: TABLE_GROUP_TYPE, row: { groupedBy: 'a' } },
         tableColumns: [{}, {}, tableColumn],
       }))
-        .toBe(1);
+        .toBe(3);
 
       expect(getCellColSpanGetter({
         tableColumn,
         tableRow: { type: TABLE_GROUP_TYPE, row: { groupedBy: 'b' } },
         tableColumns: [{}, tableColumn, {}],
       }))
-        .toBe(2);
+        .toBe(3);
 
       expect(getCellColSpanGetter({
         tableColumn,
@@ -193,6 +193,54 @@ describe('TableGroupRow Plugin computeds', () => {
         tableColumns: [{}, tableColumn, {}],
       }))
         .toBe('original');
+    });
+
+    describe('Virtual Table', () => {
+      [0, 1, 2].map((firstVisibleColumn) => {
+        const tableColumn = { type: TABLE_GROUP_TYPE, column: { name: 'a' } };
+        const getCellColSpanGetter = tableGroupCellColSpanGetter(
+          parentGetCellColSpan, [], firstVisibleColumn,
+        );
+        const getExpectedColSpan = (tableColumns) => {
+          const firstGroupColumnIndex = tableColumns
+            .findIndex(col => col.type === TABLE_GROUP_TYPE);
+          return tableColumns.length - Math.min(firstVisibleColumn, firstGroupColumnIndex);
+        };
+
+        // tslint:disable-next-line: max-line-length
+        it(`should return correct colspan if the "firstVisibleColumn" is ${firstVisibleColumn}`, () => {
+          let tableColumns = [tableColumn, {}, {}];
+          expect(getCellColSpanGetter({
+            tableColumn,
+            tableRow: { type: TABLE_GROUP_TYPE, row: { groupedBy: 'a' } },
+            tableColumns,
+          }))
+            .toBe(getExpectedColSpan(tableColumns));
+
+          tableColumns = [{}, tableColumn, {}];
+          expect(getCellColSpanGetter({
+            tableColumn,
+            tableRow: { type: TABLE_GROUP_TYPE, row: { groupedBy: 'a' } },
+            tableColumns,
+          }))
+            .toBe(getExpectedColSpan(tableColumns));
+
+          tableColumns = [{}, {}, tableColumn];
+          expect(getCellColSpanGetter({
+            tableColumn,
+            tableRow: { type: TABLE_GROUP_TYPE, row: { groupedBy: 'a' } },
+            tableColumns,
+          }))
+            .toBe(getExpectedColSpan(tableColumns));
+
+          expect(getCellColSpanGetter({
+            tableColumn,
+            tableRow: { type: Symbol('undefined'), row: {} },
+            tableColumns: [{}, tableColumn, {}],
+          }))
+            .toBe('original');
+        });
+      });
     });
 
     it('should return correct colspan if have few columns with different types', () => {

--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.ts
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.ts
@@ -80,10 +80,10 @@ const groupSummaryChains: GroupSummaryChainsFn = (
   tableRow,
   tableColumns,
   groupSummaryItems,
-  firstVisibleColumn,
+  firstVisibleColumnIndex,
 ) => {
   let captionStarted = false;
-  return sortAndSpliceColumns(tableColumns, firstVisibleColumn)
+  return sortAndSpliceColumns(tableColumns, firstVisibleColumnIndex)
     .reduce((acc, col) => {
       const colName = (col.column && col.column.name) as string;
       const isStartOfGroupCaption = col.type === TABLE_GROUP_TYPE
@@ -108,7 +108,7 @@ const groupSummaryChains: GroupSummaryChainsFn = (
 };
 
 export const tableGroupCellColSpanGetter: GroupCellColSpanGetter = (
-  getTableCellColSpan, groupSummaryItems, firstVisibleColumn,
+  getTableCellColSpan, groupSummaryItems, firstVisibleColumnIndex,
 ) => (params) => {
   const { tableRow, tableColumns, tableColumn } = params;
 
@@ -117,7 +117,7 @@ export const tableGroupCellColSpanGetter: GroupCellColSpanGetter = (
     const dataColumnGroupedBy =
       tableRow.row.groupedBy === colName && tableColumn.type !== TABLE_GROUP_TYPE;
     const chains = groupSummaryChains(
-      tableRow, tableColumns, groupSummaryItems, firstVisibleColumn,
+      tableRow, tableColumns, groupSummaryItems, firstVisibleColumnIndex,
     );
     const chain = chains.find(ch => !dataColumnGroupedBy && ch[0] === colName);
 

--- a/packages/dx-grid-core/src/plugins/table-group-row/computeds.ts
+++ b/packages/dx-grid-core/src/plugins/table-group-row/computeds.ts
@@ -9,6 +9,7 @@ import {
   GroupSummaryChainsFn,
   SummaryItem,
 } from '../../types';
+import { sortAndSpliceColumns } from './helpers';
 
 const tableColumnsWithDraftGrouping: TableColumnsWithDraftGroupingFn = (
   tableColumns, grouping, draftGrouping, showColumnWhenGrouped,
@@ -75,9 +76,14 @@ const isRowLevelSummary: PureComputed<[SummaryItem[], string], boolean> = (
   )
 );
 
-const groupSummaryChains: GroupSummaryChainsFn = (tableRow, tableColumns, groupSummaryItems) => {
+const groupSummaryChains: GroupSummaryChainsFn = (
+  tableRow,
+  tableColumns,
+  groupSummaryItems,
+  firstVisibleColumn,
+) => {
   let captionStarted = false;
-  return tableColumns
+  return sortAndSpliceColumns(tableColumns, firstVisibleColumn)
     .reduce((acc, col) => {
       const colName = (col.column && col.column.name) as string;
       const isStartOfGroupCaption = col.type === TABLE_GROUP_TYPE
@@ -102,7 +108,7 @@ const groupSummaryChains: GroupSummaryChainsFn = (tableRow, tableColumns, groupS
 };
 
 export const tableGroupCellColSpanGetter: GroupCellColSpanGetter = (
-  getTableCellColSpan, groupSummaryItems,
+  getTableCellColSpan, groupSummaryItems, firstVisibleColumn,
 ) => (params) => {
   const { tableRow, tableColumns, tableColumn } = params;
 
@@ -110,7 +116,9 @@ export const tableGroupCellColSpanGetter: GroupCellColSpanGetter = (
     const colName = tableColumn.column?.name;
     const dataColumnGroupedBy =
       tableRow.row.groupedBy === colName && tableColumn.type !== TABLE_GROUP_TYPE;
-    const chains = groupSummaryChains(tableRow, tableColumns, groupSummaryItems);
+    const chains = groupSummaryChains(
+      tableRow, tableColumns, groupSummaryItems, firstVisibleColumn,
+    );
     const chain = chains.find(ch => !dataColumnGroupedBy && ch[0] === colName);
 
     if (chain) {

--- a/packages/dx-grid-core/src/plugins/table-group-row/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-group-row/helpers.test.ts
@@ -143,7 +143,7 @@ describe('TableRowDetail Plugin helpers', () => {
     const groupColumn = { type: TABLE_GROUP_TYPE };
     const otherColumn = { type: Symbol('undefined') };
 
-    it('should work with the Table (firstVisibleColumn is not defined)', () => {
+    it('should work with the Table (firstVisibleColumnIndex is not defined)', () => {
       expect(sortAndSpliceColumns([groupColumn, otherColumn, dataColumn]))
         .toEqual([groupColumn, otherColumn, dataColumn]);
 
@@ -154,8 +154,8 @@ describe('TableRowDetail Plugin helpers', () => {
         .toEqual([groupColumn, otherColumn, otherColumn, dataColumn]);
     });
 
-    it('should work with the Virtual Table (firstVisibleColumn is defined)', () => {
-      describe('one group', () => {
+    describe('should work with the Virtual Table (firstVisibleColumnIndex is defined)', () => {
+      it('should work with one group', () => {
         expect(sortAndSpliceColumns(
           [otherColumn, otherColumn, groupColumn, otherColumn, dataColumn], 0,
         ))
@@ -177,7 +177,7 @@ describe('TableRowDetail Plugin helpers', () => {
           .toEqual([groupColumn, otherColumn, dataColumn]);
       });
 
-      describe('two groups', () => {
+      it('should work with two groups', () => {
         expect(sortAndSpliceColumns(
           [otherColumn, otherColumn, groupColumn, otherColumn, groupColumn, dataColumn], 0,
         ))

--- a/packages/dx-grid-core/src/plugins/table-group-row/helpers.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-group-row/helpers.test.ts
@@ -10,6 +10,8 @@ import {
   calculateGroupCellIndent,
 } from './helpers';
 import { TABLE_STUB_TYPE } from '../../utils/virtual-table';
+import { sortAndSpliceColumns } from '../..';
+import { TABLE_DATA_TYPE } from '../table/constants';
 
 describe('TableRowDetail Plugin helpers', () => {
   const key = { key: 'key' };
@@ -133,6 +135,69 @@ describe('TableRowDetail Plugin helpers', () => {
         { ...key, type: TABLE_GROUP_TYPE, column: { name: 'a' } },
       ))
         .toBeTruthy();
+    });
+  });
+
+  describe('#sortAndSpliceColumns', () => {
+    const dataColumn = { type: TABLE_DATA_TYPE };
+    const groupColumn = { type: TABLE_GROUP_TYPE };
+    const otherColumn = { type: Symbol('undefined') };
+
+    it('should work with the Table (firstVisibleColumn is not defined)', () => {
+      expect(sortAndSpliceColumns([groupColumn, otherColumn, dataColumn]))
+        .toEqual([groupColumn, otherColumn, dataColumn]);
+
+      expect(sortAndSpliceColumns([otherColumn, groupColumn, dataColumn]))
+        .toEqual([groupColumn, otherColumn, dataColumn]);
+
+      expect(sortAndSpliceColumns([otherColumn, groupColumn, otherColumn, dataColumn]))
+        .toEqual([groupColumn, otherColumn, otherColumn, dataColumn]);
+    });
+
+    it('should work with the Virtual Table (firstVisibleColumn is defined)', () => {
+      describe('one group', () => {
+        expect(sortAndSpliceColumns(
+          [otherColumn, otherColumn, groupColumn, otherColumn, dataColumn], 0,
+        ))
+          .toEqual([groupColumn, otherColumn, otherColumn, otherColumn, dataColumn]);
+
+        expect(sortAndSpliceColumns(
+          [otherColumn, otherColumn, groupColumn, otherColumn, dataColumn], 1,
+        ))
+          .toEqual([groupColumn, otherColumn, otherColumn, dataColumn]);
+
+        expect(sortAndSpliceColumns(
+          [otherColumn, otherColumn, groupColumn, otherColumn, dataColumn], 2,
+        ))
+          .toEqual([groupColumn, otherColumn, dataColumn]);
+
+        expect(sortAndSpliceColumns(
+          [otherColumn, otherColumn, groupColumn, otherColumn, dataColumn], 3,
+        ))
+          .toEqual([groupColumn, otherColumn, dataColumn]);
+      });
+
+      describe('two groups', () => {
+        expect(sortAndSpliceColumns(
+          [otherColumn, otherColumn, groupColumn, otherColumn, groupColumn, dataColumn], 0,
+        ))
+          .toEqual([groupColumn, groupColumn, otherColumn, otherColumn, otherColumn, dataColumn]);
+
+        expect(sortAndSpliceColumns(
+          [otherColumn, otherColumn, groupColumn, otherColumn, groupColumn, dataColumn], 1,
+        ))
+          .toEqual([groupColumn, groupColumn, otherColumn, otherColumn, dataColumn]);
+
+        expect(sortAndSpliceColumns(
+          [otherColumn, otherColumn, groupColumn, otherColumn, groupColumn, dataColumn], 2,
+        ))
+          .toEqual([groupColumn, groupColumn, otherColumn, dataColumn]);
+
+        expect(sortAndSpliceColumns(
+          [otherColumn, otherColumn, groupColumn, otherColumn, groupColumn, dataColumn], 3,
+        ))
+          .toEqual([groupColumn, groupColumn, otherColumn, dataColumn]);
+      });
     });
   });
 

--- a/packages/dx-grid-core/src/plugins/table-group-row/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/table-group-row/helpers.ts
@@ -2,6 +2,7 @@ import { PureComputed } from '@devexpress/dx-core';
 import { TABLE_GROUP_TYPE } from './constants';
 import { TableRow, TableColumn, IsSpecificCellFn, Grouping, GroupSummaryItem } from '../../types';
 import { TABLE_STUB_TYPE } from '../../utils/virtual-table';
+import { TABLE_DATA_TYPE } from '../table/constants';
 
 type IsGroupIndentCellFn = PureComputed<[TableRow, TableColumn, Grouping[]], boolean>;
 
@@ -86,3 +87,20 @@ export const calculateGroupCellIndent: PureComputed<[TableColumn, Grouping[], nu
 ) => (
   indentWidth * getGroupIndexByColumn(grouping, tableColumn)
 );
+
+export const sortAndSpliceColumns: PureComputed<[TableColumn[], number]> = (
+  tableColumns, firstVisibleColumn,
+) => {
+  const groupColumns = tableColumns.filter(col => col.type === TABLE_GROUP_TYPE);
+  const dataColumns = tableColumns.filter(col => col.type === TABLE_DATA_TYPE);
+  const otherColumns = tableColumns.filter(
+    col => col.type !== TABLE_DATA_TYPE && col.type !== TABLE_GROUP_TYPE,
+  );
+
+  if (firstVisibleColumn) {
+    const firstGroupIndex = tableColumns.indexOf(groupColumns[0]);
+    otherColumns.splice(0, Math.min(firstVisibleColumn, firstGroupIndex));
+  }
+
+  return [...groupColumns, ...otherColumns, ...dataColumns];
+};

--- a/packages/dx-grid-core/src/plugins/table-group-row/helpers.ts
+++ b/packages/dx-grid-core/src/plugins/table-group-row/helpers.ts
@@ -89,7 +89,7 @@ export const calculateGroupCellIndent: PureComputed<[TableColumn, Grouping[], nu
 );
 
 export const sortAndSpliceColumns: PureComputed<[TableColumn[], number]> = (
-  tableColumns, firstVisibleColumn,
+  tableColumns, firstVisibleColumnIndex,
 ) => {
   const groupColumns = tableColumns.filter(col => col.type === TABLE_GROUP_TYPE);
   const dataColumns = tableColumns.filter(col => col.type === TABLE_DATA_TYPE);
@@ -97,9 +97,9 @@ export const sortAndSpliceColumns: PureComputed<[TableColumn[], number]> = (
     col => col.type !== TABLE_DATA_TYPE && col.type !== TABLE_GROUP_TYPE,
   );
 
-  if (firstVisibleColumn) {
+  if (firstVisibleColumnIndex) {
     const firstGroupIndex = tableColumns.indexOf(groupColumns[0]);
-    otherColumns.splice(0, Math.min(firstVisibleColumn, firstGroupIndex));
+    otherColumns.splice(0, Math.min(firstVisibleColumnIndex, firstGroupIndex));
   }
 
   return [...groupColumns, ...otherColumns, ...dataColumns];

--- a/packages/dx-grid-core/src/types/grouping.types.ts
+++ b/packages/dx-grid-core/src/types/grouping.types.ts
@@ -74,12 +74,12 @@ export type GetGroupCellTargetIndexFn = PureComputed<
 >;
 /** @internal */
 export type GroupCellColSpanGetter = PureComputed<
-  [GetCellColSpanFn, SummaryItem[]],
+  [GetCellColSpanFn, SummaryItem[], number],
   GetCellColSpanFn
 >;
 
 /** @internal */
 export type GroupSummaryChainsFn = PureComputed<
-  [TableRow, TableColumn[], SummaryItem[]],
+  [TableRow, TableColumn[], SummaryItem[], number],
   string[][]
 >;

--- a/packages/dx-react-grid/src/plugins/table-group-row.test.tsx
+++ b/packages/dx-react-grid/src/plugins/table-group-row.test.tsx
@@ -156,7 +156,7 @@ describe('TableGroupRow', () => {
         });
     });
 
-    it('should extend getTableCellColSpan', () => {
+    it('should extend getTableCellColSpan without the Virtual Table', () => {
       const tree = mount((
         <PluginHost>
           {pluginDepsToComponents(defaultDeps)}
@@ -172,6 +172,33 @@ describe('TableGroupRow', () => {
         .toBeCalledWith(
           defaultDeps.getter.getTableCellColSpan,
           defaultDeps.getter.groupSummaryItems,
+          undefined,
+        );
+    });
+
+    it('should extend getTableCellColSpan with the Virtual Table', () => {
+      const viewport = { columns: [[0, 1]] };
+      const tree = mount((
+        <PluginHost>
+          {pluginDepsToComponents({
+            ...defaultDeps,
+            getter: {
+              ...defaultDeps.getter, viewport,
+            },
+          })}
+          <TableGroupRow
+            {...defaultProps}
+          />
+        </PluginHost>
+      ));
+
+      expect(getComputedState(tree).getTableCellColSpan)
+        .toBe('tableGroupCellColSpanGetter');
+      expect(tableGroupCellColSpanGetter)
+        .toBeCalledWith(
+          defaultDeps.getter.getTableCellColSpan,
+          defaultDeps.getter.groupSummaryItems,
+          viewport.columns[0][0],
         );
     });
   });

--- a/packages/dx-react-grid/src/plugins/table-group-row.tsx
+++ b/packages/dx-react-grid/src/plugins/table-group-row.tsx
@@ -55,8 +55,12 @@ const tableBodyRowsComputed = (
 const getCellColSpanComputed = (
   { getTableCellColSpan, groupSummaryItems, viewport }: Getters,
 ) => {
-  const firstVisibleColumn = viewport?.columns[0][0];
-  return tableGroupCellColSpanGetter(getTableCellColSpan, groupSummaryItems, firstVisibleColumn);
+  const firstVisibleColumnIndex = viewport?.columns[0][0];
+  return tableGroupCellColSpanGetter(
+    getTableCellColSpan,
+    groupSummaryItems,
+    firstVisibleColumnIndex,
+  );
 };
 
 class TableGroupRowBase extends React.PureComponent<TableGroupRowProps> {

--- a/packages/dx-react-grid/src/plugins/table-group-row.tsx
+++ b/packages/dx-react-grid/src/plugins/table-group-row.tsx
@@ -53,8 +53,11 @@ const tableBodyRowsComputed = (
   { tableBodyRows, isGroupRow }: Getters,
 ) => tableRowsWithGrouping(tableBodyRows, isGroupRow);
 const getCellColSpanComputed = (
-  { getTableCellColSpan, groupSummaryItems }: Getters,
-) => tableGroupCellColSpanGetter(getTableCellColSpan, groupSummaryItems);
+  { getTableCellColSpan, groupSummaryItems, viewport }: Getters,
+) => {
+  const firstVisibleColumn = viewport?.columns[0][0];
+  return tableGroupCellColSpanGetter(getTableCellColSpan, groupSummaryItems, firstVisibleColumn);
+};
 
 class TableGroupRowBase extends React.PureComponent<TableGroupRowProps> {
   static ROW_TYPE = TABLE_GROUP_TYPE;


### PR DESCRIPTION
Fixes #3158 