### PR TITLE
ci: Destructuring fs-extra

### DIFF
--- a/scripts/publish-site.js
+++ b/scripts/publish-site.js
@@ -1,6 +1,6 @@
 import { join, dirname } from 'path';
 import { execSync } from 'child_process';
-import { copySync, removeSync, readFileSync, writeFileSync } from 'fs-extra';
+import fse from 'fs-extra';
 import inquirer from 'inquirer';
 import { prerelease } from 'semver';
 import ensureRepoUpToDate from './ensure-repo-up-to-date.js';
@@ -8,6 +8,8 @@ import getCurrentBranchName from './get-current-branch-name.js';
 import { fileURLToPath } from 'url';
 
 const loadJSON = (path) => JSON.parse(readFileSync(new URL(path, import.meta.url)));
+
+const { copySync, removeSync, readFileSync, writeFileSync } = fse;
 
 const SITE_PUBLISHING_DIRECTORY = join(process.cwd(), 'tmp');
 const BRANCH = 'gh-pages';


### PR DESCRIPTION
After some intermediate updates (possibly https://github.com/DevExpress/devextreme-reactive/pull/3632) the "publish:site" command fails with:

```
import { copySync, removeSync, readFileSync, writeFileSync } from 'fs-extra';
         ^^^^^^^^
SyntaxError: Named export 'copySync' not found. The requested module 'fs-extra' is a CommonJS module, which may not support all module.exports as named exports.
```

Consider upgrading the "fs-extra" dep in order to use native esm import.
