### PR TITLE
chore: create the no-response.yml config for a Github action

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,26 @@
+name: No Response
+
+# Both `issue_comment` and `scheduled` event types are required for this Action
+# to work properly.
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule for five minutes after the hour, every hour
+    - cron: '5 * * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}
+          daysUntilClose: 10
+          responseRequiredLabel: "STATE: Awaiting customer response"
+          closeComment: >
+            This issue has been automatically closed because there has been no response
+            to our request for more information from the original author. With only the
+            information that is currently in the issue, we don't have enough information
+            to take action. Please reach out if you have or find the answers we need so
+            that we can investigate further.


### PR DESCRIPTION
This Github action is a replacement for the no-response bot, which is outdated now. See: https://github.com/probot/no-response