### PR TITLE
style: Add active button style user prop to grid

### DIFF
--- a/packages/dx-react-grid-bootstrap3/src/templates/paging-panel/pager.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/paging-panel/pager.jsx
@@ -5,6 +5,7 @@ import { PageSizeSelector } from './page-size-selector';
 import { Pagination } from './pagination';
 
 export const Pager = ({
+  activeButtonClass,
   currentPage,
   onCurrentPageChange,
   totalPages,
@@ -26,12 +27,12 @@ export const Pager = ({
     {...restProps}
   >
     {!!pageSizes.length && (
-    <PageSizeSelector
-      pageSize={pageSize}
-      onPageSizeChange={onPageSizeChange}
-      pageSizes={pageSizes}
-      getMessage={getMessage}
-    />
+      <PageSizeSelector
+        pageSize={pageSize}
+        onPageSizeChange={onPageSizeChange}
+        pageSizes={pageSizes}
+        getMessage={getMessage}
+      />
     )}
     <Pagination
       totalPages={totalPages}
@@ -40,6 +41,7 @@ export const Pager = ({
       onCurrentPageChange={page => onCurrentPageChange(page)}
       pageSize={pageSize}
       getMessage={getMessage}
+      activeButtonClass={activeButtonClass}
     />
   </div>
 );
@@ -51,6 +53,7 @@ Pager.propTypes = {
   pageSize: PropTypes.number.isRequired,
   onPageSizeChange: PropTypes.func.isRequired,
   pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
+  activeButtonClass: PropTypes.string,
   totalCount: PropTypes.number.isRequired,
   getMessage: PropTypes.func.isRequired,
   className: PropTypes.string,
@@ -58,6 +61,7 @@ Pager.propTypes = {
 };
 
 Pager.defaultProps = {
+  activeButtonClass: '',
   className: undefined,
   style: null,
 };

--- a/packages/dx-react-grid-bootstrap4/src/templates/paging-panel/pager.jsx
+++ b/packages/dx-react-grid-bootstrap4/src/templates/paging-panel/pager.jsx
@@ -5,6 +5,7 @@ import { PageSizeSelector } from './page-size-selector';
 import { Pagination } from './pagination';
 
 export const Pager = ({
+  activeButtonClass,
   currentPage,
   onCurrentPageChange,
   totalPages,
@@ -21,12 +22,12 @@ export const Pager = ({
     {...restProps}
   >
     {!!pageSizes.length && (
-    <PageSizeSelector
-      pageSize={pageSize}
-      onPageSizeChange={onPageSizeChange}
-      pageSizes={pageSizes}
-      getMessage={getMessage}
-    />
+      <PageSizeSelector
+        pageSize={pageSize}
+        onPageSizeChange={onPageSizeChange}
+        pageSizes={pageSizes}
+        getMessage={getMessage}
+      />
     )}
     <Pagination
       totalPages={totalPages}
@@ -35,6 +36,7 @@ export const Pager = ({
       onCurrentPageChange={page => onCurrentPageChange(page)}
       pageSize={pageSize}
       getMessage={getMessage}
+      activeButtonClass={activeButtonClass}
     />
   </div>
 );
@@ -46,11 +48,13 @@ Pager.propTypes = {
   pageSize: PropTypes.number.isRequired,
   onPageSizeChange: PropTypes.func.isRequired,
   pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
+  activeButtonClass: PropTypes.string,
   totalCount: PropTypes.number.isRequired,
   getMessage: PropTypes.func.isRequired,
   className: PropTypes.string,
 };
 
 Pager.defaultProps = {
+  activeButtonClass: '',
   className: undefined,
 };

--- a/packages/dx-react-grid-bootstrap4/src/templates/paging-panel/pagination.jsx
+++ b/packages/dx-react-grid-bootstrap4/src/templates/paging-panel/pagination.jsx
@@ -11,6 +11,7 @@ const renderPageButtons = (
   currentPage,
   totalPageCount,
   currentPageChange,
+  activeButtonClass,
 ) => {
   const pageButtons = [];
   const maxButtonCount = 3;
@@ -24,7 +25,7 @@ const renderPageButtons = (
   }
   if (startPage > 1) {
     pageButtons.push((
-      <PaginationItem key={1}>
+      <PaginationItem key={1} activeButtonClass={activeButtonClass}>
         <PaginationLink
           href="#"
           onClick={e => currentPageChange(e, 0)}
@@ -50,6 +51,7 @@ const renderPageButtons = (
       <PaginationItem
         key={page}
         active={page === currentPage + 1}
+        activeButtonClass={activeButtonClass}
         disabled={startPage === endPage}
       >
         <PaginationLink
@@ -74,7 +76,7 @@ const renderPageButtons = (
     }
 
     pageButtons.push((
-      <PaginationItem key={totalPageCount}>
+      <PaginationItem key={totalPageCount} activeButtonClass={activeButtonClass}>
         <PaginationLink
           href="#"
           onClick={e => currentPageChange(e, totalPageCount - 1)}
@@ -95,6 +97,7 @@ export const Pagination = ({
   totalCount,
   pageSize,
   getMessage,
+  activeButtonClass,
 }) => {
   const from = firstRowOnPage(currentPage, pageSize, totalCount);
   const to = lastRowOnPage(currentPage, pageSize, totalCount);
@@ -112,7 +115,7 @@ export const Pagination = ({
             onClick={e => currentPageChange(e, currentPage - 1)}
           />
         </PaginationItem>
-        {renderPageButtons(currentPage, totalPages, currentPageChange)}
+        {renderPageButtons(currentPage, totalPages, currentPageChange, activeButtonClass)}
         <PaginationItem disabled={currentPage === totalPages - 1 || totalCount === 0}>
           <PaginationLink
             next
@@ -152,7 +155,12 @@ Pagination.propTypes = {
   totalPages: PropTypes.number.isRequired,
   currentPage: PropTypes.number.isRequired,
   onCurrentPageChange: PropTypes.func.isRequired,
+  activeButtonClass: PropTypes.string,
   totalCount: PropTypes.number.isRequired,
   pageSize: PropTypes.number.isRequired,
   getMessage: PropTypes.func.isRequired,
+};
+
+Pagination.defaultProps = {
+  activeButtonClass: '',
 };

--- a/packages/dx-react-grid-bootstrap4/src/templates/parts/pagination/pagination-item.jsx
+++ b/packages/dx-react-grid-bootstrap4/src/templates/parts/pagination/pagination-item.jsx
@@ -4,21 +4,24 @@ import classNames from 'clsx';
 
 export const PaginationItem = ({
   active,
+  activeButtonClass,
   disabled,
   ...restProps
 }) => (
   <li
-    className={classNames('page-item', { active, disabled })}
+    className={classNames('page-item', { active, disabled, [activeButtonClass]: active })}
     {...restProps}
   />
 );
 
 PaginationItem.propTypes = {
   active: PropTypes.bool,
+  activeButtonClass: PropTypes.string,
   disabled: PropTypes.bool,
 };
 
 PaginationItem.defaultProps = {
   active: false,
+  activeButtonClass: '',
   disabled: false,
 };

--- a/packages/dx-react-grid-bootstrap4/src/templates/parts/pagination/pagination-item.test.jsx
+++ b/packages/dx-react-grid-bootstrap4/src/templates/parts/pagination/pagination-item.test.jsx
@@ -13,13 +13,13 @@ describe('Pagination item', () => {
     it('should append "active" if this prop is set', () => {
       const tree = shallow(<PaginationItem active />);
 
-      expect(tree.prop('className')).toBe('page-item active');
+      expect(tree.prop('className')).toContain('active');
     });
 
     it('should append "disabled" if this prop is set', () => {
       const tree = shallow(<PaginationItem disabled />);
 
-      expect(tree.prop('className')).toBe('page-item disabled');
+      expect(tree.prop('className')).toContain('disabled');
     });
   });
 

--- a/packages/dx-react-grid-material-ui/src/templates/paging-panel/pager.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/paging-panel/pager.jsx
@@ -17,6 +17,7 @@ const styles = theme => ({
 });
 
 const PagerBase = ({
+  activeButtonClass,
   currentPage,
   pageSizes,
   totalPages,
@@ -34,12 +35,12 @@ const PagerBase = ({
     {...restProps}
   >
     {!!pageSizes.length && (
-    <PageSizeSelector
-      pageSize={pageSize}
-      onPageSizeChange={onPageSizeChange}
-      pageSizes={pageSizes}
-      getMessage={getMessage}
-    />
+      <PageSizeSelector
+        pageSize={pageSize}
+        onPageSizeChange={onPageSizeChange}
+        pageSizes={pageSizes}
+        getMessage={getMessage}
+      />
     )}
     <Pagination
       totalPages={totalPages}
@@ -48,6 +49,7 @@ const PagerBase = ({
       onCurrentPageChange={page => onCurrentPageChange(page)}
       pageSize={pageSize}
       getMessage={getMessage}
+      activeButtonClass={activeButtonClass}
     />
   </div>
 );
@@ -58,6 +60,7 @@ PagerBase.propTypes = {
   pageSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
   pageSize: PropTypes.number.isRequired,
   classes: PropTypes.object.isRequired,
+  activeButtonClass: PropTypes.string,
   onCurrentPageChange: PropTypes.func.isRequired,
   onPageSizeChange: PropTypes.func.isRequired,
   totalCount: PropTypes.number.isRequired,
@@ -66,6 +69,7 @@ PagerBase.propTypes = {
 };
 
 PagerBase.defaultProps = {
+  activeButtonClass: '',
   className: undefined,
 };
 

--- a/packages/dx-react-grid-material-ui/src/templates/paging-panel/pagination.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/paging-panel/pagination.jsx
@@ -51,11 +51,12 @@ const styles = theme => ({
 });
 
 const PageButton = ({
-  text, isActive, isDisabled, classes, onClick,
+  text, isActive, isDisabled, classes, activeButtonClass, onClick,
 }) => {
   const buttonClasses = classNames({
     [classes.button]: true,
     [classes.activeButton]: isActive,
+    [activeButtonClass]: isActive,
   });
 
   return (
@@ -75,13 +76,15 @@ PageButton.propTypes = {
   isActive: PropTypes.bool,
   isDisabled: PropTypes.bool,
   classes: PropTypes.object.isRequired,
+  activeButtonClass: PropTypes.string,
   onClick: PropTypes.func,
 };
 
 PageButton.defaultProps = {
-  onClick: () => {},
+  onClick: () => { },
   isDisabled: false,
   isActive: false,
+  activeButtonClass: '',
 };
 
 const ellipsisSymbol = '\u2026';
@@ -91,12 +94,12 @@ const renderPageButtons = (
   totalPageCount,
   classes,
   onCurrentPageChange,
+  activeButtonClass,
 ) => {
   const pageButtons = [];
   const maxButtonCount = 3;
   let startPage = 1;
   let endPage = totalPageCount || 1;
-
   // NOTE: take into account last button and ellipsis (T1004797)
   if (maxButtonCount < totalPageCount - 2) {
     startPage = calculateStartPage(currentPage + 1, maxButtonCount, totalPageCount);
@@ -108,6 +111,7 @@ const renderPageButtons = (
         key={1}
         text={String(1)}
         classes={classes}
+        activeButtonClass={activeButtonClass}
         onClick={() => onCurrentPageChange(0)}
       />
     ));
@@ -118,6 +122,7 @@ const renderPageButtons = (
           key="ellipsisStart"
           text={ellipsisSymbol}
           classes={classes}
+          activeButtonClass={activeButtonClass}
           isDisabled
         />
       ));
@@ -131,6 +136,7 @@ const renderPageButtons = (
         text={String(page)}
         isActive={page === currentPage + 1}
         classes={classes}
+        activeButtonClass={activeButtonClass}
         onClick={() => onCurrentPageChange(page - 1)}
         isDisabled={startPage === endPage}
       />
@@ -144,6 +150,7 @@ const renderPageButtons = (
           key="ellipsisEnd"
           text={ellipsisSymbol}
           classes={classes}
+          activeButtonClass={activeButtonClass}
           isDisabled
         />
       ));
@@ -154,6 +161,7 @@ const renderPageButtons = (
         key={totalPageCount}
         text={String(totalPageCount)}
         classes={classes}
+        activeButtonClass={activeButtonClass}
         onClick={() => onCurrentPageChange(totalPageCount - 1)}
       />
     ));
@@ -170,6 +178,7 @@ const PaginationBase = ({
   onCurrentPageChange,
   getMessage,
   classes,
+  activeButtonClass,
 }) => {
   const from = firstRowOnPage(currentPage, pageSize, totalCount);
   const to = lastRowOnPage(currentPage, pageSize, totalCount);
@@ -187,7 +196,7 @@ const PaginationBase = ({
       >
         <ChevronLeft />
       </IconButton>
-      {renderPageButtons(currentPage, totalPages, classes, onCurrentPageChange)}
+      {renderPageButtons(currentPage, totalPages, classes, onCurrentPageChange, activeButtonClass)}
       <IconButton
         className={classNames(classes.arrowButton, classes.next)}
         disabled={currentPage === totalPages - 1 || totalCount === 0}
@@ -204,10 +213,15 @@ PaginationBase.propTypes = {
   totalPages: PropTypes.number.isRequired,
   currentPage: PropTypes.number.isRequired,
   onCurrentPageChange: PropTypes.func.isRequired,
+  activeButtonClass: PropTypes.string,
   classes: PropTypes.object.isRequired,
   totalCount: PropTypes.number.isRequired,
   pageSize: PropTypes.number.isRequired,
   getMessage: PropTypes.func.isRequired,
+};
+
+PaginationBase.defaultProps = {
+  activeButtonClass: '',
 };
 
 export const Pagination = withStyles(styles, { name: 'Pagination' })(PaginationBase);

--- a/packages/dx-react-grid/api/dx-react-grid.api.md
+++ b/packages/dx-react-grid/api/dx-react-grid.api.md
@@ -537,6 +537,7 @@ export const PagingPanel: React_2.ComponentType<PagingPanelProps>;
 // @public (undocumented)
 export namespace PagingPanel {
     export interface ContainerProps {
+        activeButtonClass?: string;
         currentPage: number;
         getMessage: (messageKey: string, parameters?: {
             from: number;
@@ -564,6 +565,7 @@ export namespace PagingPanel {
 
 // @public (undocumented)
 export interface PagingPanelProps {
+    activeButtonClass?: string;
     containerComponent: React_2.ComponentType<PagingPanel.ContainerProps>;
     messages?: PagingPanel.LocalizationMessages;
     pageSizes?: Array<number>;

--- a/packages/dx-react-grid/src/plugins/paging-panel.tsx
+++ b/packages/dx-react-grid/src/plugins/paging-panel.tsx
@@ -8,25 +8,27 @@ import { pageCount } from '@devexpress/dx-grid-core';
 import { PagingPanelProps } from '../types';
 
 const pluginDependencies = [
-  { name: 'PagingState' },
+  { name: 'PagingState' }
 ];
 
 const defaultMessages = {
   showAll: 'All',
-  info: ({ from, to, count }) => `${from}${from < to ? `-${to}` : ''} of ${count}`,
+  info: ({ from, to, count }) => `${from}${from < to ? `-${to}` : ''} of ${count}`
 };
 
 class PagingPanelBase extends React.PureComponent<PagingPanelProps> {
   static defaultProps = {
+    activeButtonClass: '',
     pageSizes: [],
-    messages: {},
+    messages: {}
   };
   static components = {
-    containerComponent: 'Container',
+    containerComponent: 'Container'
   };
 
   render() {
     const {
+      activeButtonClass,
       containerComponent: Pager,
       pageSizes,
       messages,
@@ -43,6 +45,7 @@ class PagingPanelBase extends React.PureComponent<PagingPanelProps> {
           <TemplateConnector>
             {({ currentPage, pageSize, totalCount }, { setCurrentPage, setPageSize }) => (
               <Pager
+                activeButtonClass={activeButtonClass}
                 currentPage={currentPage}
                 pageSize={pageSize}
                 totalCount={totalCount}

--- a/packages/dx-react-grid/src/plugins/paging-panel.tsx
+++ b/packages/dx-react-grid/src/plugins/paging-panel.tsx
@@ -8,22 +8,22 @@ import { pageCount } from '@devexpress/dx-grid-core';
 import { PagingPanelProps } from '../types';
 
 const pluginDependencies = [
-  { name: 'PagingState' }
+  { name: 'PagingState' },
 ];
 
 const defaultMessages = {
   showAll: 'All',
-  info: ({ from, to, count }) => `${from}${from < to ? `-${to}` : ''} of ${count}`
+  info: ({ from, to, count }) => `${from}${from < to ? `-${to}` : ''} of ${count}`,
 };
 
 class PagingPanelBase extends React.PureComponent<PagingPanelProps> {
   static defaultProps = {
     activeButtonClass: '',
     pageSizes: [],
-    messages: {}
+    messages: {},
   };
   static components = {
-    containerComponent: 'Container'
+    containerComponent: 'Container',
   };
 
   render() {

--- a/packages/dx-react-grid/src/types/paging/paging-panel.types.ts
+++ b/packages/dx-react-grid/src/types/paging/paging-panel.types.ts
@@ -12,6 +12,8 @@ export namespace PagingPanel {
     pageSize: number;
     /** Specifies the total row count. */
     totalCount: number;
+    /** Specifies if there is a user-provided class for buttons in an active state. */
+    activeButtonClass?: string;
     /** Handles the page size changes. */
     onPageSizeChange: (size: number) => void;
     /** Specifies the page sizes that a user can select. */
@@ -40,4 +42,6 @@ export interface PagingPanelProps {
   pageSizes?: Array<number>;
   /** An object that specifies the localization messages. */
   messages?: PagingPanel.LocalizationMessages;
+  /** A user-provided class for buttons in an active state. */
+  activeButtonClass?: string;
 }


### PR DESCRIPTION
As I have seen a few requests for it and the functionality doesn't seem to exist yet, I have created a prop named `activeButtonClass` that can be passed into the Grid when creating that component to let the user manipulate the CSS styles of the "active" button in the `PagingPanel`.  This prop will take a string that should be a user-generated class name, and will add it to the classes for a button with the `activeButton` class.  An example of how this would work in a React-Material UI setup is as follows:

```
import React, { useState } from 'react';
import Paper from '@material-ui/core/Paper';
import {
  PagingState,
  IntegratedPaging,
} from '@devexpress/dx-react-grid';
import {
  Grid,
  Table,
  TableHeaderRow,
  PagingPanel,
} from '@devexpress/dx-react-grid-material-ui';
import { makeStyles } from '@material-ui/core/styles'
import { generateRows } from '../../../demo-data/generator';

const useStyles = makeStyles((_theme) => ({
  myClass: {
    backgroundColor: 'maroon',
    color: 'white',
  },
}))

export default () => {
  const [columns] = useState([
    { name: 'name', title: 'Name' },
    { name: 'gender', title: 'Gender' },
    { name: 'city', title: 'City' },
    { name: 'car', title: 'Car' },
  ]);
  const [rows] = useState(generateRows({ length: 8 }));
  const [currentPage, setCurrentPage] = useState(0);
  const [pageSize, setPageSize] = useState(5);
  const [pageSizes] = useState([5, 10, 15]);

  const classes = useStyles()

  return (
    <Paper>
      <Grid
        rows={rows}
        columns={columns}
      >
        <PagingState
          currentPage={currentPage}
          onCurrentPageChange={setCurrentPage}
          pageSize={pageSize}
          onPageSizeChange={setPageSize}
        />
        <IntegratedPaging />
        <Table />
        <TableHeaderRow />
        <PagingPanel
          pageSizes={pageSizes}
          activeButtonClass={classes.myClass}
        />
      </Grid>
    </Paper>
  );
};
```

That is modified code from your `controlled-mode.g.jsx` file, and the result looks like this ....

<img width="853" alt="sample-grid" src="https://user-images.githubusercontent.com/13025282/125130946-889c7200-e0c7-11eb-90d1-75a522a98b14.png">


There are still some issues to be addressed by the maintainers, however, and I can tweak accordingly.  Questions off the top of my head ...

1.  Is `activeButtonClass` an acceptable name for this prop?
2. I didn't yet create a test, because I wasn't sure exactly what type of test you would like (just that the class makes it to the button?) or where it should be placed.  Should I place something in `packages/dx-react-grid-material-ui/src/templates/paging-panel/pagination.test.jsx`?
3. As the styling is much better for Bootstrap (and as I only needed this for my Material UI setup ... as did most of the people asking about this feature in my online searches), I first fully implemented this prop for the `dx-react-grid-material-ui` module.  Once I had a test or two fail, I implemented for Bootstrap 4 .... Bootstrap 3 proved trickier, so I just handled the new prop without passing it through.  Is it critical to implement for the Bootstrap 3 module ... will this PR not be accepted if it is not included?

Anyway, please review and let me know if there are any further issues to address or changes to make!  I think this would be a useful feature to have for many people, so I'm hoping we can get this into the repo!  Thank you!