### PR TITLE
fix(react-grid): prevent resize of the column out the left side of window

### DIFF
--- a/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell/resizing-control.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell/resizing-control.jsx
@@ -51,7 +51,9 @@ export class ResizingControl extends React.PureComponent {
     };
     this.onResizeUpdate = ({ x }) => {
       const { onWidthDraft } = this.props;
-      onWidthDraft({ shift: x - this.resizeStartingX });
+      if (x >= 0) {
+        onWidthDraft({ shift: x - this.resizeStartingX });
+      }
     };
     this.onResizeEnd = ({ x }) => {
       const { onWidthChange, onWidthDraftCancel } = this.props;

--- a/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell/resizing-control.test.jsx
+++ b/packages/dx-react-grid-bootstrap3/src/templates/table-header-cell/resizing-control.test.jsx
@@ -54,4 +54,19 @@ describe('ResizingControl', () => {
     expect(onWidthDraft)
       .toBeCalledWith({ shift: 10 });
   });
+
+  it('should not trigger onWidthDraft, x coordinate is negative value', () => {
+    const onWidthDraft = jest.fn();
+    const tree = shallow((
+      <ResizingControl
+        {...defaultProps}
+        onWidthDraft={onWidthDraft}
+      />
+    ));
+
+    tree.find(Draggable).prop('onStart')({ x: 0 });
+
+    tree.find(Draggable).prop('onUpdate')({ x: -10 });
+    expect(onWidthDraft).not.toBeCalled();
+  });
 });

--- a/packages/dx-react-grid-bootstrap4/src/templates/table-header-cell/resizing-control.jsx
+++ b/packages/dx-react-grid-bootstrap4/src/templates/table-header-cell/resizing-control.jsx
@@ -17,7 +17,9 @@ export class ResizingControl extends React.PureComponent {
     };
     this.onResizeUpdate = ({ x }) => {
       const { onWidthDraft } = this.props;
-      onWidthDraft({ shift: x - this.resizeStartingX });
+      if (x >= 0) {
+        onWidthDraft({ shift: x - this.resizeStartingX });
+      }
     };
     this.onResizeEnd = ({ x }) => {
       const { onWidthChange, onWidthDraftCancel } = this.props;

--- a/packages/dx-react-grid-bootstrap4/src/templates/table-header-cell/resizing-control.test.jsx
+++ b/packages/dx-react-grid-bootstrap4/src/templates/table-header-cell/resizing-control.test.jsx
@@ -54,4 +54,19 @@ describe('ResizingControl', () => {
     expect(onWidthDraft)
       .toBeCalledWith({ shift: 10 });
   });
+
+  it('should not trigger onWidthDraft, x coordinate is negative value', () => {
+    const onWidthDraft = jest.fn();
+    const tree = shallow((
+      <ResizingControl
+        {...defaultProps}
+        onWidthDraft={onWidthDraft}
+      />
+    ));
+
+    tree.find(Draggable).prop('onStart')({ x: 0 });
+
+    tree.find(Draggable).prop('onUpdate')({ x: -10 });
+    expect(onWidthDraft).not.toBeCalled();
+  });
 });

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell/resizing-control.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell/resizing-control.jsx
@@ -81,7 +81,9 @@ export class ResizingControl extends React.PureComponent {
     };
     this.onResizeUpdate = ({ x }) => {
       const { onWidthDraft } = this.props;
-      onWidthDraft({ shift: x - this.resizeStartingX });
+      if (x >= 0) {
+        onWidthDraft({ shift: x - this.resizeStartingX });
+      }
     };
     this.onResizeEnd = ({ x }) => {
       const { onWidthChange, onWidthDraftCancel } = this.props;

--- a/packages/dx-react-grid-material-ui/src/templates/table-header-cell/resizing-control.test.jsx
+++ b/packages/dx-react-grid-material-ui/src/templates/table-header-cell/resizing-control.test.jsx
@@ -73,4 +73,19 @@ describe('ResizingControl', () => {
     expect(onWidthDraft)
       .toBeCalledWith({ shift: 10 });
   });
+
+  it('should not trigger onWidthDraft, x coordinate is negative value', () => {
+    const onWidthDraft = jest.fn();
+    const tree = shallow((
+      <ResizingControl
+        {...defaultProps}
+        onWidthDraft={onWidthDraft}
+      />
+    ));
+
+    tree.find(Draggable).prop('onStart')({ x: 0 });
+
+    tree.find(Draggable).prop('onUpdate')({ x: -10 });
+    expect(onWidthDraft).not.toBeCalled();
+  });
 });


### PR DESCRIPTION
Fixes #3330