### PR TITLE
fix(react-scheduler): Add missing type

### DIFF
--- a/packages/dx-react-scheduler/src/types/editing/appointment-tooltip.types.ts
+++ b/packages/dx-react-scheduler/src/types/editing/appointment-tooltip.types.ts
@@ -62,6 +62,8 @@ export namespace AppointmentTooltip {
   export interface ContentProps {
     /** The appointment’s displayed metadata. */
     appointmentData?: AppointmentModel;
+    /** The appointment's resource items. */
+    appointmentResources: Array<ValidResourceInstance>;
     /** A function that formats dates according to the locale. */
     formatDate: FormatterFn;
     /** A component that renders an icon that indicates a recurring appointment. */


### PR DESCRIPTION
thank you. made a great library.

While using it, I found the missing type and made a pull request

<https://github.com/DevExpress/devextreme-reactive/blob/master/packages/dx-react-scheduler-material-ui/src/templates/appointment-tooltip/content.jsx#L152>

Added undefined props type to appointment-tooltip content component. (appointmentResources)