### PR TITLE
fix(react-grid): format currency in the Data Editing demo

### DIFF
--- a/packages/dx-react-grid-demos/src/theme-sources/material-ui/components/currency-type-provider.jsx
+++ b/packages/dx-react-grid-demos/src/theme-sources/material-ui/components/currency-type-provider.jsx
@@ -51,7 +51,8 @@ EditorBase.defaultProps = {
 
 const Editor = withStyles(styles)(EditorBase);
 
-const Formatter = ({ value }) => `$${value}`;
+const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+const Formatter = ({ value }) => currencyFormatter.format(value);
 
 const availableFilterOperations = [
   'equal', 'notEqual',


### PR DESCRIPTION
Fix [demo](https://devexpress.github.io/devextreme-reactive/react/grid/demos/featured/data-editing/).

Before:
![image](https://user-images.githubusercontent.com/43685423/99225520-3be2ee80-27f9-11eb-899c-152c9f8aba76.png)


After:
![image](https://user-images.githubusercontent.com/43685423/99225535-42716600-27f9-11eb-8f93-db44eb18cd36.png)
