### PR TITLE
fix(react-grid): make tree data work with a high level of row nesting

### DIFF
--- a/packages/dx-grid-core/src/types/tree-data.types.ts
+++ b/packages/dx-grid-core/src/types/tree-data.types.ts
@@ -31,11 +31,6 @@ export type ExpandedTreeRowsComputed = PureComputed<
 >;
 
 /** @internal */
-export type GetCustomTreeRowsFn = PureComputed<
-  [Row, GetTreeChildRowsFn, Row[], number?],
-  RowsWithTreeMeta
->;
-/** @internal */
 export type CustomTreeRowsWithMetaComputed = PureComputed<
   [Row[], GetTreeChildRowsFn], RowsWithTreeMetaMap
 >;

--- a/packages/dx-react-grid-demos/src/demo-sources/grid-tree-data/max-call-stack-test.jsxt
+++ b/packages/dx-react-grid-demos/src/demo-sources/grid-tree-data/max-call-stack-test.jsxt
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';<%&additionalImports%>
+import {
+  TreeDataState,
+  CustomTreeData,
+} from '@devexpress/dx-react-grid';
+import {
+  Grid,
+  Table,
+  TableHeaderRow,
+  TableTreeColumn,
+} from '@devexpress/dx-react-grid-<%&themeName%>';
+<%&cssImports%>
+
+import {
+  generateRows,
+  defaultColumnValues,
+} from '../../../demo-data/generator';
+
+const getChildRows = (row, rootRows) => {
+  const childRows = rootRows.filter(r => r.parentId === (row ? row.id : null));
+  return childRows.length ? childRows : null;
+};
+
+export default () => {
+  const [columns] = useState([
+    { name: 'name', title: 'Name' },
+    { name: 'gender', title: 'Gender' },
+    { name: 'city', title: 'City' },
+    { name: 'car', title: 'Car' },
+  ]);
+  const [data] = useState(generateRows({
+    columnValues: {
+      id: ({ index }) => index,
+      parentId: ({ index, random }) => (index > 0 ? index - 1 : null),
+      ...defaultColumnValues,
+    },
+    length: 100000,
+  }));
+  const [tableColumnExtensions] = useState([
+    { columnName: 'name', width: 300 },
+  ]);
+  const [defaultExpandedRowIds] = useState([0, 1]);
+
+  return (
+    <<%&wrapperTag%><%&wrapperAttributes%>>
+      <Grid
+        rows={data}
+        columns={columns}
+      >
+        <TreeDataState
+          defaultExpandedRowIds={defaultExpandedRowIds}
+        />
+        <CustomTreeData
+          getChildRows={getChildRows}
+        />
+        <Table
+          columnExtensions={tableColumnExtensions}
+        />
+        <TableHeaderRow />
+        <TableTreeColumn
+          for="name"
+        />
+      </Grid>
+    </<%&wrapperTag%>>
+  );
+};

--- a/packages/dx-react-grid-demos/src/demo-sources/grid-tree-data/max-call-stack-test.jsxt
+++ b/packages/dx-react-grid-demos/src/demo-sources/grid-tree-data/max-call-stack-test.jsxt
@@ -34,12 +34,8 @@ export default () => {
       parentId: ({ index }) => (index > 0 ? index - 1 : null),
       ...defaultColumnValues,
     },
-    length: 100000,
+    length: 10000,
   }));
-  const [tableColumnExtensions] = useState([
-    { columnName: 'name', width: 300 },
-  ]);
-  const [defaultExpandedRowIds] = useState([0, 1]);
 
   return (
     <<%&wrapperTag%><%&wrapperAttributes%>>
@@ -47,15 +43,11 @@ export default () => {
         rows={data}
         columns={columns}
       >
-        <TreeDataState
-          defaultExpandedRowIds={defaultExpandedRowIds}
-        />
+        <TreeDataState />
         <CustomTreeData
           getChildRows={getChildRows}
         />
-        <Table
-          columnExtensions={tableColumnExtensions}
-        />
+        <Table />
         <TableHeaderRow />
         <TableTreeColumn
           for="name"

--- a/packages/dx-react-grid-demos/src/demo-sources/grid-tree-data/max-call-stack-test.jsxt
+++ b/packages/dx-react-grid-demos/src/demo-sources/grid-tree-data/max-call-stack-test.jsxt
@@ -31,7 +31,7 @@ export default () => {
   const [data] = useState(generateRows({
     columnValues: {
       id: ({ index }) => index,
-      parentId: ({ index, random }) => (index > 0 ? index - 1 : null),
+      parentId: ({ index }) => (index > 0 ? index - 1 : null),
       ...defaultColumnValues,
     },
     length: 100000,


### PR DESCRIPTION
Fixes #3111 