### PR TITLE
fix(react-grid): Don't attach a stub column for resizing mode 'nextColumn'

### DIFF
--- a/packages/dx-grid-core/src/plugins/table-column-resizing/computeds.ts
+++ b/packages/dx-grid-core/src/plugins/table-column-resizing/computeds.ts
@@ -32,7 +32,7 @@ const specifyWidths: SpecifyWidthsFn = (tableColumns, widths, resizingMode, onEr
         if (width === undefined) {
           acc.push(tableColumn);
         } else {
-          acc.push({ ...tableColumn, width: convertWidth(width) });
+          acc.push({ ...tableColumn, width: convertWidth(width), resizingMode });
         }
       } else {
         acc.push(tableColumn);

--- a/packages/dx-grid-core/src/types/table.types.ts
+++ b/packages/dx-grid-core/src/types/table.types.ts
@@ -34,6 +34,8 @@ export interface TableColumn {
   align?: 'left' | 'right' | 'center';
   /** Specifies the fixed table's column alignment. */
   fixed?: 'left' | 'right';
+  /** Specifies column resize mode. */
+  resizingMode?: string;
 }
 
 export type GridColumnExtension = {

--- a/packages/dx-react-grid/api/dx-react-grid.api.md
+++ b/packages/dx-react-grid/api/dx-react-grid.api.md
@@ -785,6 +785,7 @@ export interface TableColumn {
     column?: Column;
     fixed?: 'left' | 'right';
     key: string;
+    resizingMode?: string;
     type: symbol;
     width?: number | string;
 }

--- a/packages/dx-react-grid/src/components/table-layout.tsx
+++ b/packages/dx-react-grid/src/components/table-layout.tsx
@@ -81,7 +81,10 @@ class TableLayoutBase extends React.PureComponent<TableLayoutCoreProps, TableLay
     let result = columns;
 
     const isFixedWidth = columns
-      .filter(column => column.width === undefined || column.width === 'auto')
+      .filter(column =>
+        (column.width === undefined || column.width === 'auto')
+        || (column.resizingMode && column.resizingMode !== 'widget')
+      )
       .length === 0;
     if (isFixedWidth) {
       // presumably a flex column added here instead of in a getter in the Table plugin

--- a/packages/dx-react-grid/src/components/table-layout.tsx
+++ b/packages/dx-react-grid/src/components/table-layout.tsx
@@ -81,11 +81,8 @@ class TableLayoutBase extends React.PureComponent<TableLayoutCoreProps, TableLay
     let result = columns;
 
     const isFixedWidth = columns
-      .filter(column =>
-        (column.width === undefined || column.width === 'auto')
-        || (column.resizingMode && column.resizingMode !== 'widget')
-      )
-      .length === 0;
+      .filter(column => (column.width === undefined || column.width === 'auto')
+        || (column.resizingMode && column.resizingMode !== 'widget')).length === 0;
     if (isFixedWidth) {
       // presumably a flex column added here instead of in a getter in the Table plugin
       // to make sure that all manipulations on taleColumns have already done earlier


### PR DESCRIPTION
Provides a fix for not displaying a stub column when we use TableColumnResizing and resizing mode is set to 'nextColumn'; 
Fixes #2466 