### PR TITLE
chore: use react-popper 2.x in bootstrap4 packages (permits React 18 support)

### DIFF
--- a/packages/dx-react-bootstrap4/components/popover.jsx
+++ b/packages/dx-react-bootstrap4/components/popover.jsx
@@ -77,7 +77,7 @@ export class Popover extends React.PureComponent {
   renderPopper() {
     const {
       children, target, renderInBody,
-      arrowComponent: ArrowComponent, modifiers,
+      arrowComponent: ArrowComponent, modifiers = [],
       ...restProps
     } = this.props;
 

--- a/packages/dx-react-bootstrap4/components/popover.jsx
+++ b/packages/dx-react-bootstrap4/components/popover.jsx
@@ -81,13 +81,15 @@ export class Popover extends React.PureComponent {
       ...restProps
     } = this.props;
 
-    const popperModifiers = [{
-      name: 'offset',
-      options: {
-        offset: [0, 8],
+    const popperModifiers = [
+      {
+        name: 'offset',
+        options: {
+          offset: [0, 8],
+        },
       },
-      ...modifiers
-    }];
+      ...modifiers,
+    ];
 
     return (
       <Popper

--- a/packages/dx-react-bootstrap4/components/popover.jsx
+++ b/packages/dx-react-bootstrap4/components/popover.jsx
@@ -77,11 +77,22 @@ export class Popover extends React.PureComponent {
   renderPopper() {
     const {
       children, target, renderInBody,
-      arrowComponent: ArrowComponent, ...restProps
+      arrowComponent: ArrowComponent, modifiers,
+      ...restProps
     } = this.props;
+
+    const popperModifiers = [{
+      name: 'offset',
+      options: {
+        offset: [0, 8],
+      },
+      ...modifiers
+    }];
+
     return (
       <Popper
         referenceElement={target}
+        modifiers={popperModifiers}
         {...restProps}
       >
         {({

--- a/packages/dx-react-bootstrap4/components/popover.test.jsx
+++ b/packages/dx-react-bootstrap4/components/popover.test.jsx
@@ -50,7 +50,7 @@ describe('BS4 Popover', () => {
       );
 
       expect(tree.root.children).toHaveLength(1);
-      expect(tree.root.find(Popper)).not.toBeNull();
+      expect(tree.root.findByType(Popper)).not.toBeNull();
     });
 
     it('should render correct elements', () => {
@@ -59,10 +59,10 @@ describe('BS4 Popover', () => {
           <Content />
         </Popover>
       ), container);
-      expect(tree.root.findByProps({className:'popover show bs-popover-undefined'})).not.toBeNull();
-      expect(tree.root.findByProps({className:'popover show bs-popover-undefined'}).children).toHaveLength(2);
+      expect(tree.root.findByProps({className:'popover show bs-popover-bottom'})).not.toBeNull();
+      expect(tree.root.findByProps({className:'popover show bs-popover-bottom'}).children).toHaveLength(2);
       expect(tree.root.findAllByProps({className:'.arrow'})).not.toBeNull();
-      expect(tree.root.findByProps({className:'popover-inner'}).parent.props.className).toBe('popover show bs-popover-undefined');
+      expect(tree.root.findByProps({className:'popover-inner'}).parent.props.className).toBe('popover show bs-popover-bottom');
       expect(tree.root.findByProps({className:'popover-inner'}).find(Content)).not.toBeNull();
     });
 

--- a/packages/dx-react-chart-bootstrap4/package.json
+++ b/packages/dx-react-chart-bootstrap4/package.json
@@ -94,7 +94,7 @@
   "dependencies": {
     "clsx": "^1.0.4",
     "prop-types": "^15.7.2",
-    "react-popper": "^2.3.0"
+    "react-popper": "~2.2.5"
   },
   "peerDependencies": {
     "@devexpress/dx-chart-core": "4.0.3",

--- a/packages/dx-react-chart-bootstrap4/package.json
+++ b/packages/dx-react-chart-bootstrap4/package.json
@@ -94,7 +94,7 @@
   "dependencies": {
     "clsx": "^1.0.4",
     "prop-types": "^15.7.2",
-    "react-popper": "^1.3.11"
+    "react-popper": "^2.3.0"
   },
   "peerDependencies": {
     "@devexpress/dx-chart-core": "4.0.3",

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/overlay.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/overlay.jsx
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 import { RIGHT, TOP } from '@devexpress/dx-chart-core';
 import { Popover } from '../../../../dx-react-bootstrap4/components';
 
-const popperModifiers = {
-  flip: { enabled: false },
-};
+const popperModifiers = [{
+  name: 'flip',
+  enabled: false,
+}];
 
 export class Overlay extends React.PureComponent {
   render() {

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/overlay.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/overlay.jsx
@@ -3,10 +3,18 @@ import PropTypes from 'prop-types';
 import { RIGHT, TOP } from '@devexpress/dx-chart-core';
 import { Popover } from '../../../../dx-react-bootstrap4/components';
 
-const popperModifiers = [{
-  name: 'flip',
-  enabled: false,
-}];
+const popperModifiers = [
+  {
+    name: 'flip',
+    enabled: false,
+  },
+  {
+    name: 'preventOverflow',
+    options: {
+      altAxis: true,
+    },
+  },
+];
 
 export class Overlay extends React.PureComponent {
   render() {

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/overlay.test.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/overlay.test.jsx
@@ -31,6 +31,12 @@ describe('Overlay', () => {
           name: 'flip',
           enabled: false,
         },
+        {
+          name: 'preventOverflow',
+          options: {
+            altAxis: true,
+          },
+        },
       ],
     });
     expect(tree.root.findByProps({ className: 'content' })).toBeTruthy();
@@ -53,6 +59,12 @@ describe('Overlay', () => {
         {
           name: 'flip',
           enabled: false,
+        },
+        {
+          name: 'preventOverflow',
+          options: {
+            altAxis: true,
+          },
         },
       ],
     });

--- a/packages/dx-react-chart-bootstrap4/src/templates/tooltip/overlay.test.jsx
+++ b/packages/dx-react-chart-bootstrap4/src/templates/tooltip/overlay.test.jsx
@@ -26,9 +26,12 @@ describe('Overlay', () => {
       placement: 'top',
       isOpen: true,
       target: 'test-target',
-      modifiers: {
-        flip: { enabled: false },
-      },
+      modifiers: [
+        {
+          name: 'flip',
+          enabled: false,
+        },
+      ],
     });
     expect(tree.root.findByProps({ className: 'content' })).toBeTruthy();
   });
@@ -46,9 +49,12 @@ describe('Overlay', () => {
       placement: 'right',
       isOpen: true,
       target: 'test-target',
-      modifiers: {
-        flip: { enabled: false },
-      },
+      modifiers: [
+        {
+          name: 'flip',
+          enabled: false,
+        },
+      ],
     });
   });
 });

--- a/packages/dx-react-chart-demos/package.json
+++ b/packages/dx-react-chart-demos/package.json
@@ -55,7 +55,7 @@
     "react-bootstrap": "=0.33.1",
     "react-dom": "^17.0.2",
     "react-frame-component": "^4.1.3",
-    "react-popper": "^2.3.0",
+    "react-popper": "~2.2.5",
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.4",

--- a/packages/dx-react-chart-demos/package.json
+++ b/packages/dx-react-chart-demos/package.json
@@ -55,7 +55,7 @@
     "react-bootstrap": "=0.33.1",
     "react-dom": "^17.0.2",
     "react-frame-component": "^4.1.3",
-    "react-popper": "^1.3.11",
+    "react-popper": "^2.3.0",
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.4",

--- a/packages/dx-react-chart-demos/src/demo-sources/export/bootstrap4/demo.jsx
+++ b/packages/dx-react-chart-demos/src/demo-sources/export/bootstrap4/demo.jsx
@@ -141,6 +141,16 @@ const Export = () => {
     handleClose();
     action(chart);
   };
+
+  const modifiers = [
+    {
+      name: 'offset',
+      options: {
+        offset: [0, 8],
+      },
+    },
+  ];
+
   return (
     <Plugin name="Export">
       <Template name="top">
@@ -157,6 +167,7 @@ const Export = () => {
         { anchorEl
           ? (
             <Popper
+              modifiers={modifiers}
               referenceElement={anchorEl}
             >
               {({

--- a/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.jsx
+++ b/packages/dx-react-chart-material-ui/src/templates/tooltip/overlay.jsx
@@ -17,9 +17,29 @@ const StyledPopper = styled(Popper)(() => ({
 }));
 
 const popperModifiers = arrowRef => ([
-  { name: 'flip', enabled: false },
-  { name: 'arrow', enabled: true, options: { element: arrowRef } },
-  { name: 'offset', options: { offset: [0, 9] } },
+  {
+    name: 'flip',
+    enabled: false,
+  },
+  {
+    name: 'arrow',
+    enabled: true,
+    options: {
+      element: arrowRef,
+    },
+  },
+  {
+    name: 'offset',
+    options: {
+      offset: [0, 9],
+    },
+  },
+  {
+    name: 'preventOverflow',
+    options: {
+      altAxis: true,
+    },
+  },
 ]);
 
 export const Overlay = ({

--- a/packages/dx-react-grid-bootstrap4/package.json
+++ b/packages/dx-react-grid-bootstrap4/package.json
@@ -93,7 +93,7 @@
   "dependencies": {
     "clsx": "^1.0.4",
     "prop-types": "^15.7.2",
-    "react-popper": "^2.3.0"
+    "react-popper": "~2.2.5"
   },
   "peerDependencies": {
     "@devexpress/dx-grid-core": "4.0.3",

--- a/packages/dx-react-grid-bootstrap4/package.json
+++ b/packages/dx-react-grid-bootstrap4/package.json
@@ -93,7 +93,7 @@
   "dependencies": {
     "clsx": "^1.0.4",
     "prop-types": "^15.7.2",
-    "react-popper": "^1.3.11"
+    "react-popper": "^2.3.0"
   },
   "peerDependencies": {
     "@devexpress/dx-grid-core": "4.0.3",

--- a/packages/dx-styles/dx-chart-bs4.scss
+++ b/packages/dx-styles/dx-chart-bs4.scss
@@ -31,3 +31,13 @@
 .dx-c-bs4-rect-opacity {
   opacity: 0.2;
 }
+
+.popover {
+  &[class*="bs-popover-"] {
+    margin: 0;
+  }
+
+  .arrow {
+    margin: 0;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19198,6 +19198,11 @@ react-fast-compare@^2.0.2:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-fast-compare@^3.0.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.1.tgz#53933d9e14f364281d6cba24bfed7a4afb808b5f"
+  integrity sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg==
+
 react-frame-component@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-4.1.3.tgz#64c09dd29574720879c5f43ee36c17d8ae74d4ec"
@@ -19259,7 +19264,7 @@ react-overlays@^0.9.0:
     react-transition-group "^2.2.1"
     warning "^3.0.0"
 
-react-popper@^1.3.11, react-popper@^1.3.6:
+react-popper@^1.3.6:
   version "1.3.11"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.11.tgz#a2cc3f0a67b75b66cfa62d2c409f9dd1fcc71ffd"
   integrity sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==
@@ -19270,6 +19275,14 @@ react-popper@^1.3.11, react-popper@^1.3.6:
     popper.js "^1.14.4"
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
+    warning "^4.0.2"
+
+react-popper@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
+  integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
+  dependencies:
+    react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
 react-prop-types@^0.4.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -19277,10 +19277,10 @@ react-popper@^1.3.6:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-popper@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
-  integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
+react-popper@~2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
+  integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"


### PR DESCRIPTION
Hi there!

With React 18 having been available for some time now, one thing holding back an upgrade is the version of Popper in use in the bootstrap4 packages here (since popper 1.x only declares compatibility with up to React 17).

Since Popper 2.x is both compatible with React 18 and [still exposes the render-props](https://popper.js.org/react-popper/v2/render-props/) for compatibility with the existing class-based components in here, is it possible / reasonable to update the package to the 2.x line?