### PR TITLE
fix(react-grid): add dependence in the TableBandHeader plugin

### DIFF
--- a/packages/dx-react-grid/src/plugins/table-band-header.tsx
+++ b/packages/dx-react-grid/src/plugins/table-band-header.tsx
@@ -67,6 +67,7 @@ class TableBandHeaderBase extends React.PureComponent<TableBandHeaderProps> {
           { name: 'TableHeaderRow' },
           { name: 'TableSelection', optional: true },
           { name: 'TableEditColumn', optional: true },
+          { name: 'TableColumnVisibility', optional: true },
         ]}
       >
         <Getter name="tableHeaderRows" computed={tableHeaderRowsComputed} />


### PR DESCRIPTION
Fixes #3397

BREAKING CHANGES:

Now, declare the `TableColumnVisibility` plug-in before the `TableBandHeader` plug-in to correctly calculate column spans and borders.

```diff
...
+<TableColumnVisibility
+  defaultHiddenColumnNames={...}
+/>
...
<TableBandHeader
  columnBands={columnBands}
/>
...
-<TableColumnVisibility
-  defaultHiddenColumnNames={...}
-/>
...
```