### PR TITLE
fix(react-grid): make inline cell editing works only with data rows

### DIFF
--- a/packages/dx-grid-core/src/plugins/table-inline-cell-editing/computeds.test.ts
+++ b/packages/dx-grid-core/src/plugins/table-inline-cell-editing/computeds.test.ts
@@ -1,10 +1,26 @@
+import { TABLE_DATA_TYPE } from '../table/constants';
 import { rowsWithEditingCells, columnsWithEditingCells } from './computeds';
 
 describe('TableInlineCellEditing Plugin computeds', () => {
   const editingCells = [{ rowId: 0, columnName: 'b' }];
 
   describe('#rowsWithEditingCells', () => {
-    it('should work', () => {
+    it('should work with rows which type is TABLE_DATA_TYPE', () => {
+      const rows = [
+        { rowId: 0, type: TABLE_DATA_TYPE },
+        { rowId: 1, type: TABLE_DATA_TYPE },
+      ];
+
+      expect(rowsWithEditingCells(rows, []))
+        .toEqual(rows);
+      expect(rowsWithEditingCells(rows, editingCells))
+        .toEqual([
+          { rowId: 0, type: TABLE_DATA_TYPE, hasEditCell: true },
+          { rowId: 1, type: TABLE_DATA_TYPE },
+        ]);
+    });
+
+    it('should ignore rows which type is not TABLE_DATA_TYPE', () => {
       const rows = [
         { rowId: 0 },
         { rowId: 1 },
@@ -13,10 +29,7 @@ describe('TableInlineCellEditing Plugin computeds', () => {
       expect(rowsWithEditingCells(rows, []))
         .toEqual(rows);
       expect(rowsWithEditingCells(rows, editingCells))
-        .toEqual([
-          { rowId: 0, hasEditCell: true },
-          { rowId: 1 },
-        ]);
+        .toEqual(rows);
     });
   });
 

--- a/packages/dx-grid-core/src/plugins/table-inline-cell-editing/computeds.ts
+++ b/packages/dx-grid-core/src/plugins/table-inline-cell-editing/computeds.ts
@@ -1,10 +1,15 @@
 import { TableRowsWithEditingCellsFn, TableColumnsWithEditingCellsFn } from '../../types';
+import { TABLE_DATA_TYPE } from '../table/constants';
 
 export const rowsWithEditingCells: TableRowsWithEditingCellsFn = (
   tableBodyRows, editingCells,
 ) => tableBodyRows.map((row) => {
-  const { rowId } = row;
-  if (rowId !== undefined && editingCells.some(elem => elem.rowId === rowId)) {
+  const { rowId, type } = row;
+  if (
+    rowId !== undefined &&
+    type === TABLE_DATA_TYPE &&
+    editingCells.some(elem => elem.rowId === rowId)
+  ) {
     return {
       ...row,
       hasEditCell: true,


### PR DESCRIPTION
Fixes #3200 